### PR TITLE
Ready the repo for the community catalog, and stop pointing people at upstream's plugin

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug in Team Relay plugin or relay server
+description: Report a bug in the Knap Sync plugin or the relay it talks to
 title: "[Bug]: "
 labels: ["bug"]
 body:
@@ -9,7 +9,7 @@ body:
       label: Component
       description: Where does the issue occur?
       options:
-        - Obsidian Plugin (sync/collaboration)
+        - Knap Sync plugin (sync/collaboration)
         - Relay Server (self-hosted)
         - Web Publish
         - Control Plane / Admin UI
@@ -34,7 +34,7 @@ body:
       label: Deployment
       options:
         - Self-hosted (docker compose)
-        - Hosted (entire.vc)
+        - Hosted (cp.knap.pantalytics.com)
         - Local development
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Suggest a feature for Team Relay plugin or relay server
+description: Suggest a feature for the Knap Sync plugin or the relay it talks to
 title: "[Feature]: "
 labels: ["enhancement"]
 body:
@@ -8,7 +8,7 @@ body:
     attributes:
       label: Component
       options:
-        - Obsidian Plugin
+        - Knap Sync plugin
         - Relay Server
         - Web Publish
         - Control Plane / Admin UI

--- a/.github/ISSUE_TEMPLATE/web-publish.yml
+++ b/.github/ISSUE_TEMPLATE/web-publish.yml
@@ -19,7 +19,7 @@ body:
       label: Deployment
       options:
         - Self-hosted
-        - Hosted (entire.vc)
+        - Hosted (cp.knap.pantalytics.com)
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,36 @@ jobs:
           fi
           echo "OK: manifest-beta.json also agrees on $PKG_VER"
 
+      - name: Catalog readiness — what the community directory requires
+        # The directory reads manifest.json and README.md off the DEFAULT BRANCH and
+        # fetches the files themselves from the release tagged as manifest.version.
+        # These are the rules it applies at submission, checked here so they cannot
+        # rot between now and the next submission or resubmission.
+        # See docs/catalog-submission.md.
+        run: |
+          fail=0
+          for f in README.md LICENSE manifest.json; do
+            [ -f "$f" ] || { echo "::error::$f is required in the repo root by the community directory"; fail=1; }
+          done
+          ID=$(node -p "require('./manifest.json').id")
+          NAME=$(node -p "require('./manifest.json').name")
+          DESC=$(node -p "require('./manifest.json').description")
+          # Verified rule: the id must be unique across published plugins and cannot
+          # contain "obsidian" (docs.obsidian.md, Submit your plugin, read 2026-08-10).
+          case "$ID" in *[Oo]bsidian*) echo "::error::plugin id '$ID' contains 'obsidian', which the directory rejects"; fail=1;; esac
+          # A name carrying "Obsidian" reads as a first-party product, which is the
+          # reason this plugin is called Knap Sync in the first place.
+          case "$NAME" in *[Oo]bsidian*) echo "::error::plugin name '$NAME' contains 'Obsidian', which reads as a first-party product"; fail=1;; esac
+          [ -n "$(node -p "require('./manifest.json').author")" ] || { echo "::error::manifest.json needs an author"; fail=1; }
+          # 250 is our own budget, not a published limit: the description is what
+          # someone reads in the plugin browser list, and longer than this gets cut off.
+          if [ "${#DESC}" -gt 250 ]; then
+            echo "::error::description is ${#DESC} characters; keep it under 250 so it reads in the plugin browser"
+            fail=1
+          fi
+          [ "$fail" = "0" ] || exit 1
+          echo "OK: id '$ID', name '$NAME', description ${#DESC} chars, required files present"
+
       - name: Monotonicity guard — version must be strictly greater than latest release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,9 +34,9 @@ an individual is officially representing the community in public spaces.
 
 ## Enforcement
 
-Instances of unacceptable behavior may be reported to the project team at
-**conduct@entire.vc**. All complaints will be reviewed and investigated promptly
-and fairly.
+Instances of unacceptable behavior may be reported to the maintainers at
+**rutger@pantalytics.com**. All complaints will be reviewed and investigated
+promptly and fairly.
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
-# Contributing to EVC Team Relay Obsidian Plugin
+# Contributing to Knap Sync
 
-Thanks for your interest in contributing! This plugin enables live team editing and sync in Obsidian via EVC Team Relay.
+Thanks for your interest. Knap Sync is an Obsidian plugin that syncs a vault, or
+a folder of one, to a relay you host yourself.
 
 ## Getting Started
 
@@ -20,39 +21,65 @@ npm run build
 
 # Lint
 npm run lint
+
+# Tests
+npm test
 ```
 
 ### Testing in Obsidian
 
 1. Build the plugin: `npm run build`
-2. Copy `main.js` and `manifest.json` to your vault's `.obsidian/plugins/evc-team-relay-plugin/`
-3. Enable the plugin in Obsidian Settings > Community Plugins
-4. Point it at your local Team Relay instance
+2. Copy `main.js`, `manifest.json` and `styles.css` into your vault's
+   `.obsidian/plugins/knap-sync/`
+3. Enable the plugin in *Settings → Community plugins*
+4. Point it at your relay in *Settings → Knap Sync → Relay Servers*
+
+A vault you do not mind breaking is the right vault for this.
 
 ## Pull Requests
 
 1. Create a branch from `main`
 2. Make your changes
 3. Ensure `npm run build` succeeds with no errors
-4. Ensure `npm run lint` passes
+4. Ensure `npm run lint` and `npm test` pass
 5. Write a clear PR description explaining what and why
 6. Submit the PR
 
+## Versioning and releases
+
+The version lives in three files and CI fails if they disagree: `manifest.json`,
+`package.json` and `versions.json`, plus `manifest-beta.json` for the BRAT beta
+channel. `npm version` keeps them in step.
+
+Releases are cut by pushing a tag that is bare semver and matches
+`manifest.json` exactly, so `1.2.5` and never `v1.2.5`. Obsidian looks for a
+release tagged the same as the manifest version, so a `v` prefix means the
+release is invisible to it. The release workflow builds, attests provenance and
+attaches `main.js`, `manifest.json` and `styles.css`.
+
 ## Reporting Bugs
 
-Use the [Bug Report](https://github.com/entire-vc/evc-team-relay-obsidian-plugin/issues/new?template=bug_report.md) issue template.
+Use the [bug report](https://github.com/pantalytics/knap-obsidian/issues/new?template=bug-report.yml)
+template.
 
 ## Requesting Features
 
-Use the [Feature Request](https://github.com/entire-vc/evc-team-relay-obsidian-plugin/issues/new?template=feature_request.md) issue template.
+Use the [feature request](https://github.com/pantalytics/knap-obsidian/issues/new?template=feature-request.yml)
+template.
 
 ## Code Style
 
-- TypeScript with strict mode
-- No React/Svelte - vanilla DOM with Obsidian API
-- Follow existing patterns in the codebase
+- TypeScript, strict mode
+- Svelte for settings components, plain DOM with the Obsidian API elsewhere
+- Follow the patterns already in the file you are editing
 - Keep changes focused and minimal
+
+Code copied from other projects lives in its own directory with its own licence
+file, listed in [NOTICE](NOTICE). Do not remove those headers, and think twice
+before editing those directories at all: they are easier to keep in step with
+upstream when they stay close to it.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,140 +1,128 @@
-# EVC Team Relay Plugin
+# Knap Sync
 
+**Sync your vault to a relay you run yourself.** A whole vault or one folder at
+a time, on desktop and on phone, with real-time collaborative editing on
+whatever you share.
 
-**Real-time collaboration and web publishing for Obsidian.**
-
-> Edit notes together. Share folders with your team. Publish to the web. Self-hosted or hosted — your choice.
-
----
-
-## The Problem
-
-You love Obsidian, but your team needs more:
-- **Sharing a note** means exporting, copy/pasting, or screenshotting
-- **Collaborating** means switching to Notion or Google Docs
-- **Publishing** means paying $8/month for Obsidian Publish with limited control
-- **Git sync** works until two people edit the same file
-
-## The Solution
-
-**EVC Team Relay** adds multiplayer mode to Obsidian. CRDT-based real-time sync — no merge conflicts, works offline, your data stays on your server (or ours).
+Knap Sync keeps your notes as plain markdown in your vault. The relay holds a
+CRDT copy so two people can edit the same note without a merge conflict, and so
+a device that was offline catches up when it reconnects.
 
 ---
 
-## What You Get
+## What it does
 
-### 🔄 Real-time Collaboration
-- Edit the same note simultaneously — changes merge automatically
-- Share entire folders with viewer or editor permissions
-- Works offline — edits sync when you reconnect
+- **Sync a whole vault, or pick folders.** Scope is set per server: point it at
+  everything, or share `Projects/` and leave the rest of the vault alone.
+- **Two people, one note.** Edits merge as you type. No conflict copies, no
+  last-writer-wins.
+- **Offline is normal.** Edit on a plane, reconnect, and the relay catches up.
+- **Attachments travel with the notes.** Images and PDFs sync alongside the
+  markdown.
+- **Phone included.** `isDesktopOnly` is false, sign-in comes back over an
+  `obsidian://` link rather than a local port, so iOS and Android work the same
+  way the laptop does.
 
-### 🌐 Web Publishing
-- Publish notes as a website with one click
-- Three modes: **public**, **protected** (link + token), **private** (login required)
-- Custom domains supported
-- Perfect for: internal wikis, client portals, project docs, personal sites
-- [Live example →](https://docs.entire.vc/team-relay/Demo)
-
-### 🔒 Your Data, Your Server
-- **Self-hosted:** deploy on your VPS with Docker Compose ([server repo](https://github.com/entire-vc/evc-team-relay))
-- **Hosted:** zero ops, connect and go ([entire.vc](https://entire.vc))
+Knap Sync is also the Obsidian half of [Knap](https://github.com/pantalytics),
+where the same vault is reachable by an AI assistant over MCP. You do not need
+any of that to use the plugin: point it at a relay, and it syncs.
 
 ---
 
 ## Install
 
-1. *Settings → Community plugins → Browse* → search **"EVC Team Relay"**
-2. **Install**, then **Enable**
+Knap Sync is not in the community catalog yet. Two ways to install it today.
 
-Or open directly: `obsidian://show-plugin?id=evc-team-relay`  
-Plugin page: https://obsidian.md/plugins?id=evc-team-relay
+### BRAT
 
-<details>
-<summary>Manual install</summary>
+[BRAT](https://obsidian.md/plugins?id=obsidian42-brat) installs plugins straight
+from GitHub and keeps them updated.
 
-1. Download from [latest release](https://github.com/entire-vc/evc-team-relay-obsidian-plugin/releases)
-2. Copy to `.obsidian/plugins/evc-team-relay/`
-3. Enable in Settings
+1. Install and enable **BRAT** from *Settings → Community plugins → Browse*
+2. *Settings → BRAT → Add beta plugin*
+3. Paste `pantalytics/knap-obsidian`, pick the latest version, **Add plugin**
+4. Enable **Knap Sync** in *Settings → Community plugins*
 
-</details>
+### Manual
 
----
-
-## Quickstart
-
-1. **Connect:** Plugin settings → Add server → enter your relay URL (or sign up at [entire.vc](https://entire.vc))
-2. **Share:** Right-click a folder → Share → invite by email
-3. **Collaborate:** Open a shared note — edits sync in real-time
-4. **Publish:** Right-click a note or folder → Publish to web
+1. Download `main.js`, `manifest.json` and `styles.css` from the
+   [latest release](https://github.com/pantalytics/knap-obsidian/releases/latest)
+2. Put all three in `<your vault>/.obsidian/plugins/knap-sync/`
+3. Reload Obsidian and enable **Knap Sync**
 
 ---
 
-## Who Is This For?
+## Connect
 
-### Small Teams (5-20 people)
-Replace Notion/Confluence. Keep Obsidian. Real-time collaboration without $8/user/month.
+1. *Settings → Knap Sync → Relay Servers.* One server is configured out of the
+   box, at `https://cp.knap.pantalytics.com`. If you run your own relay, use
+   **Add Server** and give it your control plane URL. Leave the other two fields
+   empty and they are worked out for you.
+2. **No trailing slash on the control plane URL.** A slash on the end turns the
+   health check into a 404 that reads as *Connection failed*.
+3. Tick **Default** on the server you actually use. Online and offline detection
+   follows the default server, so a default pointing somewhere else makes the
+   connection light meaningless.
+4. Press **Login** on the server card. Email and password, or one of the sign-in
+   buttons if your relay offers them.
 
-### Consultants & Freelancers
-Share deliverables with clients via protected web publish. No "can you export that as PDF?"
-
-### Dev Teams
-Documentation that lives in Obsidian, accessible to the whole team. Pair with [Local Sync](https://github.com/entire-vc/evc-local-sync-plugin) for repo `/docs` ↔ vault sync.
-
-### Content Creators
-Publish your vault as a beautiful website. Better than Obsidian Publish — custom domains, access control, flat pricing.
-
----
-
-## Comparison
-
-| | Obsidian Sync | Notion | Google Docs | **Team Relay** |
-|---|---|---|---|---|
-| Real-time collab | ✗ | ✅ | ✅ | ✅ |
-| Works in Obsidian | ✅ | ✗ | ✗ | ✅ |
-| Web publish | via Publish | ✅ | ✅ | ✅ |
-| Self-hosted option | ✗ | ✗ | ✗ | ✅ |
-| Offline editing | ✅ | ✗ | ✗ | ✅ |
-| Your data, your server | ✗ | ✗ | ✗ | ✅ |
+Then share a folder, or set the scope to the whole vault, and the first sync
+starts.
 
 ---
 
-## Feedback
+## Network use
 
-- [Report a bug →](https://github.com/entire-vc/evc-team-relay-obsidian-plugin/issues/new?template=bug-report.yml)
-- [Request a feature →](https://github.com/entire-vc/evc-team-relay-obsidian-plugin/issues/new?template=feature-request.yml)
-- [Report a web publish issue →](https://github.com/entire-vc/evc-team-relay-obsidian-plugin/issues/new?template=web-publish.yml)
+Knap Sync talks to the servers configured in its settings and to nothing else.
+
+| Connection | Protocol | What for | When |
+|---|---|---|---|
+| Control plane | HTTPS | Sign-in, token refresh, listing and creating shares, inviting people | On login and on share operations |
+| Control plane | HTTPS | Issuing the short-lived token for a relay connection | Before opening a socket |
+| Relay server | WSS | The document sync itself | While a shared note is open, and while catching up |
+| `obsidian://` callback | Obsidian URL scheme | Receiving the OAuth redirect, where the relay offers OAuth | During sign-in only |
+
+**No telemetry.** The plugin does not phone home, count anything, or send your
+notes anywhere except the relay you pointed it at. The default server above is a
+default, not a requirement: remove it and the plugin has nowhere to talk to.
 
 ---
 
-## Solo Workflow? No Server Needed
+## Where this comes from
 
-→ [**EVC Local Sync**](https://github.com/entire-vc/evc-local-sync-plugin) — bidirectional vault ↔ local folder sync for AI-assisted coding workflows.
+Knap Sync is a fork of
+[EVC Team Relay](https://github.com/entire-vc/evc-team-relay-obsidian-plugin),
+which is itself derived from [Relay](https://github.com/No-Instructions/Relay)
+by No Instructions, LLC. Both are MIT licensed and both copyright lines are
+carried in [LICENSE](LICENSE), with the full attribution in [NOTICE](NOTICE).
+
+The fork exists for two things upstream does not do: vault-wide scope as a first
+class option, and a sign-in that survives an identity provider matching redirect
+URIs exactly, which is why the OAuth callback arrives over `obsidian://` instead
+of a loopback port. It speaks the same protocol as an EVC Team Relay server, so
+it works against one.
 
 ---
 
+## Development
 
+```bash
+npm install
+npm run dev      # watch build
+npm run build    # production build
+npm run lint
+npm test
+```
 
-## Network Usage
+[CONTRIBUTING.md](CONTRIBUTING.md) has the rest, including how to load a
+development build into a vault.
 
-This plugin makes network requests to **user-configured servers only**. No data is sent to third parties.
+## Support
 
-| Connection | Protocol | Purpose | When |
-|------------|----------|---------|------|
-| Control plane server | HTTPS | Authentication (login, token refresh), share management (list, create, invite), server info, billing | On login, share operations, periodic token refresh |
-| Relay server | WebSocket (WSS) | Real-time CRDT document synchronization between collaborators | While editing shared documents |
-| Control plane server | HTTPS | Relay token issuance (Ed25519-signed) | Before opening a WebSocket connection |
-| OAuth callback (localhost) | HTTP | Receives OAuth redirect on `127.0.0.1` (desktop only) | During OAuth login flow |
-
-**All server URLs are configured by the user** in plugin settings. The default configuration includes `https://cp.tr.entire.vc` (EVC Team Relay hosted), but the user can add, remove, or change servers.
-
-**No telemetry or analytics data is collected.** The plugin does not phone home, track usage, or send any data to third-party services.
-
-## Community
-
-- 🌐 [entire.vc](https://entire.vc)
-- 💬 [Discussions](https://github.com/entire-vc/.github/discussions)
-- 📧 in@entire.vc
+- [Report a bug](https://github.com/pantalytics/knap-obsidian/issues/new?template=bug-report.yml)
+- [Request a feature](https://github.com/pantalytics/knap-obsidian/issues/new?template=feature-request.yml)
 
 ## License
 
-MIT — Copyright (c) 2026 Entire VC
+MIT. Copyright (c) 2024 No Instructions, LLC, (c) 2024-2026 Entire VC,
+(c) 2026 Pantalytics. See [LICENSE](LICENSE) and [NOTICE](NOTICE).

--- a/docs/catalog-submission.md
+++ b/docs/catalog-submission.md
@@ -1,0 +1,102 @@
+# Submitting Knap Sync to the community catalog
+
+What the Obsidian community directory asks for, what this repo already has, and
+the four steps left that need a human. Everything here was read off
+[docs.obsidian.md, *Submit your plugin*](https://docs.obsidian.md/Plugins/Releasing/Submit+your+plugin)
+and the [obsidian-releases README](https://github.com/obsidianmd/obsidian-releases)
+on 2026-08-10, not from memory. The submission route changed at some point from
+a pull request against `obsidian-releases` to a form at community.obsidian.md,
+so an older write-up will send you to the wrong place.
+
+## How the catalog actually works
+
+Worth understanding before the steps, because it explains why the order matters:
+
+- The directory lists plugins from `community-plugins.json`. `name`, `author`
+  and `description` are the fields people search on.
+- Opening a plugin's page pulls `manifest.json` and `README.md` **from the
+  default branch** of the repo. Not from the release.
+- The manifest on the default branch only decides *which version is latest*. The
+  files a user installs come from the **GitHub release tagged exactly that
+  version**.
+- If the manifest's `minAppVersion` is higher than the Obsidian someone is
+  running, `versions.json` is consulted for the newest version they can have.
+
+So: the default branch is the shop window, the release is the warehouse, and a
+mismatch between them shows up as a plugin that appears in search and refuses to
+install.
+
+## What this repo already satisfies
+
+| Requirement | State |
+|---|---|
+| `README.md`, `LICENSE`, `manifest.json` in the repo root | Present. CI checks they stay present. |
+| Plugin id unique across published plugins | `knap-sync` is free. Checked against all 6518 entries in `community-plugins.json` on 2026-08-10. |
+| Plugin id does not contain `obsidian` | `knap-sync`. CI checks it. |
+| Name does not read as a first-party Obsidian product | Knap Sync. CI checks it. |
+| `manifest.json` carries id, name, version, minAppVersion, description, author, `isDesktopOnly` | All set. `isDesktopOnly: false`, so the phone is a supported target and reviewers will hold it to that. |
+| Semantic version, matching across manifest, package.json, versions.json, manifest-beta.json | CI fails the build when any two disagree. |
+| Release tagged bare semver, equal to `manifest.version` | `.github/workflows/release.yml` refuses a `v` prefix and refuses a tag that differs from the manifest. |
+| Release carries `main.js`, `manifest.json`, `styles.css` | The release workflow attaches all three, with build provenance attestation. |
+| Licence and attribution for forked code | `LICENSE` carries all three copyright lines, `NOTICE` records the fork point and every vendored dependency. |
+
+## The four steps left
+
+Each needs a person, and the order is not negotiable.
+
+### 1. Merge this work into `main`
+
+The directory reads the manifest and the README off the default branch. Until
+the branch is merged, an install-from-catalog would show upstream's old README.
+
+### 2. Make the repository public
+
+`pantalytics/knap-obsidian` is private today. This blocks everything: the
+directory cannot read the manifest, BRAT cannot install a beta, and the README's
+release links 404 for everybody but us.
+
+Making it public publishes the default relay hostname
+(`cp.knap.pantalytics.com`, in `src/RelayOnPremConfig.ts`) and the whole fork
+history. Both are normal for a plugin that talks to a hosted service, and both
+are worth knowing before the switch is flipped rather than after.
+
+### 3. Cut a release
+
+```bash
+git tag 1.1.41        # bare semver, exactly the value in manifest.json
+git push origin 1.1.41
+```
+
+The release workflow builds, attests provenance and creates the release with its
+three assets. There are no releases on this repo yet, so this is the first one:
+check the assets landed before moving on. `workflow_dispatch` rebuilds a tag if
+something needs a second run.
+
+### 4. Submit at community.obsidian.md
+
+Sign in with an Obsidian account, link the GitHub account that owns the repo,
+add the plugin. Only the first version is submitted by hand; after that Obsidian
+picks up new releases from GitHub on its own.
+
+## What review is likely to ask about
+
+Not blockers, but cheaper to have an answer ready than to be surprised:
+
+- **This is a fork of a plugin already in the catalog.** EVC Team Relay is
+  listed as `evc-team-relay`, and it is itself derived from Relay
+  (`system3-relay`). A near-duplicate submission gets read carefully, so the
+  honest answer is the one in the README: vault-wide scope, and an OAuth
+  callback over `obsidian://` instead of a loopback port, which is what makes
+  sign-in work on a phone and against an identity provider that matches redirect
+  URIs exactly.
+- **It ships with a server configured.** `cp.knap.pantalytics.com` is a default,
+  not a lock-in: the settings let you remove it and point anywhere. The README
+  says so in the network section, which is where a reviewer looks.
+- **Mobile.** `isDesktopOnly: false` is a promise. The loopback HTTP server that
+  upstream used for OAuth is gone for exactly this reason, but anything else
+  reaching for Node or Electron APIs would be caught here.
+
+## Before resubmitting after review feedback
+
+Bump the version, let CI confirm the four files agree, tag, and the release
+workflow does the rest. The directory entry does not need touching again.

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -3,7 +3,7 @@
 	"name": "Knap Sync",
 	"version": "1.1.41",
 	"minAppVersion": "1.8.7",
-	"description": "Sync an Obsidian vault to a self-hosted relay, whole vault or one folder at a time.",
+	"description": "Sync your vault to a relay you host yourself, a whole vault or one folder at a time, with real-time collaborative editing on what you share.",
 	"author": "Pantalytics",
 	"authorUrl": "https://github.com/pantalytics",
 	"isDesktopOnly": false

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Knap Sync",
 	"version": "1.1.41",
 	"minAppVersion": "1.8.7",
-	"description": "Sync an Obsidian vault to a self-hosted relay, whole vault or one folder at a time.",
+	"description": "Sync your vault to a relay you host yourself, a whole vault or one folder at a time, with real-time collaborative editing on what you share.",
 	"author": "Pantalytics",
 	"authorUrl": "https://github.com/pantalytics",
 	"isDesktopOnly": false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "knap-sync",
 	"version": "1.1.41",
-	"description": "Sync an Obsidian vault to a self-hosted relay, whole vault or one folder at a time.",
+	"description": "Sync your vault to a relay you host yourself, a whole vault or one folder at a time, with real-time collaborative editing on what you share.",
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs watch",


### PR DESCRIPTION
## Summary

The community directory reads `manifest.json` and `README.md` off the **default branch** and fetches the installable files from the **release tagged as `manifest.version`**. Ours still told people to search for *EVC Team Relay* and linked `obsidian.md/plugins?id=evc-team-relay`, which installs upstream's plugin rather than the one this repo builds.

This is docs, metadata and one CI guard. No plugin code changes.

- **README** rewritten for Knap Sync: what it does, install via BRAT or by hand while there is no catalog entry, how to connect a server, and a network table that matches the code. The old table described a loopback OAuth callback on `127.0.0.1`; sign-in comes back over `obsidian://knap-sync/oauth-callback` now, which is what makes it work on a phone.
- **CONTRIBUTING**: plugin folder is `knap-sync`, issue links are ours, and the release rules (bare semver tag equal to `manifest.version`) are written down instead of learned from a release Obsidian ignores.
- **Code of conduct** reporting address and the three issue templates point at us, not `entire.vc`.
- **manifest description** drops the redundant "Obsidian" and fits one line in the plugin browser. Same string in `manifest.json`, `manifest-beta.json` and `package.json`.
- **CI** gains a catalog readiness step next to the version checks: README/LICENSE/manifest present, id free of `obsidian`, name not first-party-sounding, author set, description short.
- **`docs/catalog-submission.md`**: what the directory requires, what this repo already satisfies, and the four steps that still need a person.

Verified rather than assumed, on 2026-08-10: `knap-sync` appears in none of the 6518 entries in `community-plugins.json`, and the submission route is now a form at community.obsidian.md, not a pull request against `obsidian-releases`.

### Still needs a human, in this order

1. Merge this branch, since the directory reads the default branch. Worth deciding at the same time whether `knap/fork-base` stays the default branch, because that is the branch the catalog will read.
2. **Make the repo public.** It is private today, which blocks the directory, blocks BRAT, and 404s the release links in the README. It also publishes `cp.knap.pantalytics.com` and the fork history.
3. Tag `1.1.41` (bare semver) and let the release workflow publish the first release. There are none yet.
4. Submit at community.obsidian.md.

`docs/catalog-submission.md` also lists what review is likely to ask about, the near-duplicate question first: this is a fork of `evc-team-relay`, which is itself derived from `system3-relay`.

## Type of Change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [ ] Tested in Obsidian (not applicable: no plugin code changed. `npm test` passes, 441 tests in 34 suites)
- [x] Changes are minimal and focused

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLcZdF6C9U1o7A9Vi2wn4x)_