### PR TITLE
CI runs on the branch we actually merge into, and a release cuts itself

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,93 @@
+name: Bump version and release
+# Cutting a release from a phone, or from anywhere without a checkout.
+#
+# It does what a person would do locally: npm version writes the four version
+# files, the commit lands on the default branch, and a release follows. The
+# release is called from here rather than left to cd.yml, because this run
+# pushes with GITHUB_TOKEN and a push made with that token does not start
+# another workflow. cd.yml is for bumps that arrive some other way.
+on:
+  workflow_dispatch:
+    inputs:
+      level:
+        description: 'how much to bump'
+        required: true
+        default: patch
+        type: choice
+        options: [patch, minor, major, exact]
+      exact_version:
+        description: 'the version to set, when level is exact (bare semver, e.g. 1.2.5)'
+        required: false
+        type: string
+
+concurrency:
+  group: bump
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    name: "Bump"
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.ref }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci
+
+      # A version nobody can install is worse than no release, so the same
+      # checks that gate a pull request run before the bump is written.
+      - name: Lint, type-check, test and build
+        run: |
+          npm run lint
+          npx tsc --noEmit --skipLibCheck
+          npx jest --forceExit --passWithNoTests
+          npm run build
+
+      - id: bump
+        env:
+          LEVEL: ${{ inputs.level }}
+          EXACT: ${{ inputs.exact_version }}
+        run: |
+          if [ "$LEVEL" = "exact" ]; then
+            [ -n "$EXACT" ] || { echo "::error::level is exact, so exact_version is required"; exit 1; }
+            case "$EXACT" in v*) echo "::error::'$EXACT' has a 'v' prefix. Obsidian needs bare semver"; exit 1;; esac
+            TARGET="$EXACT"
+          else
+            TARGET="$LEVEL"
+          fi
+          # --no-git-tag-version because the tag is the release workflow's job,
+          # and a tag pushed from here would be a second way of cutting one.
+          npm version "$TARGET" --no-git-tag-version
+          VER=$(node -p "require('./package.json').version")
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          echo "Bumped to $VER"
+
+      - name: Commit and push
+        env:
+          VER: ${{ steps.bump.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json manifest.json manifest-beta.json versions.json
+          git commit -m "Version $VER"
+          git push origin HEAD:${{ github.ref_name }}
+
+  release:
+    name: "Release"
+    needs: bump
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/release.yml
+    with:
+      version: ${{ needs.bump.outputs.version }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,59 @@
+name: CD
+# A release happens when the version changes, and never otherwise.
+#
+# The trigger is a version bump landing on the default branch, not a merge: most
+# merges are not releases, and the ones that are say so in manifest.json. CI
+# already refuses a bump where manifest.json, package.json, versions.json and
+# manifest-beta.json disagree, or where the version is not strictly greater than
+# the last release, so by the time a bump is on the default branch it is a
+# release-shaped commit.
+#
+# This file only decides whether to release. The building, attesting and
+# publishing all stay in release.yml, called below, so there is one description
+# of what a release is.
+on:
+  push:
+    branches: [knap/fork-base]
+    paths: ['manifest.json']
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  decide:
+    name: "Is this version already released?"
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      needed: ${{ steps.check.outputs.needed }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VER=$(node -p "require('./manifest.json').version")
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          # manifest.json changes for reasons other than a version bump, and a
+          # re-run of an old commit is a real thing. Either way the question is
+          # the same: does this version already exist as a release.
+          if gh release view "$VER" >/dev/null 2>&1; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "$VER is already released. Nothing to do."
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "$VER has no release yet. Cutting one."
+          fi
+
+  release:
+    name: "Release"
+    needs: decide
+    if: needs.decide.outputs.needed == 'true'
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/release.yml
+    with:
+      version: ${{ needs.decide.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,21 @@
 # CI — Team Relay Obsidian Plugin
 # Based on F3 ci-ts-plugin template (bob/docs/ci-templates/ci-ts-plugin.yml)
 #
-# Burn-in mode: all jobs use continue-on-error: true (non-blocking REPORT).
-# To flip to ENFORCE: set continue-on-error: false on each job and set
-# CI_MODE=ENFORCE in repo Settings → Variables → Actions.
+# The gate enforces by default. Individual jobs keep continue-on-error: true so
+# that one red job does not hide the others: every job runs, and ci-gate is the
+# single check that fails the run. Set CI_MODE=REPORT in repo Settings →
+# Variables → Actions to make failures informational again, which is the escape
+# hatch for a bad day rather than the normal state.
 
 name: CI
 
 on:
   pull_request:
+  # The default branch is knap/fork-base, not main. Naming main here meant no CI
+  # ever ran on a merge: the PR run was the last word, and anything that only
+  # breaks once two PRs are combined landed unnoticed.
   push:
-    branches: [main]
+    branches: [knap/fork-base]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -216,7 +221,7 @@ jobs:
     steps:
       - name: Check outcomes
         run: |
-          MODE="${{ vars.CI_MODE || 'REPORT' }}"
+          MODE="${{ vars.CI_MODE || 'ENFORCE' }}"
           TC="${{ needs.type-check.result }}"
           UC="${{ needs.unit-coverage.result }}"
           BS="${{ needs.build-smoke.result }}"
@@ -234,5 +239,5 @@ jobs:
               exit 1
             fi
           else
-            echo "REPORT mode — failures are informational. Flip CI_MODE=ENFORCE after 3-day green burn-in."
+            echo "REPORT mode — failures are informational. Unset the CI_MODE variable to enforce again."
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@ name: Release
 # manifest.version (BARE semver, no 'v'), with main.js/manifest.json/styles.css as assets.
 # Closes the two recurring gaps (Pavel 2026-06-24): (1) no/v-prefixed release → not distributed,
 # (2) "assets missing GitHub artifact attestation" scorecard recommendation.
+#
+# Three ways in, one job. A tag push is the manual route and still works. The
+# other two are how CD reaches this file: cd.yml calls it when a version bump
+# lands on the default branch, and bump.yml calls it straight after making that
+# bump itself. Both have to call rather than push a tag, because a tag pushed
+# with GITHUB_TOKEN does not start a workflow run, so the tag-push trigger below
+# would never fire for anything automated.
 on:
   push:
     tags: ['[0-9]*.[0-9]*.[0-9]*']        # bare semver only — a 'v'-prefixed tag won't trigger
@@ -11,6 +18,12 @@ on:
       version:
         description: 'version tag to (re)build, attest and release (bare semver, e.g. 1.2.5)'
         required: true
+  workflow_call:
+    inputs:
+      version:
+        description: 'version to release (bare semver, must equal manifest.json)'
+        required: true
+        type: string
 permissions:
   contents: write
   id-token: write
@@ -19,6 +32,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # A dispatch names an existing tag and checks that out. A call comes from
+      # a run on the default branch, where the tag does not exist yet, so the
+      # caller's ref is what holds the bump.
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref }}
@@ -34,7 +50,7 @@ jobs:
       - name: Resolve + verify version (bare, tag == manifest)
         id: v
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then TAG="${{ inputs.version }}"; else TAG="${GITHUB_REF_NAME}"; fi
+          TAG="${{ inputs.version || github.ref_name }}"
           VER=$(node -p "require('./manifest.json').version")
           case "$TAG" in v*) echo "::error::tag '$TAG' has a 'v' prefix — Obsidian needs bare semver"; exit 1;; esac
           if [ "$TAG" != "$VER" ]; then echo "::error::tag '$TAG' != manifest.version '$VER'"; exit 1; fi
@@ -56,5 +72,9 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" $ASSETS --clobber
           else
-            gh release create "$TAG" $ASSETS --title "$TAG" --notes "Release $TAG"
+            # --target pins the tag to the commit that was checked out and
+            # built. Not $GITHUB_SHA: when this workflow is called by another
+            # one, that is the caller's commit, which for bump.yml is the
+            # commit BEFORE the version bump.
+            gh release create "$TAG" $ASSETS --title "$TAG" --notes "Release $TAG" --target "$(git rev-parse HEAD)"
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ A vault you do not mind breaking is the right vault for this.
 
 ## Pull Requests
 
-1. Create a branch from `main`
+1. Create a branch from `knap/fork-base`, the default branch
 2. Make your changes
 3. Ensure `npm run build` succeeds with no errors
 4. Ensure `npm run lint` and `npm test` pass
@@ -51,11 +51,31 @@ The version lives in three files and CI fails if they disagree: `manifest.json`,
 `package.json` and `versions.json`, plus `manifest-beta.json` for the BRAT beta
 channel. `npm version` keeps them in step.
 
-Releases are cut by pushing a tag that is bare semver and matches
-`manifest.json` exactly, so `1.2.5` and never `v1.2.5`. Obsidian looks for a
-release tagged the same as the manifest version, so a `v` prefix means the
-release is invisible to it. The release workflow builds, attests provenance and
-attaches `main.js`, `manifest.json` and `styles.css`.
+A release happens when the version changes, and never otherwise. Merging does
+not release anything: most merges are not releases, and the ones that are say so
+in `manifest.json`.
+
+The usual way is the **Bump version and release** workflow, under Actions. Pick
+patch, minor or major, and it lints, type-checks, tests and builds first, writes
+the four version files, commits to the default branch and publishes the release.
+It needs no checkout, which is the point: a release can be cut from a phone.
+
+Bumping the version yourself works the same way. `npm version patch` writes all
+four files, and once that commit is on the default branch the release follows on
+its own.
+
+Tags stay bare semver matching `manifest.json` exactly, so `1.2.5` and never
+`v1.2.5`. Obsidian looks for a release tagged the same as the manifest version,
+so a `v` prefix means the release is invisible to it. Pushing such a tag by hand
+still publishes, and so does running the **Release** workflow against an
+existing tag when a release needs rebuilding. Every route ends in the same job:
+build, attest provenance, attach `main.js`, `manifest.json` and `styles.css`.
+
+CI runs on every pull request and on the default branch, and the **CI gate**
+check is what passes or fails: lint, type-check, tests, a build, and the version
+files agreeing with each other and increasing. Setting the repository variable
+`CI_MODE` to `REPORT` makes everything except the version check informational,
+which is an escape hatch rather than the normal state.
 
 ## Reporting Bugs
 

--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -12,3 +12,11 @@ writeFileSync("manifest.json", JSON.stringify(manifest, null, "\t"));
 let versions = JSON.parse(readFileSync("versions.json", "utf8"));
 versions[targetVersion] = minAppVersion;
 writeFileSync("versions.json", JSON.stringify(versions, null, "\t"));
+
+// manifest-beta.json is what BRAT reads off the default branch for the beta
+// channel. CI fails when it disagrees with manifest.json, and it used to be the
+// one file `npm version` left behind, so every bump needed a manual edit that
+// was only ever remembered by the build going red.
+let beta = JSON.parse(readFileSync("manifest-beta.json", "utf8"));
+beta.version = targetVersion;
+writeFileSync("manifest-beta.json", JSON.stringify(beta, null, "\t"));


### PR DESCRIPTION
## Summary

Three gaps, and the first is why the other two went unnoticed.

**CI never ran on a merge.** `ci.yml` listened for pushes to `main`; the default branch is `knap/fork-base`. In practice CI only ran on pull requests, so anything that breaks when two of them combine broke quietly. It now runs on `knap/fork-base`.

**The gate was advisory.** `ci-gate` defaulted to `REPORT`, the burn-in mode, where everything except the version check was informational. It defaults to `ENFORCE` now. Setting the repository variable `CI_MODE=REPORT` is the way back for a bad day, rather than the resting state.

**Releasing was manual.** It needed a tag pushed by hand from a checkout. Now a release happens when the version changes:

- `cd.yml` fires when `manifest.json` changes on the default branch, checks that the version has no release yet, and calls `release.yml`. Merging still releases nothing: most merges are not releases, and the ones that are say so in the manifest.
- `bump.yml` is the same thing without a checkout. Pick patch, minor, major or an exact version in the Actions tab; it lints, type-checks, tests and builds, writes the four version files, commits to the default branch and publishes. A release cut from a phone.
- Both **call** `release.yml` instead of pushing a tag, because a tag pushed with `GITHUB_TOKEN` does not start a workflow run, so the tag trigger would never fire for anything automated. `release.yml` gained a `workflow_call` entry for that, and keeps its tag-push and `workflow_dispatch` routes unchanged.
- `release.yml` now pins the tag to the commit it built (`git rev-parse HEAD`) rather than `$GITHUB_SHA`, which under a call is the caller's commit: one before the bump.

**And `npm version` now writes `manifest-beta.json`.** It was the one version file it left behind, and CI fails when that file disagrees with `manifest.json`, so every bump needed a manual edit remembered only by the build going red.

`CONTRIBUTING.md` describes all of this.

## Two things that need a human

- **Branch protection.** `bump.yml` pushes the version commit straight to the default branch. If that branch requires pull requests, the workflow will fail there and the bump needs to arrive as a PR instead (which `cd.yml` then releases).
- **Workflow permissions.** `bump.yml` needs the repository's Actions token set to read *and write*. If it is read-only, the push fails.

Neither is something I can verify from here.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npm test` passes (441 tests)
- [x] Workflows validated with `actionlint` 1.7.7, clean
- [x] `version-bump.mjs` exercised against copies of the four version files: 1.1.42 to 1.1.43 across `manifest.json`, `manifest-beta.json` and `versions.json`, other fields untouched
- [ ] Tested in Obsidian. Not applicable, no plugin code changed
- [x] Changes are minimal and focused

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZ6ATj1J2VQvN1RmTHuM9W)_