### PR TITLE
Sign in with Zitadel by swapping redirect_uri and return_url

### DIFF
--- a/__tests__/auth/OAuthDeepLinkReceiver.test.ts
+++ b/__tests__/auth/OAuthDeepLinkReceiver.test.ts
@@ -2,12 +2,22 @@ import { describe, test, expect, beforeEach, jest } from "@jest/globals";
 import {
 	OAuthDeepLinkReceiver,
 	OAUTH_CALLBACK_ACTION,
-	OAUTH_REDIRECT_URI,
+	OAUTH_RETURN_URL,
 } from "../../src/auth/OAuthDeepLinkReceiver";
 
 jest.mock("../../src/debug", () => ({
 	curryLog: () => () => {},
 }));
+
+/** What the patched control plane appends to the return URL. */
+const SESSION = {
+	access_token: "access_abc",
+	refresh_token: "refresh_abc",
+	expires_in: "1800",
+	user_id: "user-1",
+	user_email: "someone@example.com",
+	user_name: "Someone",
+};
 
 describe("OAuthDeepLinkReceiver", () => {
 	let receiver: OAuthDeepLinkReceiver;
@@ -16,36 +26,41 @@ describe("OAuthDeepLinkReceiver", () => {
 		receiver = new OAuthDeepLinkReceiver();
 	});
 
-	test("the redirect URI is one fixed string", () => {
+	test("the return URL is one fixed string", () => {
 		// The whole point of the change: a loopback port varied per run and
-		// could not be registered at an IdP that matches exactly.
-		expect(OAUTH_REDIRECT_URI).toBe(`obsidian://${OAUTH_CALLBACK_ACTION}`);
-		expect(OAUTH_REDIRECT_URI).not.toMatch(/127\.0\.0\.1|localhost|:\d+/);
+		// could not be registered anywhere.
+		expect(OAUTH_RETURN_URL).toBe(`obsidian://${OAUTH_CALLBACK_ACTION}`);
+		expect(OAUTH_RETURN_URL).not.toMatch(/127\.0\.0\.1|localhost|:\d+/);
 	});
 
-	test("resolves with the code when the state matches", async () => {
+	test("resolves with the session when the state matches", async () => {
 		const waiting = receiver.waitForCallback("state_abc", 5000);
 		expect(receiver.isWaiting).toBe(true);
 
 		const consumed = receiver.handleCallback({
-			code: "code_xyz",
+			...SESSION,
 			state: "state_abc",
 		});
 
 		expect(consumed).toBe(true);
 		await expect(waiting).resolves.toEqual({
-			code: "code_xyz",
 			state: "state_abc",
+			accessToken: "access_abc",
+			refreshToken: "refresh_abc",
+			expiresIn: 1800,
+			userId: "user-1",
+			userEmail: "someone@example.com",
+			userName: "Someone",
 		});
 		expect(receiver.isWaiting).toBe(false);
 	});
 
 	test("P6-TR21: rejects a callback whose state does not match", async () => {
 		// Anything on the machine can open an obsidian:// URL, so a callback
-		// carrying the wrong state is somebody else's code or a forgery.
+		// carrying the wrong state is somebody else's session or a forgery.
 		const waiting = receiver.waitForCallback("state_ours", 5000);
 
-		receiver.handleCallback({ code: "code_theirs", state: "state_theirs" });
+		receiver.handleCallback({ ...SESSION, state: "state_theirs" });
 
 		await expect(waiting).rejects.toThrow("state mismatch");
 	});
@@ -61,14 +76,16 @@ describe("OAuthDeepLinkReceiver", () => {
 		await expect(waiting).rejects.toThrow("access_denied");
 	});
 
-	test("rejects a callback missing its code", async () => {
+	test("says so when the callback carries no session", async () => {
+		// An unpatched control plane redirects here with the token in a cookie
+		// this application cannot read, so the callback arrives empty.
 		const waiting = receiver.waitForCallback("state_abc", 5000);
 		receiver.handleCallback({ state: "state_abc" });
-		await expect(waiting).rejects.toThrow("missing code or state");
+		await expect(waiting).rejects.toThrow("without a session");
 	});
 
 	test("ignores a callback when nothing is waiting", () => {
-		expect(receiver.handleCallback({ code: "c", state: "s" })).toBe(false);
+		expect(receiver.handleCallback({ ...SESSION, state: "s" })).toBe(false);
 	});
 
 	test("refuses a second concurrent flow rather than orphaning the first", async () => {
@@ -78,11 +95,10 @@ describe("OAuthDeepLinkReceiver", () => {
 		);
 
 		// The first is still live and still the one that gets answered.
-		receiver.handleCallback({ code: "code_one", state: "state_one" });
-		await expect(first).resolves.toEqual({
-			code: "code_one",
-			state: "state_one",
-		});
+		receiver.handleCallback({ ...SESSION, state: "state_one" });
+		await expect(first).resolves.toEqual(
+			expect.objectContaining({ state: "state_one", accessToken: "access_abc" }),
+		);
 	});
 
 	test("times out", async () => {

--- a/__tests__/auth/OAuthHandler.live.test.ts
+++ b/__tests__/auth/OAuthHandler.live.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The plugin's own OAuth code against a real control plane.
+ *
+ * Skipped unless SPIKE_CP points at one. The rig that provides it lives in
+ * knap-mcp-admin at `scripts/spikes/oauth_native_return_url/`: their control
+ * plane at d3ae231 with both patches, plus a three-endpoint stub standing in
+ * for Zitadel. Nothing here is mocked except `customFetch`, which is swapped
+ * for node's fetch because the real one goes through Obsidian's `requestUrl`.
+ *
+ *   SPIKE_CP=http://127.0.0.1:8010 SPIKE_IDP=http://127.0.0.1:9099 npx jest live
+ *
+ * What it proves that the unit tests cannot: the two parameters this plugin
+ * sends are the two that control plane accepts, and the query string it
+ * redirects to is one the receiver can turn into a session.
+ */
+
+import { describe, test, expect, jest } from "@jest/globals";
+
+const CP = process.env.SPIKE_CP ?? "";
+const IDP = process.env.SPIKE_IDP ?? "http://127.0.0.1:9099";
+const PROVIDER = "zitadel";
+
+jest.mock("../../src/debug", () => ({
+	curryLog: () => jest.fn(),
+	HasLogging: class HasLogging {
+		protected debug = jest.fn();
+		protected log = jest.fn();
+		protected warn = jest.fn();
+		protected error = jest.fn();
+	},
+}));
+
+// The real thing wraps Obsidian's requestUrl, which does not exist here.
+jest.mock("../../src/customFetch", () => ({
+	customFetch: (url: string, init?: RequestInit) =>
+		fetch(url, { ...init, redirect: "manual" }),
+}));
+
+import { OAuthHandler } from "../../src/auth/OAuthHandler";
+import { oauthDeepLinkReceiver } from "../../src/auth/OAuthDeepLinkReceiver";
+
+const live = CP ? describe : describe.skip;
+
+live("OAuthHandler against a live control plane", () => {
+	test("signs in end to end and comes back with a usable session", async () => {
+		const handler = new OAuthHandler(CP, "spike-server");
+
+		// 1. The plugin asks the control plane to start a flow.
+		const { authorizeUrl, returnUrl } = await handler.prepareOAuthFlow(PROVIDER);
+		expect(returnUrl).toBe("obsidian://knap-sync/oauth-callback");
+
+		// The IdP is only ever told to come back to the control plane.
+		const authorizeParams = new URL(authorizeUrl).searchParams;
+		expect(authorizeParams.get("redirect_uri")).toBe(
+			`${CP}/v1/auth/oauth/${PROVIDER}/callback`,
+		);
+		expect(authorizeUrl).not.toContain("obsidian");
+
+		// 2. The browser's job: the IdP, then the control plane's callback.
+		const atIdp = await fetch(
+			authorizeUrl.replace("http://host.docker.internal:9099", IDP),
+			{ redirect: "manual" },
+		);
+		const backToCp = atIdp.headers.get("location");
+		expect(backToCp).toBeTruthy();
+
+		const callback = await fetch(backToCp as string, { redirect: "manual" });
+		const deepLink = callback.headers.get("location");
+		expect(deepLink).toMatch(/^obsidian:\/\/knap-sync\/oauth-callback\?/);
+
+		// 3. Obsidian's job: hand those parameters to the protocol handler.
+		const waiting = handler.waitForCallbackAndExchange(PROVIDER, 10_000);
+		const params: Record<string, string> = {};
+		new URL(deepLink as string).searchParams.forEach((value, key) => {
+			params[key] = value;
+		});
+		expect(oauthDeepLinkReceiver.handleCallback(params)).toBe(true);
+
+		const auth = await waiting;
+		expect(auth.user.email).toBe("spike@example.com");
+		expect(auth.token.token).toBeTruthy();
+		expect(auth.refreshToken).toBeTruthy();
+
+		// 4. And the token the plugin ended up holding actually opens a session.
+		const me = await fetch(`${CP}/v1/auth/me`, {
+			headers: { authorization: `Bearer ${auth.token.token}` },
+		});
+		expect(me.status).toBe(200);
+		expect((await me.json()).email).toBe("spike@example.com");
+	}, 30_000);
+
+	test("a callback whose state is not ours is refused (TR-21)", async () => {
+		const handler = new OAuthHandler(CP, "spike-server");
+		await handler.prepareOAuthFlow(PROVIDER);
+
+		const waiting = handler.waitForCallbackAndExchange(PROVIDER, 10_000);
+		oauthDeepLinkReceiver.handleCallback({
+			state: "not-the-state-we-were-issued",
+			access_token: "somebody-elses-session",
+		});
+
+		await expect(waiting).rejects.toThrow("state mismatch");
+	}, 30_000);
+});

--- a/__tests__/auth/OAuthHandler.test.ts
+++ b/__tests__/auth/OAuthHandler.test.ts
@@ -6,7 +6,6 @@
 
 import { describe, test, expect, beforeEach, jest } from "@jest/globals";
 import { OAuthHandler } from "../../src/auth/OAuthHandler";
-import type { AuthResponse } from "../../src/auth/IAuthProvider";
 
 // Mock dependencies
 jest.mock("../../src/debug", () => ({
@@ -25,7 +24,7 @@ const mockFetch = customFetch as jest.MockedFunction<typeof customFetch>;
 
 jest.mock("../../src/auth/OAuthDeepLinkReceiver", () => ({
 	OAUTH_CALLBACK_ACTION: "knap-sync/oauth-callback",
-	OAUTH_REDIRECT_URI: "obsidian://knap-sync/oauth-callback",
+	OAUTH_RETURN_URL: "obsidian://knap-sync/oauth-callback",
 	oauthDeepLinkReceiver: {
 		waitForCallback: jest.fn(),
 		cancel: jest.fn(),
@@ -53,21 +52,40 @@ function mockFetchResponse(status: number, data: any, ok = true) {
 describe("OAuthHandler", () => {
 	const CONTROL_PLANE_URL = "https://cp.example.com";
 	const SERVER_ID = "test-server-123";
-	const PROVIDER = "casdoor";
+	const PROVIDER = "zitadel";
+
+	/** What the control plane hands back over the deep link once it has
+	 *  exchanged the code itself. */
+	const SESSION = {
+		state: "state_xyz",
+		accessToken: "access_token_abc",
+		expiresIn: 3600,
+		userId: "user-123",
+		userEmail: "test@example.com",
+		userName: "Test User",
+	};
 
 	let handler: OAuthHandler;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
 
-		// Setup mock callback server
-
 		handler = new OAuthHandler(CONTROL_PLANE_URL, SERVER_ID);
 	});
 
+	async function prepare(state = "state_xyz") {
+		mockFetch.mockResolvedValueOnce(
+			await mockFetchResponse(200, {
+				authorize_url: "https://idp.example.com/oauth/v2/authorize",
+				state,
+			}),
+		);
+		return handler.prepareOAuthFlow(PROVIDER);
+	}
+
 	describe("prepareOAuthFlow()", () => {
 		test("P7: Calls authorize endpoint correctly", async () => {
-			const authorizeUrl = "https://casdoor.example.com/oauth/authorize?...";
+			const authorizeUrl = "https://idp.example.com/oauth/v2/authorize?...";
 			mockFetch.mockResolvedValue(
 				await mockFetchResponse(200, { authorize_url: authorizeUrl, state: "state_xyz" }),
 			);
@@ -87,11 +105,27 @@ describe("OAuthHandler", () => {
 			);
 			expect(result).toEqual({
 				authorizeUrl,
-				callbackUrl: "obsidian://knap-sync/oauth-callback",
+				returnUrl: "obsidian://knap-sync/oauth-callback",
 			});
 		});
 
-		test("P8: Error stops callback server", async () => {
+		test("The IdP is sent the control plane's callback, never the custom scheme", async () => {
+			// Measured 2026-08-11: Zitadel stores a custom scheme on a Web app
+			// and then refuses it at authorize time. So the custom scheme goes
+			// in return_url, which the control plane keeps to itself, and
+			// redirect_uri is an https URI the IdP already has registered.
+			await prepare();
+
+			const url = new URL(String(mockFetch.mock.calls[0][0]));
+			expect(url.searchParams.get("redirect_uri")).toBe(
+				`${CONTROL_PLANE_URL}/v1/auth/oauth/${PROVIDER}/callback`,
+			);
+			expect(url.searchParams.get("return_url")).toBe(
+				"obsidian://knap-sync/oauth-callback",
+			);
+		});
+
+		test("P8: Error stops the pending flow", async () => {
 			mockFetch.mockResolvedValue(
 				await mockFetchResponse(500, { error: "Server error" }, false),
 			);
@@ -116,7 +150,7 @@ describe("OAuthHandler", () => {
 		test("P9b-TR21: Missing state throws error (nothing to verify the callback against)", async () => {
 			mockFetch.mockResolvedValue(
 				await mockFetchResponse(200, {
-					authorize_url: "https://casdoor.example.com/oauth/authorize",
+					authorize_url: "https://idp.example.com/oauth/v2/authorize",
 				}),
 			);
 
@@ -139,7 +173,7 @@ describe("OAuthHandler", () => {
 
 			mockFetch.mockResolvedValue(
 				await mockFetchResponse(200, {
-					authorize_url: "https://casdoor.example.com/oauth/authorize",
+					authorize_url: "https://idp.example.com/oauth/v2/authorize",
 					state: "state_xyz",
 				}),
 			);
@@ -161,45 +195,18 @@ describe("OAuthHandler", () => {
 	});
 
 	describe("waitForCallbackAndExchange()", () => {
-		test("P10: Parses response correctly", async () => {
-			mockReceiver.waitForCallback.mockResolvedValue({
-				code: "auth_code_123",
-				state: "state_xyz",
-			});
+		test("P10: Turns the session into an AuthResponse", async () => {
+			mockReceiver.waitForCallback.mockResolvedValue(SESSION);
 
-			const mockUserData = {
-				user_id: "user-123",
-				user_email: "test@example.com",
-				user_name: "Test User",
-				access_token: "access_token_abc",
-				expires_in: 3600,
-			};
-
-			mockFetch.mockResolvedValue(await mockFetchResponse(200, mockUserData));
-
-			// Need to prepare first
-			mockFetch.mockResolvedValueOnce(
-				await mockFetchResponse(200, {
-					authorize_url: "https://casdoor.example.com/oauth/authorize",
-					state: "state_xyz",
-				}),
-			);
-			await handler.prepareOAuthFlow(PROVIDER);
-
+			await prepare();
 			mockFetch.mockClear();
-			mockFetch.mockResolvedValue(await mockFetchResponse(200, mockUserData));
 
 			const result = await handler.waitForCallbackAndExchange(PROVIDER);
 
 			expect(mockReceiver.waitForCallback).toHaveBeenCalledWith("state_xyz", 300000);
-			expect(mockFetch).toHaveBeenCalledWith(
-				expect.stringContaining(
-					`/v1/auth/oauth/${PROVIDER}/callback?code=auth_code_123&state=state_xyz`,
-				),
-				expect.objectContaining({
-					method: "GET",
-				}),
-			);
+			// The control plane exchanged the code before it redirected, so
+			// there is nothing left for this side to call.
+			expect(mockFetch).not.toHaveBeenCalled();
 
 			expect(result).toEqual({
 				user: {
@@ -216,35 +223,30 @@ describe("OAuthHandler", () => {
 			});
 		});
 
-		test("P11: Includes refresh_token if provided", async () => {
+		test("P11: Includes the refresh token if the callback carried one", async () => {
 			mockReceiver.waitForCallback.mockResolvedValue({
-				code: "auth_code_123",
-				state: "state_xyz",
+				...SESSION,
+				refreshToken: "refresh_token_xyz",
 			});
 
-			const mockUserData = {
-				user_id: "user-123",
-				user_email: "test@example.com",
-				access_token: "access_token_abc",
-				refresh_token: "refresh_token_xyz",
-				expires_in: 3600,
-			};
-
-			// Prepare
-			mockFetch.mockResolvedValueOnce(
-				await mockFetchResponse(200, {
-					authorize_url: "https://casdoor.example.com/oauth/authorize",
-					state: "state_xyz",
-				}),
-			);
-			await handler.prepareOAuthFlow(PROVIDER);
-
-			mockFetch.mockClear();
-			mockFetch.mockResolvedValue(await mockFetchResponse(200, mockUserData));
+			await prepare();
 
 			const result = await handler.waitForCallbackAndExchange(PROVIDER);
 
 			expect(result.refreshToken).toBe("refresh_token_xyz");
+		});
+
+		test("Falls back to the email when no display name comes back", async () => {
+			mockReceiver.waitForCallback.mockResolvedValue({
+				...SESSION,
+				userName: undefined,
+			});
+
+			await prepare();
+
+			const result = await handler.waitForCallbackAndExchange(PROVIDER);
+
+			expect(result.user.name).toBe("test@example.com");
 		});
 
 		test("P12: Handles callback error", async () => {
@@ -252,14 +254,7 @@ describe("OAuthHandler", () => {
 				new Error("OAuth callback timeout"),
 			);
 
-			// Prepare
-			mockFetch.mockResolvedValueOnce(
-				await mockFetchResponse(200, {
-					authorize_url: "https://casdoor.example.com/oauth/authorize",
-					state: "state_xyz",
-				}),
-			);
-			await handler.prepareOAuthFlow(PROVIDER);
+			await prepare();
 
 			await expect(
 				handler.waitForCallbackAndExchange(PROVIDER),
@@ -268,46 +263,10 @@ describe("OAuthHandler", () => {
 			expect(mockReceiver.cancel).toHaveBeenCalled();
 		});
 
-		test("Handles exchange API error", async () => {
-			mockReceiver.waitForCallback.mockResolvedValue({
-				code: "auth_code_123",
-				state: "state_xyz",
-			});
-
-			// Prepare
-			mockFetch.mockResolvedValueOnce(
-				await mockFetchResponse(200, {
-					authorize_url: "https://casdoor.example.com/oauth/authorize",
-					state: "state_xyz",
-				}),
-			);
-			await handler.prepareOAuthFlow(PROVIDER);
-
-			mockFetch.mockClear();
-			mockFetch.mockResolvedValue(
-				await mockFetchResponse(401, { error: "Invalid code" }, false),
-			);
-
-			await expect(
-				handler.waitForCallbackAndExchange(PROVIDER),
-			).rejects.toThrow("OAuth callback exchange failed");
-
-			expect(mockReceiver.cancel).toHaveBeenCalled();
-		});
-
 		test("P15: Cleanup on error (pending callback cancelled)", async () => {
-			// Prepare
-			mockFetch.mockResolvedValueOnce(
-				await mockFetchResponse(200, {
-					authorize_url: "https://casdoor.example.com/oauth/authorize",
-					state: "state_xyz",
-				}),
-			);
-			await handler.prepareOAuthFlow(PROVIDER);
+			await prepare();
 
-			mockReceiver.waitForCallback.mockRejectedValue(
-				new Error("Timeout"),
-			);
+			mockReceiver.waitForCallback.mockRejectedValue(new Error("Timeout"));
 
 			await expect(
 				handler.waitForCallbackAndExchange(PROVIDER),
@@ -326,31 +285,14 @@ describe("OAuthHandler", () => {
 	});
 
 	describe("completeOAuthFlow()", () => {
-		test("P13: Chains prepare + browser + exchange", async () => {
-			const authorizeUrl = "https://casdoor.example.com/oauth/authorize?...";
+		test("P13: Chains prepare + browser + callback", async () => {
+			const authorizeUrl = "https://idp.example.com/oauth/v2/authorize?...";
 			const openBrowser = jest.fn();
 
-			// Mock prepare
 			mockFetch.mockResolvedValueOnce(
 				await mockFetchResponse(200, { authorize_url: authorizeUrl, state: "state_xyz" }),
 			);
-
-			// Mock callback
-			mockReceiver.waitForCallback.mockResolvedValue({
-				code: "auth_code_123",
-				state: "state_xyz",
-			});
-
-			// Mock exchange
-			const mockUserData = {
-				user_id: "user-123",
-				user_email: "test@example.com",
-				access_token: "access_token_abc",
-				expires_in: 3600,
-			};
-			mockFetch.mockResolvedValueOnce(
-				await mockFetchResponse(200, mockUserData),
-			);
+			mockReceiver.waitForCallback.mockResolvedValue(SESSION);
 
 			const result = await handler.completeOAuthFlow(PROVIDER, openBrowser);
 
@@ -358,45 +300,11 @@ describe("OAuthHandler", () => {
 			expect(result.user.email).toBe("test@example.com");
 			expect(result.token.token).toBe("access_token_abc");
 		});
-
-		test("Opens browser with correct URL", async () => {
-			const authorizeUrl = "https://casdoor.example.com/oauth/authorize?client_id=123";
-			const openBrowser = jest.fn();
-
-			mockFetch.mockResolvedValueOnce(
-				await mockFetchResponse(200, { authorize_url: authorizeUrl, state: "state_xyz" }),
-			);
-
-			mockReceiver.waitForCallback.mockResolvedValue({
-				code: "code",
-				state: "state",
-			});
-
-			mockFetch.mockResolvedValueOnce(
-				await mockFetchResponse(200, {
-					user_id: "u1",
-					user_email: "test@test.com",
-					access_token: "token",
-					expires_in: 3600,
-				}),
-			);
-
-			await handler.completeOAuthFlow(PROVIDER, openBrowser);
-
-			expect(openBrowser).toHaveBeenCalledWith(authorizeUrl);
-		});
 	});
 
 	describe("destroy()", () => {
 		test("Cancels a pending callback", async () => {
-			mockFetch.mockResolvedValue(
-				await mockFetchResponse(200, {
-					authorize_url: "https://casdoor.example.com/oauth/authorize",
-					state: "state_xyz",
-				}),
-			);
-
-			await handler.prepareOAuthFlow(PROVIDER);
+			await prepare();
 
 			handler.destroy();
 

--- a/src/auth/OAuthDeepLinkReceiver.ts
+++ b/src/auth/OAuthDeepLinkReceiver.ts
@@ -13,10 +13,24 @@
  * Node's `http`, refused to start outside the desktop app, and iOS would not
  * have let a plugin listen on a socket anyway.
  *
+ * **The IdP never sees this URI.** Registering it there was tried and refused:
+ * Zitadel stores a custom scheme on a Web app and then answers "this client's
+ * redirect_uri is using a custom schema and is not allowed" at authorize time,
+ * and the Native app type that would allow it cannot carry a client secret,
+ * which the control plane requires of a provider. So the redirect URI is the
+ * control plane's own https callback and this URI is the `return_url` it
+ * forwards to afterwards. The custom scheme stays between those two.
+ *
+ * What arrives here is therefore a finished session rather than an
+ * authorization code: the control plane has already exchanged the code by the
+ * time it redirects. It hands the token over in the query string, which is
+ * only acceptable because it allowlists this prefix -- see
+ * `deploy/evc-patches/oauth-native-return-url.patch` in knap-mcp-admin.
+ *
  * What is deliberately kept from the server it replaces: the state check. A
  * callback carrying the wrong state is rejected rather than used (TR-21).
  * Anything on the machine can invoke a URL scheme, so without that check
- * somebody else's authorization code could be fed into our flow.
+ * somebody else's session could be fed into our flow.
  */
 
 import { curryLog } from "../debug";
@@ -24,8 +38,13 @@ import { curryLog } from "../debug";
 const log = curryLog("[OAuthDeepLinkReceiver]", "log");
 
 export interface OAuthCallbackParams {
-	code: string;
 	state: string;
+	accessToken: string;
+	refreshToken?: string;
+	expiresIn?: number;
+	userId?: string;
+	userEmail?: string;
+	userName?: string;
 }
 
 interface Pending {
@@ -36,17 +55,21 @@ interface Pending {
 }
 
 /**
- * The path half of the redirect URI, after `obsidian://`.
+ * The path half of the return URL, after `obsidian://`.
  *
  * Registered with `registerObsidianProtocolHandler` at plugin load, and sent
- * to the control plane as part of the redirect URI, which forwards it to the
- * IdP and seals it into the signed state. All three must agree, so this is
- * the one place it is spelled.
+ * to the control plane as `return_url`, which seals it into the signed state
+ * and redirects here when the flow is done. Both ends must agree, and the
+ * control plane's allowlist has to carry the same prefix, so this is the one
+ * place it is spelled.
  */
 export const OAUTH_CALLBACK_ACTION = "knap-sync/oauth-callback";
 
-/** The full redirect URI. This is the string registered at the IdP. */
-export const OAUTH_REDIRECT_URI = `obsidian://${OAUTH_CALLBACK_ACTION}`;
+/**
+ * The full return URL. Never registered at the IdP, which refuses custom
+ * schemes on a Web app -- only the control plane ever sees this string.
+ */
+export const OAUTH_RETURN_URL = `obsidian://${OAUTH_CALLBACK_ACTION}`;
 
 export class OAuthDeepLinkReceiver {
 	private pending: Pending | null = null;
@@ -64,7 +87,17 @@ export class OAuthDeepLinkReceiver {
 			return false;
 		}
 
-		const { code, state, error, error_description: description } = params;
+		const {
+			state,
+			access_token: accessToken,
+			refresh_token: refreshToken,
+			expires_in: expiresIn,
+			user_id: userId,
+			user_email: userEmail,
+			user_name: userName,
+			error,
+			error_description: description,
+		} = params;
 		const pending = this.pending;
 
 		if (error) {
@@ -76,9 +109,17 @@ export class OAuthDeepLinkReceiver {
 			return true;
 		}
 
-		if (!code || !state) {
+		if (!accessToken || !state) {
+			// An empty callback is the signature of a control plane without the
+			// native-return_url patch: it put the token in a cookie this
+			// application cannot read and redirected here with nothing.
 			this.settle(() =>
-				pending.reject(new Error("OAuth callback missing code or state")),
+				pending.reject(
+					new Error(
+						"The sign-in came back without a session. The server needs " +
+							"the patch that hands a token to an application callback.",
+					),
+				),
 			);
 			return true;
 		}
@@ -93,7 +134,17 @@ export class OAuthDeepLinkReceiver {
 			return true;
 		}
 
-		this.settle(() => pending.resolve({ code, state }));
+		this.settle(() =>
+			pending.resolve({
+				state,
+				accessToken,
+				refreshToken: refreshToken || undefined,
+				expiresIn: expiresIn ? Number(expiresIn) : undefined,
+				userId: userId || undefined,
+				userEmail: userEmail || undefined,
+				userName: userName || undefined,
+			}),
+		);
 		return true;
 	}
 

--- a/src/auth/OAuthHandler.ts
+++ b/src/auth/OAuthHandler.ts
@@ -1,15 +1,27 @@
 /**
  * OAuth Handler
  *
- * Orchestrates the OAuth flow for relay-onprem authentication.
- * Handles opening browser, callback server, and token exchange.
+ * Orchestrates the OAuth flow for relay-onprem authentication: opens the
+ * browser, waits for the deep link back, and turns it into a session.
+ *
+ * Two parameters carry the whole design, and swapping them is what made an
+ * IdP with exact redirect matching work at all:
+ *
+ *   redirect_uri  the control plane's own https callback -- the only URI the
+ *                 IdP ever sees, and one it already has registered
+ *   return_url    obsidian://knap-sync/oauth-callback -- where the control
+ *                 plane sends the finished session afterwards
+ *
+ * The other way round, the custom scheme reached the IdP and was refused. So
+ * the token exchange happens on the control plane rather than here, and what
+ * this file waits for is a session, not an authorization code.
  */
 
 import { curryLog } from "../debug";
 import { customFetch } from "../customFetch";
 import {
 	oauthDeepLinkReceiver,
-	OAUTH_REDIRECT_URI,
+	OAUTH_RETURN_URL,
 } from "./OAuthDeepLinkReceiver";
 import type { AuthResponse } from "./IAuthProvider";
 
@@ -18,20 +30,11 @@ interface OAuthAuthorizeApiResponse {
 	state: string;
 }
 
-interface OAuthCallbackApiResponse {
-	user_id: string;
-	user_email: string;
-	user_name?: string;
-	access_token: string;
-	expires_in?: number;
-	refresh_token?: string;
-}
-
 const log = curryLog("[OAuthHandler]");
 
 export interface OAuthStartResult {
 	authorizeUrl: string;
-	callbackUrl: string;
+	returnUrl: string;
 }
 
 export class OAuthHandler {
@@ -50,22 +53,26 @@ export class OAuthHandler {
 	}
 
 	/**
-	 * Start OAuth flow - prepares callback server and returns authorize URL
+	 * Start OAuth flow - registers the return URL and returns the authorize URL
 	 * @param provider - OAuth provider name (e.g., "casdoor", "google", "github")
-	 * @returns Authorization URL and callback info
+	 * @returns Authorization URL and where the flow comes back
 	 */
 	async prepareOAuthFlow(provider: string): Promise<OAuthStartResult> {
 		log(`Preparing OAuth flow for provider: ${provider}`);
 
-		// One fixed redirect URI, registered once at the IdP. It used to be a
-		// loopback URL on an OS-assigned port, which is why signing in against
-		// an IdP that matches redirect URIs exactly was impossible.
-		const callbackUrl = OAUTH_REDIRECT_URI;
+		// The IdP is told to come back to the control plane, which is the only
+		// URI it has registered. Where WE want the flow to end up is the
+		// return_url, which the control plane keeps to itself.
+		const redirectUri = `${this.normalizedUrl}/v1/auth/oauth/${provider}/callback`;
+		const returnUrl = OAUTH_RETURN_URL;
 
-		log(`Awaiting the callback on ${callbackUrl}`);
+		log(`Awaiting the sign-in on ${returnUrl}`);
 
 		// Get authorize URL from control plane
-		const authorizeUrlEndpoint = `${this.normalizedUrl}/v1/auth/oauth/${provider}/authorize?redirect_uri=${encodeURIComponent(callbackUrl)}`;
+		const authorizeUrlEndpoint =
+			`${this.normalizedUrl}/v1/auth/oauth/${provider}/authorize` +
+			`?redirect_uri=${encodeURIComponent(redirectUri)}` +
+			`&return_url=${encodeURIComponent(returnUrl)}`;
 
 		try {
 			const response = await customFetch(authorizeUrlEndpoint, {
@@ -101,7 +108,7 @@ export class OAuthHandler {
 
 			return {
 				authorizeUrl,
-				callbackUrl,
+				returnUrl,
 			};
 		} catch (error: unknown) {
 			this.stopCallbackServer();
@@ -110,9 +117,9 @@ export class OAuthHandler {
 	}
 
 	/**
-	 * Wait for OAuth callback and exchange code for tokens
+	 * Wait for the control plane to hand the finished session back
 	 * @param provider - OAuth provider name
-	 * @param timeoutMs - Maximum time to wait for callback (default 5 minutes)
+	 * @param timeoutMs - Maximum time to wait for the deep link (default 5 minutes)
 	 * @returns Authentication response with user and token
 	 */
 	async waitForCallbackAndExchange(
@@ -124,54 +131,35 @@ export class OAuthHandler {
 		}
 
 		try {
-			log("Waiting for OAuth callback...");
+			log("Waiting for the sign-in to come back...");
 
-			// Wait for callback with code and state, rejecting anything that doesn't carry
-			// the state token we were issued for this flow (TR-21)
-			const { code, state } = await oauthDeepLinkReceiver.waitForCallback(
+			// The control plane has already exchanged the code by now, so what
+			// arrives is a session. Anything not carrying the state token we
+			// were issued for this flow is rejected (TR-21).
+			const session = await oauthDeepLinkReceiver.waitForCallback(
 				this.expectedState,
 				timeoutMs,
 			);
 
-			log(`Received callback with code and state`);
+			log(`Signed in with ${provider}`);
 
-			// Exchange code for tokens via control plane (GET with query params)
-			const callbackEndpoint = `${this.normalizedUrl}/v1/auth/oauth/${provider}/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`;
-
-			const response = await customFetch(callbackEndpoint, {
-				method: "GET",
-				headers: {
-					"Accept": "application/json",
-				},
-			});
-
-			if (!response.ok) {
-				const errorText = await response.text();
-				throw new Error(`OAuth callback exchange failed: ${response.status} ${errorText}`);
-			}
-
-			const data = await response.json() as OAuthCallbackApiResponse;
-
-			log("OAuth token exchange successful");
-
-			// Parse response to AuthResponse format (server returns flat fields)
 			const authResponse: AuthResponse = {
 				user: {
-					id: data.user_id,
-					email: data.user_email,
-					name: data.user_name ?? data.user_email,
-					picture: undefined, // Server doesn't return picture in callback
+					id: session.userId ?? "",
+					email: session.userEmail ?? "",
+					name: session.userName || (session.userEmail ?? ""),
+					picture: undefined, // The callback carries no picture
 				},
 				token: {
-					token: data.access_token,
-					expiresAt: Date.now() + (data.expires_in ?? 3600) * 1000,
+					token: session.accessToken,
+					expiresAt: Date.now() + (session.expiresIn ?? 3600) * 1000,
 				},
-				refreshToken: data.refresh_token,
+				refreshToken: session.refreshToken,
 			};
 
 			return authResponse;
 		} finally {
-			// Always stop the callback server
+			// Always drop the pending flow
 			this.stopCallbackServer();
 		}
 	}


### PR DESCRIPTION
The `obsidian://` handler was the right idea and it went in the wrong field.

Sending it as `redirect_uri` means it reaches the IdP, and Zitadel refuses a custom scheme on a Web app **even after its management API has accepted it**:

> This client's redirect_uri is using a custom schema and is not allowed.

Measured on the real instance on 2026-08-11 and reproduced on a self-hosted Zitadel 2.65.1. The app type that would allow it is Native, which cannot carry a client secret, and the control plane's `oauth_service` will not register a provider without one.

## What this does

- `redirect_uri` is now the control plane's own https callback, the URI Zitadel already has registered.
- `obsidian://knap-sync/oauth-callback` goes in `return_url`, which the control plane keeps to itself.
- The code exchange therefore happens on the control plane, so what this side waits for is a finished session rather than an authorization code: the deep link carries `access_token`, `refresh_token` and who signed in. One fewer round trip from here.
- The state check is untouched (TR-21).
- A control plane without the matching patch redirects here with the token in a cookie an application cannot read, so an empty callback now says exactly that instead of "missing code or state".

The other half is the control-plane patch in [pantalytics/knap-mcp-admin#64](https://github.com/pantalytics/knap-mcp-admin/pull/64), which hands a token to an allowlisted native return URL. This change does nothing without it.

## Testing

`OAuthHandler.live.test.ts` drives the real thing against a patched control plane and skips itself without `SPIKE_CP`, so CI and ordinary runs never depend on it. The rig lives in knap-mcp-admin at `scripts/spikes/oauth_native_return_url/`. Against it, this code completes a sign-in and the token it ends up holding opens `/v1/auth/me`.

`npx tsc -noEmit`, `npm run lint`, `npm run build`, 441 tests.

See ADR-0035 in knap-mcp-admin for the reasoning and the measurements. It corrects one wire in ADR-0030, which had the deep link travelling as `redirect_uri`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)