### PR TITLE
Call the plugin Knap Sync everywhere a person can read it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# CI — Team Relay Obsidian Plugin
+# CI for the Knap Sync Obsidian plugin
 # Based on F3 ci-ts-plugin template (bob/docs/ci-templates/ci-ts-plugin.yml)
 #
 # Burn-in mode: all jobs use continue-on-error: true (non-blocking REPORT).
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: jest-coverage-team-relay
+          name: jest-coverage-knap-sync
           path: coverage/
 
   # ── Build smoke ─────────────────────────────────────────────────────────────
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: team-relay-dist
+          name: knap-sync-dist
           path: main.js
 
   # ── Lint ────────────────────────────────────────────────────────────────────

--- a/docs/ui-ux.md
+++ b/docs/ui-ux.md
@@ -126,7 +126,7 @@ side gets the button.
 
 *Relay* is upstream's word for their product and their server. Neither is
 something a person using this plugin has to know about, so neither reaches the
-screen. `Relay: share folder` becomes `Knap: share folder`, for the same reason
+screen. `Relay: share folder` becomes `Knap Sync: share folder`, for the same reason
 the settings section stopped being called Relay Servers.
 
 ## Permissions come from one place

--- a/src/EndpointManager.ts
+++ b/src/EndpointManager.ts
@@ -391,7 +391,7 @@ export class EndpointManager {
 				errorMessage.includes('ECONNREFUSED')) {
 				errorMessage = `Unable to connect to ${tenantUrl}. Please check the URL and ensure the server is running.`;
 			} else if (errorMessage.includes('404')) {
-				errorMessage = `No tenant license found at ${tenantUrl}. This may not be a valid Enterprise Relay tenant.`;
+				errorMessage = `No tenant license found at ${tenantUrl}. This may not be a valid enterprise relay tenant.`;
 			} else if (errorMessage.includes('License fetch failed')) {
 				// Keep the existing error message as it's already user-friendly
 			}

--- a/src/InboundFileDownloader.ts
+++ b/src/InboundFileDownloader.ts
@@ -173,9 +173,9 @@ export class InboundFileDownloader {
 					serverHash: serverSha256,
 				});
 				new Notice(
-					`Team Relay: skipped syncing "${relativePath}" — local changes ` +
-						`would have been overwritten by the relay version. Resolve ` +
-						`manually, then it will sync normally.`,
+					`Knap Sync: skipped "${relativePath}". The relay version would ` +
+						`have overwritten changes you made here. Merge them yourself ` +
+						`and it syncs normally again.`,
 					0,
 				);
 				return;

--- a/src/LiveViews.ts
+++ b/src/LiveViews.ts
@@ -494,7 +494,7 @@ export class LiveView<ViewType extends TextFileView>
 				try {
 					stale = await this.document.checkStale();
 				} catch (e: unknown) {
-					console.warn("[Relay] setMergeButton checkStale failed:", (e as Error).message);
+					console.warn("[Knap Sync] setMergeButton checkStale failed:", (e as Error).message);
 					this.clearMergeButton();
 					return;
 				}
@@ -546,7 +546,7 @@ export class LiveView<ViewType extends TextFileView>
 					try {
 						stale = await this.document.checkStale();
 					} catch (e: unknown) {
-						console.warn("[Relay] mergeBanner checkStale failed:", (e as Error).message);
+						console.warn("[Knap Sync] mergeBanner checkStale failed:", (e as Error).message);
 						return true;
 					}
 					if (!stale) {
@@ -659,7 +659,7 @@ export class LiveView<ViewType extends TextFileView>
 		} catch (e: unknown) {
 			// HTTP download failed (e.g., 401 with CWT tokens on relay-server).
 			// Return false — rely on WS sync for CRDT state.
-			console.warn("[Relay] LiveView.checkStale failed, relying on WS sync:", (e as Error).message);
+			console.warn("[Knap Sync] LiveView.checkStale failed, relying on WS sync:", (e as Error).message);
 			return false;
 		}
 		if (stale && this.document._diskBuffer?.contents) {
@@ -895,13 +895,13 @@ export class LiveViewManager {
 
 
 	goOffline() {
-		this.log("[System 3][Relay][Live Views] going offline");
+		this.log("[Knap Sync][Live Views] going offline");
 		this.views.forEach((view) => view.document?.disconnect());
 		void this.refresh("[NetworkStatus]");
 	}
 
 	goOnline() {
-		this.log("[System 3][Relay][Live Views] going online");
+		this.log("[Knap Sync][Live Views] going online");
 		void this.refresh("[NetworkStatus]");
 		this.sharedFolders.items().forEach((folder: SharedFolder) => {
 			void folder.connect();
@@ -1004,7 +1004,7 @@ export class LiveViewManager {
 						);
 						views.push(view);
 					} catch (e: unknown) {
-						this.warn(`[Relay] Error getting doc for view ${viewFilePath}`, e);
+						this.warn(`[Knap Sync] Error getting doc for view ${viewFilePath}`, e);
 					}
 				} else {
 					this.log(`Folder not ready, skipping views. folder=${folder.path}`);
@@ -1036,7 +1036,7 @@ export class LiveViewManager {
 							const view = new RelayCanvasView(this, canvasView, doc);
 							views.push(view);
 						} catch (e: unknown) {
-							this.warn(`[Relay] Error getting canvas for view ${viewFilePath}`, e);
+							this.warn(`[Knap Sync] Error getting canvas for view ${viewFilePath}`, e);
 						}
 					} else {
 						this.log(`Folder not ready, skipping views. folder=${folder.path}`);
@@ -1110,7 +1110,7 @@ export class LiveViewManager {
 
 		if (attemptedConnections > backgroundConnections) {
 			this.warn(
-				`[System 3][Relay][Live Views] connection pool (max ${backgroundConnections}): rejected connections for ${
+				`[Knap Sync][Live Views] connection pool (max ${backgroundConnections}): rejected connections for ${
 					attemptedConnections - backgroundConnections
 				} views`,
 			);
@@ -1178,7 +1178,7 @@ export class LiveViewManager {
 		try {
 			views = this.getViews();
 		} catch (e: unknown) {
-			this.warn("[System 3][Relay][Live Views] error getting views", e);
+			this.warn("[Knap Sync][Live Views] error getting views", e);
 			return false;
 		}
 		const activeDocumentFolders = this.findFolders();

--- a/src/LoginManager.ts
+++ b/src/LoginManager.ts
@@ -263,7 +263,7 @@ export class LoginManager extends Observable<LoginManager> {
 
 		// Only initialize PocketBase if NOT in relay-onprem mode. Reaching this
 		// point at all requires relayOnPrem.enabled=false, which has no UI path —
-		// only a manual data.json edit. TR-58: the EVC build compiles API_URL/
+		// only a manual data.json edit. TR-58: this build compiles API_URL/
 		// AUTH_URL empty (this fork ships relay-onprem only, no System3 cloud),
 		// so unless a custom tenant URL was separately validated via
 		// validateAndApplyEndpoints(), getAuthUrl() is "" here — constructing

--- a/src/Patcher.ts
+++ b/src/Patcher.ts
@@ -4,7 +4,7 @@ import { HasLogging } from "./debug";
 // Extend window interface to include our debugging property
 declare global {
 	interface Window {
-		evcTeamRelayPatches?: Array<() => void>;
+		knapSyncPatches?: Array<() => void>;
 	}
 }
 
@@ -19,12 +19,12 @@ export class Patcher extends HasLogging {
 
 	private constructor() {
 		super("Patcher");
-		// Initialize window.evcTeamRelayPatches for debugging
+		// Initialize window.knapSyncPatches for debugging
 		if (typeof window !== "undefined") {
-			if (window.evcTeamRelayPatches && window.evcTeamRelayPatches.length > 0) {
-				console.warn(`Found ${window.evcTeamRelayPatches.length} existing unsubscribers on window.evcTeamRelayPatches at startup - possible memory leak or incomplete cleanup`);
+			if (window.knapSyncPatches && window.knapSyncPatches.length > 0) {
+				console.warn(`Found ${window.knapSyncPatches.length} existing unsubscribers on window.knapSyncPatches at startup - possible memory leak or incomplete cleanup`);
 			}
-			window.evcTeamRelayPatches = [];
+			window.knapSyncPatches = [];
 		}
 	}
 
@@ -74,8 +74,8 @@ export class Patcher extends HasLogging {
 		this.unsubscribes.push(unsubscribe);
 
 		// Also store on window for debugging
-		if (typeof window !== "undefined" && window.evcTeamRelayPatches) {
-			window.evcTeamRelayPatches.push(unsubscribe);
+		if (typeof window !== "undefined" && window.knapSyncPatches) {
+			window.knapSyncPatches.push(unsubscribe);
 		}
 		
 		this.debug("Applied monkeypatch", {
@@ -97,9 +97,9 @@ export class Patcher extends HasLogging {
 			if (index >= 0) this.unsubscribes.splice(index, 1);
 			
 			// Remove from window debugging
-			if (typeof window !== "undefined" && window.evcTeamRelayPatches) {
-				const windowIndex = window.evcTeamRelayPatches.indexOf(unsubscribe);
-				if (windowIndex >= 0) window.evcTeamRelayPatches.splice(windowIndex, 1);
+			if (typeof window !== "undefined" && window.knapSyncPatches) {
+				const windowIndex = window.knapSyncPatches.indexOf(unsubscribe);
+				if (windowIndex >= 0) window.knapSyncPatches.splice(windowIndex, 1);
 			}
 			
 			unsubscribe();
@@ -133,9 +133,9 @@ export class Patcher extends HasLogging {
 		});
 		this.unsubscribes.length = 0;
 
-		// Clear window.evcTeamRelayPatches as well
-		if (typeof window !== "undefined" && window.evcTeamRelayPatches) {
-			window.evcTeamRelayPatches.length = 0;
+		// Clear window.knapSyncPatches as well
+		if (typeof window !== "undefined" && window.knapSyncPatches) {
+			window.knapSyncPatches.length = 0;
 		}
 		
 		this.log("Completed cleanup of monkeypatches", { cleanedCount: count });
@@ -150,9 +150,9 @@ export class Patcher extends HasLogging {
 			Patcher.instance.cleanup();
 			Patcher.instance = null;
 		}
-		// Clear window.evcTeamRelayPatches even if instance is null
-		if (typeof window !== "undefined" && window.evcTeamRelayPatches) {
-			window.evcTeamRelayPatches.length = 0;
+		// Clear window.knapSyncPatches even if instance is null
+		if (typeof window !== "undefined" && window.knapSyncPatches) {
+			window.knapSyncPatches.length = 0;
 		}
 	}
 

--- a/src/RelayOnPremConfig.ts
+++ b/src/RelayOnPremConfig.ts
@@ -1,13 +1,13 @@
 /**
- * Relay On-Premise Configuration
+ * Knap Sync server configuration
  *
  * Configuration options for connecting to self-hosted relay-onprem instances
  * Supports multiple servers with independent authentication
  */
 
 /** Well-known Knap relay server */
-export const EVC_SERVER_ID = "knap-sync";
-export const EVC_CP_URL = "https://cp.knap.pantalytics.com";
+export const KNAP_SERVER_ID = "knap-sync";
+export const KNAP_CP_URL = "https://cp.knap.pantalytics.com";
 
 /**
  * Generate a unique server ID from URL
@@ -103,13 +103,13 @@ export const DEFAULT_RELAY_ONPREM_SETTINGS: RelayOnPremSettings = {
 	enabled: true,
 	servers: [
 		{
-			id: EVC_SERVER_ID,
+			id: KNAP_SERVER_ID,
 			name: "Knap Sync",
-			controlPlaneUrl: EVC_CP_URL,
+			controlPlaneUrl: KNAP_CP_URL,
 			isValidated: false,
 		},
 	],
-	defaultServerId: EVC_SERVER_ID,
+	defaultServerId: KNAP_SERVER_ID,
 };
 
 /**
@@ -117,7 +117,7 @@ export const DEFAULT_RELAY_ONPREM_SETTINGS: RelayOnPremSettings = {
  */
 export interface MigrationResult {
 	settings: RelayOnPremSettings;
-	/** If an existing server was adopted as EVC, this is the old server ID */
+	/** If an existing server was adopted as the well-known Knap server, this is the old server ID */
 	renamedServerId?: string;
 	/** Whether any changes were made */
 	changed: boolean;
@@ -144,65 +144,65 @@ export function migrateRelayOnPremSettings(
 		let servers = orig.servers.map((s) => ({ ...s }));
 		let defaultServerId = orig.defaultServerId;
 
-		const evcByIdIdx = servers.findIndex((s) => s.id === EVC_SERVER_ID);
-		// Find the BEST EVC-URL server: prefer one with isValidated or lastValidated (has auth)
-		const evcByUrlIdxAll = servers
+		const knapByIdIdx = servers.findIndex((s) => s.id === KNAP_SERVER_ID);
+		// Find the BEST well-known-URL server: prefer one with isValidated or lastValidated (has auth)
+		const knapByUrlIdxAll = servers
 			.map((s, i) => ({ s, i }))
-			.filter(({ s }) => s.controlPlaneUrl === EVC_CP_URL && s.id !== EVC_SERVER_ID);
+			.filter(({ s }) => s.controlPlaneUrl === KNAP_CP_URL && s.id !== KNAP_SERVER_ID);
 
-		if (evcByIdIdx >= 0 && evcByUrlIdxAll.length > 0) {
-			// Dedup: EVC by id exists AND there are duplicate(s) with same URL but different id.
-			// Keep the richer duplicate (the one with auth/validation) under the EVC_SERVER_ID,
+		if (knapByIdIdx >= 0 && knapByUrlIdxAll.length > 0) {
+			// Dedup: the well-known id exists AND there are duplicate(s) with same URL but different id.
+			// Keep the richer duplicate (the one with auth/validation) under the KNAP_SERVER_ID,
 			// remove the empty stub.
-			const richest = evcByUrlIdxAll.reduce((best, cur) =>
-				(cur.s.isValidated || cur.s.lastValidated) ? cur : best, evcByUrlIdxAll[0]);
-			const evcStub = servers[evcByIdIdx];
+			const richest = knapByUrlIdxAll.reduce((best, cur) =>
+				(cur.s.isValidated || cur.s.lastValidated) ? cur : best, knapByUrlIdxAll[0]);
+			const knapStub = servers[knapByIdIdx];
 			const richServer = richest.s;
 
-			// Merge: take all fields from the rich server, set id to EVC_SERVER_ID
-			servers[evcByIdIdx] = {
+			// Merge: take all fields from the rich server, set id to KNAP_SERVER_ID
+			servers[knapByIdIdx] = {
 				...richServer,
-				id: EVC_SERVER_ID,
-				name: richServer.name || evcStub.name || "Knap Sync",
+				id: KNAP_SERVER_ID,
+				name: richServer.name || knapStub.name || "Knap Sync",
 			};
 			renamedServerId = richServer.id;
 
 			// Update defaultServerId if it pointed to the old id
 			if (defaultServerId === richServer.id) {
-				defaultServerId = EVC_SERVER_ID;
+				defaultServerId = KNAP_SERVER_ID;
 			}
 
-			// Remove all duplicate-URL entries (keep only the one we merged into evcByIdIdx)
-			const removeIds = new Set(evcByUrlIdxAll.map(({ s }) => s.id));
+			// Remove all duplicate-URL entries (keep only the one we merged into knapByIdIdx)
+			const removeIds = new Set(knapByUrlIdxAll.map(({ s }) => s.id));
 			servers = servers.filter((s) => !removeIds.has(s.id));
 			changed = true;
-		} else if (evcByIdIdx < 0) {
-			// No EVC server by id — check if there's one by URL to adopt
-			if (evcByUrlIdxAll.length > 0) {
-				const richest = evcByUrlIdxAll.reduce((best, cur) =>
-					(cur.s.isValidated || cur.s.lastValidated) ? cur : best, evcByUrlIdxAll[0]);
+		} else if (knapByIdIdx < 0) {
+			// No well-known server by id — check if there's one by URL to adopt
+			if (knapByUrlIdxAll.length > 0) {
+				const richest = knapByUrlIdxAll.reduce((best, cur) =>
+					(cur.s.isValidated || cur.s.lastValidated) ? cur : best, knapByUrlIdxAll[0]);
 				renamedServerId = richest.s.id;
-				servers[richest.i] = { ...richest.s, id: EVC_SERVER_ID };
-				if (!servers[richest.i].name || servers[richest.i].name === new URL(EVC_CP_URL).hostname) {
+				servers[richest.i] = { ...richest.s, id: KNAP_SERVER_ID };
+				if (!servers[richest.i].name || servers[richest.i].name === new URL(KNAP_CP_URL).hostname) {
 					servers[richest.i].name = "Knap Sync";
 				}
 				if (defaultServerId === renamedServerId) {
-					defaultServerId = EVC_SERVER_ID;
+					defaultServerId = KNAP_SERVER_ID;
 				}
 				// Remove other duplicates
-				if (evcByUrlIdxAll.length > 1) {
+				if (knapByUrlIdxAll.length > 1) {
 					const removeIds = new Set(
-						evcByUrlIdxAll.filter(({ i }) => i !== richest.i).map(({ s }) => s.id)
+						knapByUrlIdxAll.filter(({ i }) => i !== richest.i).map(({ s }) => s.id)
 					);
 					servers = servers.filter((s) => !removeIds.has(s.id));
 				}
 				changed = true;
 			} else {
-				// No EVC server at all — prepend it
+				// No well-known server at all — prepend it
 				servers.unshift({
-					id: EVC_SERVER_ID,
+					id: KNAP_SERVER_ID,
 					name: "Knap Sync",
-					controlPlaneUrl: EVC_CP_URL,
+					controlPlaneUrl: KNAP_CP_URL,
 					isValidated: false,
 				});
 				changed = true;
@@ -210,7 +210,7 @@ export function migrateRelayOnPremSettings(
 		}
 
 		if (!defaultServerId) {
-			defaultServerId = EVC_SERVER_ID;
+			defaultServerId = KNAP_SERVER_ID;
 			changed = true;
 		}
 

--- a/src/WebSyncManager.ts
+++ b/src/WebSyncManager.ts
@@ -513,7 +513,7 @@ export class WebSyncManager {
 			});
 			this.unregisterAutoSyncShare(filePath);
 			new Notice(
-				`Team Relay: "${filePath}" was deleted, but its web share is still ` +
+				`Knap Sync: "${filePath}" was deleted, but its web share is still ` +
 					`published. Unpublish it manually if it should no longer be public.`,
 				0,
 			);

--- a/src/components/EndpointConfigModalContent.svelte
+++ b/src/components/EndpointConfigModalContent.svelte
@@ -204,7 +204,7 @@
 
 <div class="endpoint-config-modal">
 	<div class="setting-item-description" style="margin-bottom: 16px;">
-		<p>Manage your organization's enterprise Relay tenants. Add tenants to switch between different enterprise deployments.</p>
+		<p>Manage your organization's enterprise relay tenants. Add tenants to switch between different enterprise deployments.</p>
 	</div>
 
 

--- a/src/components/IndexedDBAnalysisModalContent.svelte
+++ b/src/components/IndexedDBAnalysisModalContent.svelte
@@ -71,7 +71,7 @@
 	});
 </script>
 
-<div class="modal-title">Relay database analysis</div>
+<div class="modal-title">Knap Sync database analysis</div>
 <div class="system3-indexeddb-analysis">
 	<div class="setting-item">
 		<div class="setting-item-info">

--- a/src/components/ManageRelay.svelte
+++ b/src/components/ManageRelay.svelte
@@ -848,7 +848,7 @@
 		{:else}
 			<SettingItem
 				name={`Plan: ${$relay.plan}`}
-				description={$relay.cta || "Thanks for supporting Relay development"}
+				description={$relay.cta || "Thanks for supporting this relay"}
 			>
 				<button
 					class="mod-cta"

--- a/src/components/RelayOnPremServerList.svelte
+++ b/src/components/RelayOnPremServerList.svelte
@@ -4,7 +4,7 @@
 	import type Live from "../main";
 	import type { RelayOnPremServer } from "../RelayOnPremConfig";
 	import {
-		EVC_SERVER_ID,
+		KNAP_SERVER_ID,
 		generateServerId,
 		validateServerConfig,
 		findDuplicateServer,
@@ -585,7 +585,7 @@
 								Make default
 							</button>
 						{/if}
-						{#if server.id !== EVC_SERVER_ID}
+						{#if server.id !== KNAP_SERVER_ID}
 							<button class="knap-link-btn is-warning" on:click={() => removeServer(server.id)}>
 								Remove
 							</button>

--- a/src/components/RelayText.svelte
+++ b/src/components/RelayText.svelte
@@ -15,7 +15,7 @@
 		color: var(--text-normal);
 	}
 
-	.evc-text {
+	.knap-text {
 		font-weight: 600;
 		letter-spacing: 0.02em;
 		white-space: nowrap;

--- a/src/customFetch.ts
+++ b/src/customFetch.ts
@@ -12,7 +12,7 @@ if (window.Response === undefined || window.Headers === undefined) {
 	// https://github.com/electron/electron/pull/42419
 	try {
 		console.warn(
-			"[Relay] Polyfilling Fetch API (Electron Bug: https://github.com/electron/electron/pull/42419)",
+			"[Knap Sync] Polyfilling Fetch API (Electron Bug: https://github.com/electron/electron/pull/42419)",
 		);
 		const windowRecord = window as unknown as Record<string, unknown>;
 		if (windowRecord["blinkfetch"]) {
@@ -30,10 +30,10 @@ if (window.Response === undefined || window.Headers === undefined) {
 if ((window as unknown as Record<string, unknown>)["EventSource"] === undefined) {
 	if (Platform.isMobile) {
 		console.warn(
-			"[Relay] Polyfilling EventSource API required, but unable to polyfill on Mobile",
+			"[Knap Sync] Polyfilling EventSource API required, but unable to polyfill on Mobile",
 		);
 	} else {
-		console.warn("[Relay] Polyfilling EventSource API");
+		console.warn("[Knap Sync] Polyfilling EventSource API");
 		// eventsource v4 exports { ErrorEvent, EventSource }, so the module object
 		// is not itself a constructor. Assigning it whole left window.EventSource
 		// as a plain object and `new EventSource(...)` would have thrown.

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,7 +97,7 @@ import { EndpointManager, type EndpointSettings } from "./EndpointManager";
 import { SelfHostModal } from "./ui/SelfHostModal";
 import {
 	DEFAULT_RELAY_ONPREM_SETTINGS,
-	EVC_SERVER_ID,
+	KNAP_SERVER_ID,
 	type RelayOnPremSettings,
 	type RelayOnPremServer,
 	migrateRelayOnPremSettings,
@@ -395,10 +395,10 @@ export default class Live extends Plugin {
 		);
 		this.notifier = new ObsidianNotifier();
 
-		this.debug = curryLog("[System 3][Relay]", "debug");
-		this.log = curryLog("[System 3][Relay]", "log");
-		this.warn = curryLog("[System 3][Relay]", "warn");
-		this.error = curryLog("[System 3][Relay]", "error");
+		this.debug = curryLog("[Knap Sync]", "debug");
+		this.log = curryLog("[Knap Sync]", "log");
+		this.warn = curryLog("[Knap Sync]", "warn");
+		this.error = curryLog("[Knap Sync]", "error");
 
 		this.settings = new Settings<RelaySettings>(this, DEFAULT_SETTINGS);
 		await this.settings.load();
@@ -412,7 +412,8 @@ export default class Live extends Plugin {
 				relayOnPrem: migration.settings,
 			}));
 		}
-		// If an existing server was adopted as EVC, migrate its localStorage auth key
+		// If an existing server was adopted as the well-known Knap server, migrate
+		// its localStorage auth key
 		// and update all shared folder settings that reference the old server ID
 		if (migration.renamedServerId) {
 			const oldId = migration.renamedServerId;
@@ -420,7 +421,7 @@ export default class Live extends Plugin {
 			// keyed by appId (stable across vault renames), not vault display name.
 			const prefix = "knap-sync_onprem_auth_";
 			const oldKey = `${prefix}${this.appId}_${oldId}`;
-			const newKey = `${prefix}${this.appId}_${EVC_SERVER_ID}`;
+			const newKey = `${prefix}${this.appId}_${KNAP_SERVER_ID}`;
 			try {
 				const oldData = window.localStorage.getItem(oldKey);
 				if (oldData && !window.localStorage.getItem(newKey)) {
@@ -438,7 +439,7 @@ export default class Live extends Plugin {
 				const updated = folders.map((f) => {
 					if (f.onpremServerId === oldId) {
 						folderChanged = true;
-						return { ...f, onpremServerId: EVC_SERVER_ID };
+						return { ...f, onpremServerId: KNAP_SERVER_ID };
 					}
 					return f;
 				});
@@ -535,7 +536,7 @@ export default class Live extends Plugin {
 
 		this.addCommand({
 			id: "reload",
-			name: "Reload relay",
+			name: "Reload plugin",
 			callback: async () => await (this.app as unknown as ObsidianApp).reloadRelay?.(),
 		});
 
@@ -868,7 +869,7 @@ export default class Live extends Plugin {
 							) {
 								menu.addItem((item) => {
 									item
-										.setTitle("Relay: share folder")
+										.setTitle("Knap Sync: share folder")
 										.setIcon("share-2")
 										.onClick(() => {
 											const modal = new QuickShareModal(this.app, this, file.path);
@@ -881,7 +882,7 @@ export default class Live extends Plugin {
 						if (folder.relayId) {
 							menu.addItem((item) => {
 								item
-									.setTitle("Relay: relay settings")
+									.setTitle("Knap Sync: relay settings")
 									.setIcon("gear")
 									.onClick(() => {
 										void this.openSettings(`/relays?id=${folder.relayId}`);
@@ -889,7 +890,7 @@ export default class Live extends Plugin {
 							});
 							menu.addItem((item) => {
 								item
-									.setTitle("Relay: share settings")
+									.setTitle("Knap Sync: share settings")
 									.setIcon("settings")
 									.onClick(() => {
 										if (folder.settings?.onpremServerId && this.loginManager.isRelayOnPremMode()) {
@@ -902,7 +903,7 @@ export default class Live extends Plugin {
 							menu.addItem((item) => {
 								item
 									.setTitle(
-										folder.connected ? "Relay: disconnect" : "Relay: connect",
+										folder.connected ? "Knap Sync: disconnect" : "Knap Sync: connect",
 									)
 									.setIcon("satellite")
 									.onClick(() => {
@@ -919,7 +920,7 @@ export default class Live extends Plugin {
 						} else {
 							menu.addItem((item) => {
 								item
-									.setTitle("Relay: share settings")
+									.setTitle("Knap Sync: share settings")
 									.setIcon("settings")
 									.onClick(() => {
 										if (folder.settings?.onpremServerId && this.loginManager.isRelayOnPremMode()) {
@@ -933,7 +934,7 @@ export default class Live extends Plugin {
 							if (folder.settings?.onpremServerId && this.loginManager.isRelayOnPremMode()) {
 								menu.addItem((item) => {
 									item
-										.setTitle("Relay: unshare folder")
+										.setTitle("Knap Sync: unshare folder")
 										.setIcon("folder-x")
 										.onClick(async () => {
 											const confirmed = await confirmDialog(
@@ -966,7 +967,7 @@ export default class Live extends Plugin {
 						if (folder.relayId && folder.connected) {
 							menu.addItem((item) => {
 								item
-									.setTitle("Relay: sync")
+									.setTitle("Knap Sync: sync")
 									.setIcon("folder-sync")
 									.onClick(async () => {
 										void folder.netSync();
@@ -995,7 +996,7 @@ export default class Live extends Plugin {
 						if (ifile && isSyncFile(ifile)) {
 							menu.addItem((item) => {
 								item
-									.setTitle("Relay: download")
+									.setTitle("Knap Sync: download")
 									.setIcon("cloud-download")
 									.onClick(async () => {
 										await ifile.pull();
@@ -1005,7 +1006,7 @@ export default class Live extends Plugin {
 							if (this.debugSettings.get().debugging) {
 								menu.addItem((item) => {
 									item
-										.setTitle("Relay: verify upload")
+										.setTitle("Knap Sync: verify upload")
 										.setIcon("search-check")
 										.onClick(async () => {
 											const present = await ifile.verifyUpload();
@@ -1017,7 +1018,7 @@ export default class Live extends Plugin {
 							}
 							menu.addItem((item) => {
 								item
-									.setTitle("Relay: upload")
+									.setTitle("Knap Sync: upload")
 									.setIcon("cloud-upload")
 									.onClick(async () => {
 										await ifile.push(true);
@@ -1720,7 +1721,7 @@ export default class Live extends Plugin {
 			}),
 		);
 
-		const vaultLog = curryLog("[System 3][Relay][Vault]", "log");
+		const vaultLog = curryLog("[Knap Sync][Vault]", "log");
 
 		const handlePromiseRejection = (event: PromiseRejectionEvent): void => {
 			//event.preventDefault();

--- a/src/ui/RelayOnPremLoginModal.ts
+++ b/src/ui/RelayOnPremLoginModal.ts
@@ -1,7 +1,7 @@
 /**
- * Relay On-Premise Login Modal
+ * Knap Sync login modal
  *
- * Modal dialog for email/password authentication with relay-onprem control plane
+ * Modal dialog for email/password authentication with a relay-onprem control plane
  * Supports multi-server mode with optional serverId parameter
  */
 
@@ -25,7 +25,7 @@ export class RelayOnPremLoginModal extends Modal {
 		private shareClient?: RelayOnPremShareClient,
 	) {
 		super(app);
-		this.setTitle("Relay on-premise login");
+		this.setTitle("Knap Sync sign-in");
 	}
 
 	onOpen() {
@@ -188,7 +188,7 @@ export class RelayOnPremLoginModal extends Modal {
 			} else {
 				await this.loginManager.loginWithEmailAndPassword(email, password);
 			}
-			new Notice("Successfully logged in to relay-onprem!");
+			new Notice("Signed in");
 			this.close();
 			this.onSuccess();
 		} catch (error: unknown) {

--- a/src/ui/ShareManagementModal.ts
+++ b/src/ui/ShareManagementModal.ts
@@ -42,9 +42,9 @@ export class ShareManagementModal extends Modal {
 		this.initialShareId = initialShareId;
 
 		if (serverName) {
-			this.setTitle(`Shares — ${serverName}`);
+			this.setTitle(`Shares on ${serverName}`);
 		} else {
-			this.setTitle("Relay on-premise shares");
+			this.setTitle("Knap Sync shares");
 		}
 	}
 


### PR DESCRIPTION
## Summary

The plugin half of pantalytics/knap-mcp-admin#62. The manifest, package.json and README were already ours; the screens were not.

Renamed on screen: the ten file explorer context menu items (`Relay: share folder` and friends become `Knap Sync: ...`), three modal titles, the two notices that opened with `Team Relay:`, the sign-in notice that said `Successfully logged in to relay-onprem!`, and the `Reload relay` command (it reloads the plugin, and Obsidian already prefixes commands with the plugin name). `Enterprise Relay tenant` loses its capital R, since a relay is the thing you connect to here rather than a product. The billing fallback thanked you for supporting *Relay* development, which is upstream's business and not ours.

Console log prefixes `[System 3][Relay]` and `[Relay]` become `[Knap Sync]`. Nothing parses them.

Internal, for clarity rather than for the screen: the `window.evcTeamRelayPatches` debug global, the `EVC_SERVER_ID` / `EVC_CP_URL` constant *names* (values untouched), a dead `.evc-text` CSS rule in `RelayText.svelte` that an earlier half of the rename had left pointing at nothing, and two CI artifact names.

Deliberately left alone, spelled out in the commit message: the `knap-sync` server id (it is written into `data.json`, every shared folder's `onpremServerId` and the localStorage auth key, so changing it signs people out and detaches their shares), the `Relay-Version` HTTP header, the `RelayDiskBuffer` IndexedDB name, the `relay` resource type in S3RN, the `Relay Free` plan value the server sends, the `evc-` CSS prefix in `styles.css` (never on screen, and vault snippets are written against class names), the `relay-onprem` mode and `RelayOnPrem*` class names, and the EVC Team Relay attribution in NOTICE, LICENSE and README, which MIT requires.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [x] Documentation

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (0 errors, 5 pre-existing warnings)
- [ ] Tested in Obsidian (no Obsidian available in this environment; `tsc --noEmit` is clean and all 441 tests across 34 suites pass)
- [x] Changes are minimal and focused

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN8b8PBx6PCPa2xLCHoR6n)_