### PR TITLE
A called release checks out the branch, not a tag that does not exist yet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,18 @@ jobs:
       # A dispatch names an existing tag and checks that out. A call comes from
       # a run on the default branch, where the tag does not exist yet, so the
       # caller's ref is what holds the bump.
+      #
+      # The test is github.event.inputs, not github.event_name. Inside a called
+      # workflow, event_name is the CALLER's event: bump.yml is dispatched, so
+      # the condition below used to read workflow_dispatch, take the tag branch,
+      # and try to check out a tag this file has not created yet. Measured on
+      # 2026-08-11, run 31493430213: "fetch ... +refs/heads/1.3.0*" against a
+      # repository with no such ref, three times, then failure. github.event is
+      # the original event payload, so .inputs.version is set only when THIS
+      # workflow was the one dispatched.
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref }}
+          ref: ${{ github.event.inputs.version || github.ref }}
       - uses: actions/setup-node@v7
         with:
           node-version: '20'


### PR DESCRIPTION
## Summary

Cutting 1.3.0 through `bump.yml` got halfway. It bumped the four version files, pushed them to the default branch, called `release.yml`, and failed there: [run 31493430213](https://github.com/pantalytics/knap-obsidian/actions/runs/31493430213) tried `fetch ... +refs/heads/1.3.0* +refs/tags/1.3.0*` against a repository with no such ref, retried three times, and died. So **1.3.0 is committed on the default branch with no release behind it**, which is the one half-state this pipeline exists to avoid.

The condition on the checkout read `github.event_name`, and inside a called workflow that is the **caller's** event. `bump.yml` is dispatched, so `release.yml` saw `workflow_dispatch`, took the branch written for "a dispatch names an existing tag", and went looking for a tag it creates itself forty seconds later in `gh release create --target`.

`github.event` is the original payload rather than the resolved one, so `github.event.inputs.version` is set only when this file was the thing dispatched. Four ways in, and each now lands where the comment above it always said it should:

| Route | `github.event.inputs` | Checks out |
|---|---|---|
| tag push | absent | `github.ref`, the tag |
| dispatch of `release.yml` | `.version` set | that tag |
| call from `bump.yml` | bump's own inputs (`level`) | `github.ref`, the branch |
| call from `cd.yml` | push event, none | `github.ref`, the branch |

## Type of Change

- [x] Bug fix

## Checklist

- [ ] `npm run build` succeeds
- [ ] `npm run lint` passes
- [ ] Tested in Obsidian
- [x] Changes are minimal and focused

Build, lint and Obsidian are unticked deliberately: this is one expression in a workflow file and none of them exercise it. The YAML parses, and the four routes above are traced from the GitHub Actions context rather than run, because the only way to actually run the broken one was the failed run linked above.

## What this does not fix

**1.3.0 itself.** Once this is merged, the next bump releases normally. 1.3.0 needs a tag push, which is the one route that never goes through this condition:

```
git tag 1.3.0 a6531aa && git push origin 1.3.0
```

I could not do that from here: tag pushes through this session's proxy die with `send-pack: unexpected disconnect`, while branch pushes go through fine. The alternative, if you would rather not push a tag by hand, is to run **Bump version and release** again with `patch` after merging this. That cuts 1.3.1 and leaves 1.3.0 as a version in `versions.json` that never became a release, which is untidy but harmless: BRAT reads the version out of `manifest-beta.json` and fetches the release with that tag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMvFEqSRLwdtpFTQTJNLWF)_