### PR TITLE
The share says which vault it belongs to

### DIFF
--- a/__tests__/knapMeta.test.ts
+++ b/__tests__/knapMeta.test.ts
@@ -1,0 +1,66 @@
+import * as Y from "yjs";
+import { KNAP_META_KEY, readKnapMeta, stampKnapMeta } from "../src/knapMeta";
+
+describe("what a share says about itself", () => {
+	test("a vault share says so, and says what the vault is called", () => {
+		const doc = new Y.Doc();
+		expect(stampKnapMeta(doc, { scope: "vault", vault: "Pantalytics" })).toBe(true);
+
+		expect(readKnapMeta(doc)).toEqual({ scope: "vault", vault: "Pantalytics" });
+	});
+
+	test("a folder share says that instead", () => {
+		const doc = new Y.Doc();
+		stampKnapMeta(doc, { scope: "folder", vault: "Pantalytics" });
+
+		expect(readKnapMeta(doc)?.scope).toBe("folder");
+	});
+
+	test("it lives in a map of its own and leaves the file lists alone", () => {
+		// The document is upstream's and carries the folder's contents. Ours is
+		// one key beside them, which is what makes it safe to write into a
+		// structure we did not design.
+		const doc = new Y.Doc();
+		doc.getMap<string>("docs").set("Note.md", "doc-1");
+		stampKnapMeta(doc, { scope: "vault", vault: "Pantalytics" });
+
+		expect(doc.getMap<string>("docs").get("Note.md")).toBe("doc-1");
+		expect(doc.getMap("filemeta_v0").size).toBe(0);
+		expect(doc.getMap(KNAP_META_KEY).size).toBe(2);
+	});
+
+	test("writing the same thing twice is not a write", () => {
+		// It runs on every connect rather than once at creation, because a share
+		// made by an older build carries no key and a renamed vault carries a
+		// stale one. Without this every device would broadcast an update on
+		// every start.
+		const doc = new Y.Doc();
+		stampKnapMeta(doc, { scope: "vault", vault: "Pantalytics" });
+
+		let updates = 0;
+		doc.on("update", () => {
+			updates += 1;
+		});
+		expect(stampKnapMeta(doc, { scope: "vault", vault: "Pantalytics" })).toBe(false);
+		expect(updates).toBe(0);
+	});
+
+	test("a renamed vault is written through", () => {
+		const doc = new Y.Doc();
+		stampKnapMeta(doc, { scope: "vault", vault: "Old name" });
+
+		expect(stampKnapMeta(doc, { scope: "vault", vault: "Pantalytics" })).toBe(true);
+		expect(readKnapMeta(doc)?.vault).toBe("Pantalytics");
+	});
+
+	test("surrounding whitespace never reaches the panel", () => {
+		const doc = new Y.Doc();
+		stampKnapMeta(doc, { scope: "vault", vault: "  Pantalytics  " });
+
+		expect(readKnapMeta(doc)?.vault).toBe("Pantalytics");
+	});
+
+	test("a document nobody stamped answers nothing rather than guessing", () => {
+		expect(readKnapMeta(new Y.Doc())).toBeNull();
+	});
+});

--- a/src/SharedFolder.ts
+++ b/src/SharedFolder.ts
@@ -64,6 +64,7 @@ import {
 	type ShareScope,
 } from "./vaultScope";
 import { claimVpathIfUnclaimed, awaitVpathClaimSettled, wonVpathClaim } from "./uploadClaim";
+import { stampKnapMeta } from "./knapMeta";
 
 export interface SharedFolderSettings {
 	guid: string;
@@ -339,6 +340,19 @@ export class SharedFolder extends HasProvider {
 
 		void this.whenSynced().then(() => {
 			this.syncStore.start();
+			// Say what this share is, so Knap's page can call the row by the
+			// vault's name instead of a hostname. After the sync rather than in
+			// the constructor: the check against what is already there is only
+			// meaningful once the remote document has arrived, and it is what
+			// keeps this from being an update on every start.
+			try {
+				stampKnapMeta(this.ydoc, {
+					scope: this.scope,
+					vault: this.vault.getName(),
+				});
+			} catch (e) {
+				this.warn("could not stamp share identity", e);
+			}
 			try {
 				void this._persistence.set("path", this.path);
 				void this._persistence.set("relay", this.relayId || "");

--- a/src/knapMeta.ts
+++ b/src/knapMeta.ts
@@ -1,0 +1,69 @@
+"use strict";
+
+import * as Y from "yjs";
+import type { ShareScope } from "./vaultScope";
+
+/**
+ * The one key in a shared folder's document that is ours.
+ *
+ * Knap's web page draws a vault, not a machine, and it has nowhere else to
+ * learn a vault's name from. The control plane keeps `id`, `kind`, `path`,
+ * `visibility` and the web-publishing fields for a share and nothing more
+ * (`RelayOnPremShareClient.ts`), and `path` is the vault's name on a
+ * whole-vault share and a folder's name on a folder share, with nothing in the
+ * record telling the two apart. Guessing from the shape of the paths inside
+ * would be a guess, so the side that knows says so instead.
+ *
+ * The folder document is the channel because both sides already hold it open:
+ * Knap's replica reparses it on every event, so reading this costs no request
+ * and no token, and upstream neither reads nor writes the key.
+ *
+ * Versioned in its own name, the way `filemeta_v0` is, and namespaced because
+ * it lives in a document upstream also writes.
+ */
+export const KNAP_META_KEY = "knap_v0";
+
+/** What we put there. Both fields are plain strings and both are optional. */
+export interface KnapMeta {
+	/** Which of the two shapes this share is (`vaultScope.ts`). */
+	scope: ShareScope;
+	/** The vault's name in Obsidian, the word the person calls it by. */
+	vault: string;
+}
+
+/**
+ * Write the share's identity into its folder document, if it has changed.
+ *
+ * Idempotent on purpose, and called on every connect rather than once at
+ * creation: a share made by an older build carries no key at all, and a vault
+ * renamed in Obsidian carries a stale one. Comparing before writing is what
+ * keeps that from being an update every device broadcasts on every start.
+ *
+ * A CRDT map takes the last write, so two devices disagreeing about the vault
+ * name settle on whichever wrote last rather than fighting. They only disagree
+ * when the same vault is called two things on two machines, which is a thing
+ * the person did and not a conflict to resolve.
+ */
+export function stampKnapMeta(ydoc: Y.Doc, meta: KnapMeta): boolean {
+	const map = ydoc.getMap<string>(KNAP_META_KEY);
+	const vault = meta.vault.trim();
+	if (map.get("scope") === meta.scope && map.get("vault") === vault) {
+		return false;
+	}
+	ydoc.transact(() => {
+		map.set("scope", meta.scope);
+		map.set("vault", vault);
+	});
+	return true;
+}
+
+/** What the document says, for tests and for anything that wants to read back. */
+export function readKnapMeta(ydoc: Y.Doc): KnapMeta | null {
+	const map = ydoc.getMap<string>(KNAP_META_KEY);
+	const scope = map.get("scope");
+	const vault = map.get("vault");
+	if (scope !== "vault" && scope !== "folder") {
+		return null;
+	}
+	return { scope, vault: typeof vault === "string" ? vault : "" };
+}


### PR DESCRIPTION
## Summary

Knap's web page draws a vault and had nothing to call it, so it drew the hostname instead. The name exists in Obsidian and nowhere else: a share on the control plane carries `id`, `kind`, `path`, `visibility` and the web-publishing fields, and `path` is the vault's name on a whole-vault share and a folder's name on a folder share, with nothing to tell the two apart.

So the side that knows says so. Every shared folder's document gets one map of ours:

```
knap_v0    {"scope": "vault" | "folder", "vault": "<the vault's name>"}
```

- `src/knapMeta.ts` — the key, the shape, and a stamp that compares before it writes.
- `src/SharedFolder.ts` — stamps after `whenSynced`, so the comparison runs against what the remote actually holds.

The folder document is the channel because both sides already hold it open: Knap's replica reparses it on every event, so reading this costs no request against the control plane's 30-a-minute budget and no token. Upstream neither reads nor writes the key, and it sits beside `docs` and `filemeta_v0` rather than inside either.

Stamped on every connect rather than once at creation, because a share made by an older build carries nothing and a renamed vault carries something stale. Comparing first is what keeps that from being an update every device broadcasts on every start.

The reading half is `pantalytics/knap-mcp-admin`, where it is recorded as ADR-0036. Both sides treat the key as optional, so a plugin that is behind means a row without a name rather than a row that is broken.

## Type of Change

- [x] New feature

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (5 pre-existing warnings, no errors)
- [x] `npx jest` passes: 516 tests, 7 of them new in `__tests__/knapMeta.test.ts`
- [x] `npx tsc -noEmit` clean
- [ ] Tested in Obsidian — not run in this session. The write path is covered by unit tests against a real `Y.Doc`; the round trip through the relay is not.
- [x] Changes are minimal and focused

---
_Generated by [Claude Code](https://claude.ai/code/session_014gkqsjo7B5nkYninztWr92)_