### PR TITLE
The removal of Who can read this gets a release it is actually in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Changelog
 
-## 1.6.0
+## 1.7.0
+The three entries below were written under 1.6.0 and never shipped in it. The
+1.6.0 release was cut at 07:51 UTC on 2026-08-12 and the pull request holding
+them merged at 07:52, so the build people installed still had the settings
+screen 1.6.0 said it had removed. They are here instead, against a version that
+contains them.
+
 - The settings screen is the account row and nothing else. **Who can read this**, the share list behind it and the three screens under that (a share's detail, invite somebody, agent keys) all came off. The list was a list of one now that a vault is one share, and the row it held repeated the row above it. Worth knowing before you go looking: this is also the last route to a vault's members, invites and agent keys, so there is currently no way to invite somebody to a vault from inside Obsidian. Bringing that back is a screen about people rather than a list of shares.
 - The status bar mark carries the state. Green when the vault is up to date, the accent colour while notes are moving, grey when the share is disconnected and red when nobody is signed in, with the word itself in the tooltip. It reads the same four words the settings screen does, off the same list, so the corner of the window and the settings tab cannot describe one vault two ways.
 - The status bar menu is two actions and Settings. **Sync all shares** is **Sync vault** and **Sync current file** is **Sync this file**, because the vault is what syncs and a share is not a word anybody here has met. **Manage shares** is gone: it opened a list of one thing, on a plugin where a vault is one share.
+
+## 1.6.0
 - Sync scope: a vault is one share, and picking folders is gone. The **Sync individual folders** setting added in 1.4.0, the *Synced Vaults: sync this folder* and *stop syncing this folder* items on the file explorer's context menu, the *Add a folder* button and `CreateShareView` all came out, along with the per-server `syncMode` they were stored behind. Signing in syncs the whole vault and that is the only shape there is (ADR-0042). The either/or the toggle managed was the reason the screens needed two levels and the reason two halves could disagree about what was shared; neither is a thing that can happen now.
 - Sync scope: a vault that already syncs folders is offered one button, *Sync the whole vault*, because whole-vault and folder shares are exclusive in both directions and the folders have to come off before the vault share can be made. It asks first, since deleting a share deletes its documents and a folder somebody else is a member of takes their copy too. The removals go to the server first and the local record second, so a refusal stops the run with the two halves still agreeing.
 - Sync scope: adopting a share no longer asks for a folder either. *Sync this vault here*, on the member screen and in the share modal, attaches at the vault root with the vault scope, the same way signing in does. It used to open a folder picker and make a folder-scope record for a share the rest of the plugin treats as a whole vault, which is the disagreement one share per vault exists to end. `ShareManagementModal`'s `createShare` and `createLocalSharedFolder` went with the form that was their only caller. Every folder picker left in the fork hangs off `Relays.svelte`, `ManageRelay.svelte`, `ManageRemoteFolder.svelte` and `ManageSharedFolder.svelte`, which never render here.


### PR DESCRIPTION
## Summary

**Who can read this** came off the settings screen in #33 and is off on `knap/fork-base`. It is still on screen for anybody running the plugin, because the 1.6.0 release was cut 104 seconds before #33 merged:

| | |
|---|---|
| 1.6.0 published | 2026-08-12 07:51:06 UTC |
| `6c5359b` (#33), the removal | 2026-08-12 07:52:50 UTC |

So the 1.6.0 build has the button and the 1.6.0 release notes say it does not. This was found from a screenshot of the button, taken on a vault running the current release, which is the slowest possible way to find out.

No code changes here. Three changelog entries move from 1.6.0 to a new 1.7.0 heading, so each version claims what its build contains:

- the settings screen is the account row (this is the one with the button)
- the status bar mark carries the state
- the status bar menu is two actions and Settings

The four **Sync scope** and folder-delete entries stay under 1.6.0, since those did ship in it.

**Merging this changes nothing on anybody's device.** Cutting the release does: run `bump.yml` with level `minor` afterwards, which writes 1.7.0 into the four version files and publishes a release carrying the build without the button.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation

## Checklist

- [ ] `npm run build` succeeds (not run: no source changed, and this checkout has no `node_modules`)
- [ ] `npm run lint` passes (not run, same reason)
- [ ] Tested in Obsidian (not applicable: CHANGELOG.md only)
- [x] Changes are minimal and focused

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZJAHYddUJqrmven1BsySX)_