### PR TITLE
A green pull request merges itself

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,10 @@
 #     draft switches auto-merge off again.
 #   - A pull request from a fork. Its checks run code the fork wrote, so a green
 #     run says nothing about whether it should land.
-#   - Anything at all, while AUTOMERGE_TOKEN is missing.
+#   - Anything at all, while AUTOMERGE_TOKEN is missing. That one warns and
+#     stops rather than failing the job: without the token nothing merges, which
+#     is the safe direction, and failing would put a red check on every pull
+#     request in the repository for a setting somebody has not got to yet.
 #
 # AUTOMERGE_TOKEN is a fine-grained personal access token scoped to this
 # repository alone, with Contents: read and write and Pull requests: read and
@@ -81,15 +84,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: The token has to be ours
+        id: token
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::AUTOMERGE_TOKEN is not set. Add a fine-grained PAT with Contents and Pull requests write, scoped to this repository. Merging with the runner's GITHUB_TOKEN would land a version bump that cd.yml never sees."
-            exit 1
+            echo "::warning::AUTOMERGE_TOKEN is not set, so nothing merges itself. Add a fine-grained PAT with Contents and Pull requests write, scoped to this repository. The runner's GITHUB_TOKEN is not a substitute: a merge made with it would land a version bump that cd.yml never sees."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Switch auto-merge on, or off for a draft
+        if: steps.token.outputs.ready == 'true'
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,123 @@
+# A pull request that goes green merges itself.
+#
+# Nothing here decides what green means. GitHub's own auto-merge does the
+# waiting, and the branch ruleset on `knap/fork-base` names the check it waits
+# for. One list, in one place: a job added to ci.yml is not waited for until
+# somebody adds it to the ruleset on purpose.
+#
+# `knap/fork-base`, not `main`. It is the default branch, for the reason ci.yml
+# already gives at its own push trigger.
+#
+# ── A merge can publish a release, and only one kind can ────────────────────
+# cd.yml watches this branch for a change to manifest.json and cuts the release
+# itself. So a merged pull request that bumps the version publishes it, with
+# nobody in the loop, and every other merge publishes nothing. That was already
+# true of a merge somebody tapped; what changes is that the tap moves earlier,
+# to Ready for review. bump.yml is untouched and is still the way to cut a
+# release without a pull request at all.
+#
+# Three things are never merged:
+#
+#   - A draft. An agent opens its pull request as a draft, so draft is the hold
+#     and Ready for review is the act that means ship it. Converting one back to
+#     draft switches auto-merge off again.
+#   - A pull request from a fork. Its checks run code the fork wrote, so a green
+#     run says nothing about whether it should land.
+#   - Anything at all, while AUTOMERGE_TOKEN is missing.
+#
+# AUTOMERGE_TOKEN is a fine-grained personal access token scoped to this
+# repository alone, with Contents: read and write and Pull requests: read and
+# write. Nothing else. The runner's own GITHUB_TOKEN is deliberately not used,
+# and this repository is where we learned why: a push made with it starts no
+# workflow run, which is the trap bump.yml and cd.yml both carry a comment
+# about. A merge made with GITHUB_TOKEN would land a version bump that cd.yml
+# never sees, and the release would silently not happen.
+#
+# ── What has to be switched on before this does anything ────────────────────
+# 1. Settings -> General -> Pull Requests -> Allow auto-merge.
+# 2. A ruleset on `knap/fork-base` with the CI gate required. Without one, a
+#    pull request is mergeable the moment it is opened, there is nothing to wait
+#    for, and `gh pr merge --auto` refuses with "Pull request is in clean
+#    status". Settings -> Rules -> New branch ruleset, or:
+#
+#      gh api --method POST repos/pantalytics/knap-obsidian/rulesets \
+#        -f name='knap/fork-base' -f target='branch' -f enforcement='active' \
+#        -F 'conditions[ref_name][include][]=refs/heads/knap/fork-base' \
+#        -f 'rules[][type]=required_status_checks' \
+#        -F 'rules[][parameters][strict_required_status_checks_policy]=false' \
+#        -f 'rules[][parameters][required_status_checks][][context]=CI gate'
+#
+#    One check, not five, and that is ci.yml's own design rather than a
+#    shortcut: every other job there carries continue-on-error so that one red
+#    job does not hide the others, and ci-gate is the single check that fails
+#    the run. Requiring the others would be requiring jobs that report green by
+#    construction. It does mean the CI_MODE=REPORT escape hatch now also lets a
+#    pull request merge, so it stays what its own comment says it is, a bad day
+#    rather than the normal state.
+#
+#    A ruleset with no bypass actor also stops a direct push to the branch; add
+#    Repository admin as a bypass in the UI if that is not wanted. bump.yml
+#    pushes the version commit straight to this branch, so it needs that bypass
+#    or it stops working.
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize, converted_to_draft]
+
+# Nothing here reads the repository. The work is two API calls, made with a
+# token that is not the runner's, so the runner's needs no reach at all.
+permissions: {}
+
+concurrency:
+  group: automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    # A fork's pull request is handed no secrets, so without this it would fail
+    # on the token check below and paint every fork contribution red.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: The token has to be ours
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::AUTOMERGE_TOKEN is not set. Add a fine-grained PAT with Contents and Pull requests write, scoped to this repository. Merging with the runner's GITHUB_TOKEN would land a version bump that cd.yml never sees."
+            exit 1
+          fi
+
+      - name: Switch auto-merge on, or off for a draft
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          set -euo pipefail
+
+          on=$(gh pr view "$PR" --repo "$REPO" \
+                 --json autoMergeRequest --jq '.autoMergeRequest != null')
+
+          if [ "$DRAFT" = "true" ]; then
+            if [ "$on" = "true" ]; then
+              gh pr merge "$PR" --repo "$REPO" --disable-auto
+              echo "Draft. Auto-merge switched off."
+            else
+              echo "Draft. Nothing to do until it is marked ready for review."
+            fi
+            exit 0
+          fi
+
+          if [ "$on" = "true" ]; then
+            echo "Auto-merge is already on, and a push does not turn it off."
+            exit 0
+          fi
+
+          # Squash: every commit on the default branch is one pull request, and
+          # the history says so. A failure here is usually one of the two
+          # settings in the header, and the message gh prints names which.
+          gh pr merge "$PR" --repo "$REPO" --auto --squash
+          echo "Auto-merge on. This merges itself once the required checks pass."

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,130 +1,167 @@
 # A pull request that goes green merges itself.
 #
-# Nothing here decides what green means. GitHub's own auto-merge does the
-# waiting, and the branch ruleset on `knap/fork-base` names the check it waits
-# for. One list, in one place: a job added to ci.yml is not waited for until
-# somebody adds it to the ruleset on purpose.
+# ── Why this does the waiting itself ────────────────────────────────────────
+# GitHub has a feature for exactly this, and we cannot have it. Auto-merge and
+# rulesets are GitHub Team and Enterprise on an organisation's private
+# repositories, and Allow auto-merge is greyed out in this repository's
+# settings. Their own rulesets page is explicit: "A ruleset is a named list of
+# rules that applies to a repository or to multiple repositories in an
+# organisation for customers on GitHub Team and GitHub Enterprise plans."
 #
-# `knap/fork-base`, not `main`. It is the default branch, for the reason ci.yml
-# already gives at its own push trigger.
+# So there is no required-check list to lean on, and this file has to decide
+# what green means. It decides the only way that does not drift: **every check
+# on the commit, whatever it is called.** Not a list somebody has to remember to
+# update. A job added to ci.yml is waited for the day it is added.
 #
-# ── A merge can publish a release, and only one kind can ────────────────────
+# Every refusal below ends in "do not merge", so the direction of any mistake is
+# a pull request that sits there rather than one that ships.
+#
+#   - Nothing has reported yet, or something is still running.
+#   - Anything concluded other than success, skipped or neutral.
+#   - Nothing reported at all. A commit with no checks is not a green commit.
+#   - The pull request is a draft. An agent opens its pull request as a draft,
+#     so draft is the hold and Ready for review is the act that means ship it.
+#   - The head is a fork's branch. Its checks ran code the fork wrote.
+#
+# One thing to know about `ci.yml` here: every job but manifest-check carries
+# continue-on-error, so a red one still reports green to the API, and `CI gate`
+# is the single check that fails the run. "Every check" therefore comes down to
+# that gate in practice, and the CI_MODE=REPORT escape hatch now also lets a
+# pull request merge. It stays what its own comment says it is: a bad day, not
+# the normal state.
+#
+# ── A merge can publish a release, and only one kind can ───────────────────
 # cd.yml watches this branch for a change to manifest.json and cuts the release
 # itself. So a merged pull request that bumps the version publishes it, with
-# nobody in the loop, and every other merge publishes nothing. That was already
-# true of a merge somebody tapped; what changes is that the tap moves earlier,
-# to Ready for review. bump.yml is untouched and is still the way to cut a
-# release without a pull request at all.
+# nobody in the loop, and every other merge publishes nothing. bump.yml is
+# untouched and is still the way to cut a release without a pull request at all.
 #
-# Three things are never merged:
+# That is also why the token is AUTOMERGE_TOKEN, a fine-grained personal access
+# token scoped to this repository with Contents and Pull requests write, rather
+# than the runner's GITHUB_TOKEN. This repository is where we learned that a
+# push made with GITHUB_TOKEN starts no workflow run, and bump.yml and cd.yml
+# both carry the comment. A merge made with it would land a version bump that
+# cd.yml never sees, and the release would silently not happen.
 #
-#   - A draft. An agent opens its pull request as a draft, so draft is the hold
-#     and Ready for review is the act that means ship it. Converting one back to
-#     draft switches auto-merge off again.
-#   - A pull request from a fork. Its checks run code the fork wrote, so a green
-#     run says nothing about whether it should land.
-#   - Anything at all, while AUTOMERGE_TOKEN is missing. That one warns and
-#     stops rather than failing the job: without the token nothing merges, which
-#     is the safe direction, and failing would put a red check on every pull
-#     request in the repository for a setting somebody has not got to yet.
+# ── The one list that does need maintaining ─────────────────────────────────
+# `workflows:` below is what wakes this file up, not what it waits for. Add a
+# workflow that runs on pull requests and it should go in the list, or the last
+# check to finish may be one that wakes nobody and the pull request waits
+# forever. Getting it wrong cannot merge something early; it can only fail to
+# merge at all.
 #
-# AUTOMERGE_TOKEN is a fine-grained personal access token scoped to this
-# repository alone, with Contents: read and write and Pull requests: read and
-# write. Nothing else. The runner's own GITHUB_TOKEN is deliberately not used,
-# and this repository is where we learned why: a push made with it starts no
-# workflow run, which is the trap bump.yml and cd.yml both carry a comment
-# about. A merge made with GITHUB_TOKEN would land a version bump that cd.yml
-# never sees, and the release would silently not happen.
+# workflow_run also only ever runs the copy of this file on the default branch,
+# so this does nothing until it is merged, including on its own pull request.
 #
-# ── What has to be switched on before this does anything ────────────────────
-# 1. Settings -> General -> Pull Requests -> Allow auto-merge.
-# 2. A ruleset on `knap/fork-base` with the CI gate required. Without one, a
-#    pull request is mergeable the moment it is opened, there is nothing to wait
-#    for, and `gh pr merge --auto` refuses with "Pull request is in clean
-#    status". Settings -> Rules -> New branch ruleset, or:
-#
-#      gh api --method POST repos/pantalytics/knap-obsidian/rulesets \
-#        -f name='knap/fork-base' -f target='branch' -f enforcement='active' \
-#        -F 'conditions[ref_name][include][]=refs/heads/knap/fork-base' \
-#        -f 'rules[][type]=required_status_checks' \
-#        -F 'rules[][parameters][strict_required_status_checks_policy]=false' \
-#        -f 'rules[][parameters][required_status_checks][][context]=CI gate'
-#
-#    One check, not five, and that is ci.yml's own design rather than a
-#    shortcut: every other job there carries continue-on-error so that one red
-#    job does not hide the others, and ci-gate is the single check that fails
-#    the run. Requiring the others would be requiring jobs that report green by
-#    construction. It does mean the CI_MODE=REPORT escape hatch now also lets a
-#    pull request merge, so it stays what its own comment says it is, a bad day
-#    rather than the normal state.
-#
-#    A ruleset with no bypass actor also stops a direct push to the branch; add
-#    Repository admin as a bypass in the UI if that is not wanted. bump.yml
-#    pushes the version commit straight to this branch, so it needs that bypass
-#    or it stops working.
+# The reasoning is recorded as ADR-0056 in knap-mcp-admin.
 name: Auto-merge
 
 on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+  # Marking a draft ready starts no CI, so nothing else would wake up for a
+  # pull request whose checks are already green and only needed the hold lifted.
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize, converted_to_draft]
+    types: [ready_for_review]
 
-# Nothing here reads the repository. The work is two API calls, made with a
-# token that is not the runner's, so the runner's needs no reach at all.
+# The runner's own token is used for nothing. Every call below carries the PAT.
 permissions: {}
 
+# Never cancel: a cancelled run may be one that is mid-merge.
 concurrency:
-  group: automerge-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: automerge-${{ github.event.workflow_run.head_branch || github.event.pull_request.head.ref }}
+  cancel-in-progress: false
 
 jobs:
   auto-merge:
-    # A fork's pull request is handed no secrets, so without this it would fail
-    # on the token check below and paint every fork contribution red.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # A fork's branch, from either trigger. On the pull_request path a fork is
+    # handed no secrets and this would fail on the token check; on the
+    # workflow_run path it would run with our secrets against code the fork
+    # wrote, which is the more expensive half of the same rule.
+    if: >-
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.head_repository.full_name == github.repository) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: The token has to be ours
-        id: token
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::warning::AUTOMERGE_TOKEN is not set, so nothing merges itself. Add a fine-grained PAT with Contents and Pull requests write, scoped to this repository. The runner's GITHUB_TOKEN is not a substitute: a merge made with it would land a version bump that cd.yml never sees."
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
+            echo "::error::AUTOMERGE_TOKEN is not set. Add a fine-grained PAT with Contents and Pull requests write, scoped to this repository."
+            exit 1
           fi
 
-      - name: Switch auto-merge on, or off for a draft
-        if: steps.token.outputs.ready == 'true'
+      - name: Merge it, if everything on the commit is green
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
           REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
-          DRAFT: ${{ github.event.pull_request.draft }}
+          SHA: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
-          on=$(gh pr view "$PR" --repo "$REPO" \
-                 --json autoMergeRequest --jq '.autoMergeRequest != null')
+          # Which pull request is this commit the head of. A push to a branch
+          # with no pull request open is not our business.
+          pr=$(gh api "repos/$REPO/commits/$SHA/pulls" \
+                 --jq "[.[] | select(.state == \"open\" and .head.sha == \"$SHA\")][0].number // empty")
+          if [ -z "$pr" ]; then
+            echo "No open pull request has $SHA as its head. Nothing to do."
+            exit 0
+          fi
 
-          if [ "$DRAFT" = "true" ]; then
-            if [ "$on" = "true" ]; then
-              gh pr merge "$PR" --repo "$REPO" --disable-auto
-              echo "Draft. Auto-merge switched off."
-            else
-              echo "Draft. Nothing to do until it is marked ready for review."
+          draft=$(gh api "repos/$REPO/pulls/$pr" --jq .draft)
+          if [ "$draft" = "true" ]; then
+            echo "Pull request #$pr is a draft. Holding until it is marked ready for review."
+            exit 0
+          fi
+
+          # Every check on the commit, by whatever name. filter=latest is the
+          # API's default, so a re-run replaces its earlier attempt rather than
+          # counting twice.
+          total=0; waiting=0; failed=0
+          while IFS=$'\t' read -r name status conclusion; do
+            [ -z "$name" ] && continue
+            total=$((total + 1))
+            if [ "$status" != "completed" ]; then
+              waiting=$((waiting + 1))
+              echo "waiting: $name ($status)"
+              continue
             fi
+            case "$conclusion" in
+              success|skipped|neutral) ;;
+              *) failed=$((failed + 1)); echo "not green: $name ($conclusion)" ;;
+            esac
+          done < <(gh api --paginate "repos/$REPO/commits/$SHA/check-runs" \
+                     --jq '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv')
+
+          # Commit statuses are the older mechanism and some tools still post
+          # them. total_count 0 means nobody posts any here, which reads as
+          # "pending" from this endpoint and must not be read as one.
+          st=$(gh api "repos/$REPO/commits/$SHA/status" --jq '"\(.total_count) \(.state)"')
+          st_count=${st%% *}; st_state=${st##* }
+          if [ "$st_count" != "0" ] && [ "$st_state" != "success" ]; then
+            echo "Commit statuses are $st_state. Not merging."
             exit 0
           fi
 
-          if [ "$on" = "true" ]; then
-            echo "Auto-merge is already on, and a push does not turn it off."
+          if [ "$total" -eq 0 ]; then
+            echo "::warning::No checks have reported on $SHA. A commit nothing tested is not a green commit, so #$pr is not being merged."
+            exit 0
+          fi
+          if [ "$waiting" -gt 0 ]; then
+            echo "$waiting of $total checks still running. The last one to finish wakes this again."
+            exit 0
+          fi
+          if [ "$failed" -gt 0 ]; then
+            echo "$failed of $total checks are not green. Not merging #$pr."
             exit 0
           fi
 
-          # Squash: every commit on the default branch is one pull request, and
-          # the history says so. A failure here is usually one of the two
-          # settings in the header, and the message gh prints names which.
-          gh pr merge "$PR" --repo "$REPO" --auto --squash
-          echo "Auto-merge on. This merges itself once the required checks pass."
+          echo "All $total checks green. Merging #$pr."
+          # Squash: every commit on the default branch is one pull request,
+          # and the history says so. A conflict with the base fails here on
+          # purpose, because that needs somebody.
+          gh pr merge "$pr" --repo "$REPO" --squash


### PR DESCRIPTION
## Summary

Auto-merge and rulesets are GitHub Team and Enterprise on an organisation's private repositories, and Allow auto-merge is greyed out. Their rulesets page says it outright: *"A ruleset is a named list of rules that applies to a repository or to multiple repositories in an organisation for customers on GitHub Team and GitHub Enterprise plans."* So there is nothing to switch on and no required-check list to define green, and `automerge.yml` decides instead.

It wakes when CI completes, reads **every check run on the commit**, and merges when all of them have finished and none is worse than success, skipped or neutral. Not a list somebody has to keep current. Every refusal ends in "do not merge": still running, not green, nothing reported at all, draft, or a fork's branch.

**In practice that comes down to `CI gate` here**, and that is `ci.yml`'s own design rather than a shortcut: every job but `manifest-check` carries `continue-on-error`, so a red one still reports green to the API, and `ci-gate` is the single check that fails the run. It also means the `CI_MODE=REPORT` escape hatch now lets a pull request merge as well, so it stays what its own comment says it is: a bad day, not the normal state.

**A merged version bump publishes a release.** `cd.yml` watches `knap/fork-base` for a change to `manifest.json` and cuts the release itself, so that one kind of merge now ships with nobody in the loop, and every other merge ships nothing. That was already true of a merge somebody tapped; what changes is that the tap moves earlier, to Ready for review. `bump.yml` is untouched and is still the way to cut a release without a pull request at all.

**That is also why the token is `AUTOMERGE_TOKEN` and not the runner's `GITHUB_TOKEN`.** This repository is where we learned that a push made with `GITHUB_TOKEN` starts no workflow run, and `bump.yml` and `cd.yml` both carry the comment. A merge made with it would land a version bump `cd.yml` never sees, and the release would silently not happen.

**Draft is the hold.** An agent opens its pull request as a draft, so nothing an agent writes merges on its own. Marking a draft ready starts no CI, so `ready_for_review` is a second way in for a pull request that was already green.

## One thing to switch on

`AUTOMERGE_TOKEN`: a fine-grained PAT scoped to this repository, Contents read/write and Pull requests read/write. No ruleset, no repository settings. The earlier version of this pull request asked for both, and also for a bypass actor so `bump.yml` could keep pushing its version commit straight to the branch; none of that applies now, because nothing here protects the branch.

`workflow_run` only ever runs the copy of this file on the default branch, so this does nothing until it is merged, including on its own pull request.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] `npm run build` succeeds. Unaffected: no TypeScript, no manifest and no build config changed, and Build + smoke is green on this branch.
- [x] `npm run lint` passes. ESLint is green on this branch.
- [ ] Tested in Obsidian. Not applicable, and not run: this is CI plumbing and the plugin does not change.
- [x] Changes are minimal and focused. One workflow file, nothing else.

The merge step is tested against a stubbed `gh` across seven cases: all green (merges), one still running, one failed, no checks, draft, no pull request, and a failing commit status. Not verified from here: the real token and the `workflow_run` path, which cannot run until this is on the default branch. The plan limit was inferred from the greyed-out checkbox plus the public documentation.