### PR TITLE
The vault row is as tall as what is in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.12.1
+- A vault in the list is drawn inside its own box again. The row is a button, and Obsidian gives every button one line of height and forbids it to wrap, which fitted the row until it grew a second line: the day the vault was added and the word Sync fell out under the border, and the Create new button underneath was drawn over the top of them. The row is as tall as what is in it now. The Dashboard row is a button of the same kind and had the same thing wrong with it, one line high with a setting row's worth of content in it.
+
 ## 1.12.0
 - Every device that syncs a cloud vault now says so, so Knap's page can list the local vaults behind one cloud vault instead of the sign-ins on your account. Each device writes one row into the vault's own document: what the vault is called here, whether this is a laptop or a phone, which plugin build is running, and when it last connected. It is keyed by the id Obsidian already gives this vault on this machine, so two devices are two rows and neither can overwrite the other, and the row goes when the vault stops syncing here. It costs no request and nothing from the rate limit: the document is one both sides already hold open.
 - The vault list says less. The heading is *Cloud vaults* rather than a sentence telling you to pick one, the button on a row is *Sync* rather than *Sync with Pantalytics*, and the one under the list is *Create new*. The three lines of explanation under them are gone: the rows are vaults and each carries the word for what pressing it does.

--- a/src/components/SignIn.svelte
+++ b/src/components/SignIn.svelte
@@ -795,7 +795,14 @@
 
 	/* One vault, one button, so pressing it anywhere joins it. The facts sit
 	   under the name at caption weight, and the words that say what pressing
-	   does sit on the right where a value would be. */
+	   does sit on the right where a value would be.
+
+	   `height: auto` and `white-space: normal` are not decoration. Obsidian
+	   gives every button `height: var(--input-height)` and `white-space:
+	   nowrap`, which fits a button with one word in it and not a row of two
+	   lines: the box stayed one line tall, the date and the word Sync fell
+	   out below the border, and the Create new button underneath was drawn
+	   over them. */
 	.knap-vault {
 		display: grid;
 		grid-template-columns: 1fr auto;
@@ -803,6 +810,8 @@
 		gap: 2px 12px;
 		align-items: center;
 		width: 100%;
+		height: auto;
+		white-space: normal;
 		padding: 10px 12px;
 		margin-top: 6px;
 		background: transparent;
@@ -921,12 +930,17 @@
 	}
 
 	/* A setting row that happens to be a button, so it reads as a place to go
-	   and still lines up with the rows above it. */
+	   and still lines up with the rows above it. Same height reset as the
+	   vault row: a setting row is taller than the button height Obsidian
+	   hands out, so without it the hover background is a band across the
+	   middle of the text. */
 	.knap-row-link {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		width: 100%;
+		height: auto;
+		white-space: normal;
 		box-shadow: none;
 		background: transparent;
 		text-align: left;


### PR DESCRIPTION
The row in the Cloud vaults list is a `<button>`, and Obsidian's stylesheet gives every button `height: var(--input-height)` (30px) and `white-space: nowrap`. The row is a two-line grid, so the box stayed one line high: the name showed, *Added to Knap on 12 August 2026* and *Sync* fell out under the border, and **Create new** was drawn on top of them.

`height: auto` and `white-space: normal` on the row. Dashboard is a button of the same kind with a setting row inside it, so it had the same fault -- its hover background was a band across the middle of the text -- and gets the same two lines.

Checked against Obsidian's base button rule taken out of `app.asar`, rendered before and after. `npm run build`, `npm run lint` and `npm test` (674 passing) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)