### PR TITLE
Rename the default branch to main, without a gap in CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,9 +11,13 @@ name: CD
 # This file only decides whether to release. The building, attesting and
 # publishing all stay in release.yml, called below, so there is one description
 # of what a release is.
+# Both branch names are listed because the default branch is being renamed from
+# knap/fork-base to main. A release trigger that names only one of them silently
+# stops releasing on whichever side of the rename it is not on. Drop
+# knap/fork-base once the rename has landed.
 on:
   push:
-    branches: [knap/fork-base]
+    branches: [main, knap/fork-base]
     paths: ['manifest.json']
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,14 @@ name: CI
 
 on:
   pull_request:
-  # The default branch is knap/fork-base, not main. Naming main here meant no CI
-  # ever ran on a merge: the PR run was the last word, and anything that only
-  # breaks once two PRs are combined landed unnoticed.
+  # Naming the wrong branch here once meant no CI ever ran on a merge: the PR run
+  # was the last word, and anything that only breaks once two PRs are combined
+  # landed unnoticed. Both names are listed because the default branch is being
+  # renamed from knap/fork-base to main, and a trigger naming only one of them
+  # goes dark on whichever side of the rename it is not on. Drop knap/fork-base
+  # once the rename has landed.
   push:
-    branches: [knap/fork-base]
+    branches: [main, knap/fork-base]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ A vault you do not mind breaking is the right vault for this.
 
 ## Pull Requests
 
-1. Create a branch from `knap/fork-base`, the default branch
+1. Create a branch from `main`, the default branch
 2. Make your changes
 3. Ensure `npm run build` succeeds with no errors
 4. Ensure `npm run lint` and `npm test` pass

--- a/docs/catalog-submission.md
+++ b/docs/catalog-submission.md
@@ -25,7 +25,7 @@ Worth understanding before the steps, because it explains why the order matters:
   and `description` are the fields people search on.
 - Opening a plugin's page pulls `manifest.json` and `README.md` **from the
   default branch** of the repo. Not from the release. Our default branch is
-  `knap/fork-base`, which is unusual but is what the directory will read.
+  `main`, renamed from `knap/fork-base` on 2026-08-13.
 - The manifest on the default branch only decides *which version is latest*. The
   files a user installs come from the **GitHub release tagged exactly that
   version**.
@@ -66,7 +66,7 @@ Verified against the live repo and the live catalog on 2026-08-11, not assumed.
 |---|---|
 | Repository is public | Public. This was the blocker in the previous draft and it is gone. |
 | `README.md`, `LICENSE`, `manifest.json` in the repo root | Present. CI checks they stay present. |
-| Default branch carries the Knap manifest and README | `knap/fork-base` is the default branch and holds both. There is no `main`, so there is nothing to merge first. |
+| Default branch carries the Knap manifest and README | `main` is the default branch and holds both, so there is nothing to merge first. It was renamed from `knap/fork-base` on 2026-08-13; GitHub redirects the old name, and the directory reads whatever is default at the time it looks. |
 | Plugin id unique across published plugins | `synced-vaults` is free: re-checked against all 6582 entries in `community-plugins.json` on 2026-08-12, after the rename off `knap-sync`. The id stayed there when the name went back to Knap (ADR-0045). The name was checked separately on 2026-08-12 against all 6588 entries then published: no plugin is called Knap and none carries the word in its name. |
 | Plugin id does not contain `obsidian` | `synced-vaults`. CI checks it. |
 | Name does not read as a first-party Obsidian product | Knap. It is the product's own name and says nothing about Obsidian. CI checks for "Obsidian". |


### PR DESCRIPTION
## Summary

The default branch is `knap/fork-base`, a name left over from cutting this fork down. Nothing depends on the name any more, so it becomes `main`.

**The rename itself is a repo setting and is not in this diff.** No GitHub tool available to me can rename a branch or move the default; that stays a manual step in *Settings → Branches*. This PR is the part that has to be in place around it.

The load-bearing change is the push triggers. `ci.yml` and `cd.yml` now name **both** branches:

```yaml
branches: [main, knap/fork-base]
```

A trigger naming only one goes dark on whichever side of the rename it is not on. `ci.yml` already carried a comment about the last time that happened — a merge landing with no CI behind it — so this avoids repeating it. Listing both means the rename can be flipped before or after this lands and neither CI nor the release trigger misses a push.

### Suggested order

1. Merge this PR.
2. Rename in *Settings → Branches* (`knap/fork-base` → `main`). GitHub retargets open PRs, updates branch protection rules and redirects the old name.
3. Follow-up commit drops the `knap/fork-base` entries from both triggers.

Merging first is deliberate: it leaves the docs briefly naming a branch that does not exist yet, which is cheap. Renaming first would leave the merge itself running without CI, which is not.

### What changed, and what did not

Prose reading "the default branch" needed no change — it stays true either way. Only the four places naming the branch outright:

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | Push trigger takes both names; comment rewritten for the transition |
| `.github/workflows/cd.yml` | Same, plus a note on why a release trigger must not miss the rename |
| `CONTRIBUTING.md` | "Create a branch from `main`" |
| `docs/catalog-submission.md` | Two spots — this is what tells whoever submits to the Obsidian directory which branch the catalog reads `manifest.json` and `README.md` off |

One thing to flag: `docs/catalog-submission.md` sits under a heading that says it was *"Verified against the live repo … not assumed."* Those two lines now describe the post-rename state, so they are accurate only once step 2 is done. That is the intent, but it is worth knowing they run ahead of reality until then.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [x] Repository / CI configuration

## Checklist

- [ ] `npm run build` succeeds — not run locally; no source file is touched (YAML and Markdown only) and CI covers it on this PR
- [ ] `npm run lint` passes — same
- [ ] Tested in Obsidian — not applicable, no plugin code changed
- [x] Changes are minimal and focused
- [x] Both workflow files parse, and the triggers resolve to `['main', 'knap/fork-base']`
- [x] No `knap/fork-base` reference left except the intentional transitional ones

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiT3N3dkNqsyw69B72p3dk)_