### PR TITLE
Drop the old default branch name from the CI and CD triggers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,13 +11,11 @@ name: CD
 # This file only decides whether to release. The building, attesting and
 # publishing all stay in release.yml, called below, so there is one description
 # of what a release is.
-# Both branch names are listed because the default branch is being renamed from
-# knap/fork-base to main. A release trigger that names only one of them silently
-# stops releasing on whichever side of the rename it is not on. Drop
-# knap/fork-base once the rename has landed.
+# This has to name the default branch. A release trigger pointed at any other
+# branch does not fail, it just silently stops releasing.
 on:
   push:
-    branches: [main, knap/fork-base]
+    branches: [main]
     paths: ['manifest.json']
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,11 @@ name: CI
 
 on:
   pull_request:
-  # Naming the wrong branch here once meant no CI ever ran on a merge: the PR run
-  # was the last word, and anything that only breaks once two PRs are combined
-  # landed unnoticed. Both names are listed because the default branch is being
-  # renamed from knap/fork-base to main, and a trigger naming only one of them
-  # goes dark on whichever side of the rename it is not on. Drop knap/fork-base
-  # once the rename has landed.
+  # This has to name the default branch. Naming anything else once meant no CI
+  # ever ran on a merge: the PR run was the last word, and anything that only
+  # breaks once two PRs are combined landed unnoticed.
   push:
-    branches: [main, knap/fork-base]
+    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary

Follow-up to #61, which is now unblocked: the rename landed. `main` is the default branch and `knap/fork-base` no longer exists.

Both push triggers carried the old name as a second entry, to cover the window where either branch could receive a push. That window is closed, so it goes:

```diff
-    branches: [main, knap/fork-base]
+    branches: [main]
```

Leaving it would be more than untidy. A trigger listing a branch that cannot receive a push reads like the workflow still runs on two branches, and the next person to touch these files would have to check the branch list to find out it does not. The transitional comments come out with it.

The two mentions in `docs/catalog-submission.md` stay on purpose — they record which branch the Obsidian directory reads today and what it was called before, and those lines are accurate now that the rename is done.

Verified state at the time of writing:

| | |
|---|---|
| `default_branch` | `main` |
| `refs/heads/knap/fork-base` | gone |
| Triggers parse to | `{'branches': ['main']}` in both files |

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [x] Repository / CI configuration

## Checklist

- [ ] `npm run build` succeeds — not run locally; no source file is touched (YAML only) and CI covers it on this PR
- [ ] `npm run lint` passes — same
- [ ] Tested in Obsidian — not applicable, no plugin code changed
- [x] Changes are minimal and focused
- [x] Both workflow files parse, and the triggers resolve to `['main']`
- [x] No `knap/fork-base` reference left outside the two historical notes in `docs/catalog-submission.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiT3N3dkNqsyw69B72p3dk)_