### PR TITLE
A device says what it owes, on the socket it already holds

### DIFF
--- a/__tests__/knapPresence.test.ts
+++ b/__tests__/knapPresence.test.ts
@@ -1,0 +1,135 @@
+import * as Y from "yjs";
+import { Awareness } from "y-protocols/awareness";
+import {
+	KNAP_AWARENESS_FIELD,
+	owed,
+	publishPresence,
+	stateFor,
+	withdrawPresence,
+	type DevicePresence,
+} from "../src/knapPresence";
+
+function presence(over: Partial<DevicePresence> = {}): DevicePresence {
+	return {
+		state: "syncing",
+		up: 12,
+		down: 3,
+		vault: "Pantalytics",
+		platform: "desktop",
+		...over,
+	};
+}
+
+describe("what a device says it is doing right now", () => {
+	test("it carries the install id, which is what joins it to its row", () => {
+		// Upstream's own `user` field names the account and is the same on
+		// every machine one person owns, so without this the live half could
+		// only ever say somebody of mine is connected.
+		const awareness = new Awareness(new Y.Doc());
+		publishPresence(awareness, "app-1", presence());
+
+		expect(awareness.getLocalState()?.[KNAP_AWARENESS_FIELD]).toEqual({
+			install: "app-1",
+			state: "syncing",
+			up: 12,
+			down: 3,
+			vault: "Pantalytics",
+			platform: "desktop",
+		});
+	});
+
+	test("none of it enters the document", () => {
+		// The whole reason the live half is awareness rather than a second
+		// stamp in `knap_devices_v0`: this goes out every few seconds, and a
+		// document that grew each time would be paid for by every device on
+		// the vault, forever.
+		const doc = new Y.Doc();
+		publishPresence(new Awareness(doc), "app-1", presence());
+
+		expect(doc.getMap("knap_devices_v0").size).toBe(0);
+		expect(Y.encodeStateAsUpdate(doc).length).toBeLessThan(10);
+	});
+
+	test("a device with no id says nothing, rather than something unjoinable", () => {
+		const awareness = new Awareness(new Y.Doc());
+		publishPresence(awareness, "  ", presence());
+
+		expect(awareness.getLocalState()?.[KNAP_AWARENESS_FIELD]).toBeUndefined();
+	});
+
+	test("a count that went wrong is clamped rather than published", () => {
+		// It lands on somebody's own vault page. Two devices disagreeing about
+		// arithmetic is a bug; a negative note count on a screen is a mystery.
+		const awareness = new Awareness(new Y.Doc());
+		publishPresence(awareness, "app-1", presence({ up: -4, down: 2.6 }));
+
+		const said = awareness.getLocalState()?.[KNAP_AWARENESS_FIELD];
+		expect(said.up).toBe(0);
+		expect(said.down).toBe(3);
+	});
+
+	test("a device can stop claiming to be here", () => {
+		const awareness = new Awareness(new Y.Doc());
+		publishPresence(awareness, "app-1", presence());
+		withdrawPresence(awareness);
+
+		expect(awareness.getLocalState()?.[KNAP_AWARENESS_FIELD]).toBeNull();
+	});
+});
+
+describe("which way a device is behind", () => {
+	test("what is queued up is not the same as what is queued down", () => {
+		// They ask different things of a person: notes waiting to go up need
+		// this machine left open, notes waiting to come down need nothing.
+		expect(
+			owed({ syncs: 10, completedSyncs: 4, downloads: 3, completedDownloads: 3 }),
+		).toEqual({ up: 6, down: 0 });
+	});
+
+	test("a folder with nothing queued owes nothing", () => {
+		expect(owed(undefined)).toEqual({ up: 0, down: 0 });
+		expect(
+			owed({ syncs: 2, completedSyncs: 2, downloads: 1, completedDownloads: 1 }),
+		).toEqual({ up: 0, down: 0 });
+	});
+
+	test("a group that counted past its own total does not go negative", () => {
+		expect(
+			owed({ syncs: 1, completedSyncs: 4, downloads: 0, completedDownloads: 0 }),
+		).toEqual({ up: 0, down: 0 });
+	});
+});
+
+describe("the word a device uses for itself", () => {
+	test("nothing queued in either direction is up to date", () => {
+		expect(stateFor({ signedIn: true, paused: false, up: 0, down: 0 })).toBe(
+			"up_to_date",
+		);
+	});
+
+	test("anything queued in either direction is syncing", () => {
+		expect(stateFor({ signedIn: true, paused: false, up: 1, down: 0 })).toBe("syncing");
+		expect(stateFor({ signedIn: true, paused: false, up: 0, down: 1 })).toBe("syncing");
+	});
+
+	test("signed out and paused are not states the counts can argue with", () => {
+		expect(stateFor({ signedIn: false, paused: false, up: 9, down: 0 })).toBe(
+			"signed_out",
+		);
+		expect(stateFor({ signedIn: true, paused: true, up: 9, down: 0 })).toBe("paused");
+	});
+
+	test("every word it can produce is one the panel has a name for", () => {
+		// The list lives in status.py in the admin repository and is mirrored
+		// in syncStatus.ts. A word invented here draws a dot with no rule
+		// behind it, on a screen in another repository, with nothing failing.
+		const words = new Set(["syncing", "up_to_date", "paused", "signed_out"]);
+		for (const signedIn of [true, false]) {
+			for (const paused of [true, false]) {
+				for (const up of [0, 3]) {
+					expect(words.has(stateFor({ signedIn, paused, up, down: 0 }))).toBe(true);
+				}
+			}
+		}
+	});
+});

--- a/src/BackgroundSync.ts
+++ b/src/BackgroundSync.ts
@@ -19,6 +19,7 @@ import { SyncFile, isSyncFile } from "./SyncFile";
 import { reconcileWithConflictCopy } from "./y-diffMatchPatch";
 import { waitForBufferFlush } from "./websocketFlush";
 import { claimInitIfUnclaimed, wonInitClaim, markInitDone, awaitClaimSettled } from "./initContentClaim";
+import { owed, stateFor } from "./knapPresence";
 
 export interface QueueItem {
 	guid: string;
@@ -111,6 +112,40 @@ export class BackgroundSync extends HasLogging {
 			void this.processSyncQueue();
 			void this.processDownloadQueue();
 		}, 1000);
+		// Tell each cloud vault what this device is doing with it. Here rather
+		// than in SharedFolder because this is the only object that knows what
+		// is still queued, in each direction, which is the half Knap's page
+		// cannot work out and the half somebody can act on.
+		//
+		// Five seconds matches what that page polls at, so a number on screen
+		// is never more than one tick behind the queue it came from. It is
+		// cheap: awareness never enters the document, and an unchanged report
+		// goes out at most every ten seconds (`SharedFolder.shouldRepublish`).
+		this.timeProvider.setInterval(() => {
+			this.reportToKnap();
+		}, 5000);
+	}
+
+	/**
+	 * Publish this device's state into every vault it syncs.
+	 *
+	 * Never throws: it sits on a timer beside the queues that move somebody's
+	 * notes, and a readout on a web page is not worth risking either of them.
+	 */
+	reportToKnap(): void {
+		const signedIn = !!this.loginManager.loggedIn;
+		this.sharedFolders.items().forEach((folder) => {
+			try {
+				const { up, down } = owed(this.syncGroups.get(folder));
+				folder.reportToKnap({
+					state: stateFor({ signedIn, paused: this.isPaused, up, down }),
+					up,
+					down,
+				});
+			} catch (e) {
+				this.warn("could not report this device's state", e);
+			}
+		});
 	}
 
 	/**

--- a/src/SharedFolder.ts
+++ b/src/SharedFolder.ts
@@ -66,6 +66,12 @@ import {
 } from "./vaultScope";
 import { claimVpathIfUnclaimed, awaitVpathClaimSettled, wonVpathClaim } from "./uploadClaim";
 import { forgetKnapDevice, stampKnapDevice, stampKnapMeta } from "./knapMeta";
+import {
+	publishPresence,
+	withdrawPresence,
+	type DevicePresence,
+	type DeviceState,
+} from "./knapPresence";
 
 // Injected at build time (esbuild `define`), the same way every other module
 // that reports which build it is reads it.
@@ -164,6 +170,11 @@ export class SharedFolder extends HasProvider {
 	path: string;
 	/** Whether this share covers the whole vault or one folder in it. */
 	scope: ShareScope;
+	//: The last thing this device told the vault about itself, and when. Both
+	//: exist only so an unchanged report is not restated on every tick; see
+	//: `shouldRepublish`.
+	private _lastReported = "";
+	private _lastReportedAt = 0;
 	files: Map<string, IFile>; // Maps guids to SharedDocs
 	fset: Files;
 	relayId?: string;
@@ -375,6 +386,12 @@ export class SharedFolder extends HasProvider {
 			} catch (e) {
 				this.warn("could not stamp this device", e);
 			}
+			// And what this device is doing with the vault right now, which the
+			// row above cannot carry: it is written hourly and the counts move
+			// every few seconds. `BackgroundSync` keeps this current; this call
+			// is so a device that has just connected is on the page before its
+			// first tick.
+			this.reportToKnap();
 			try {
 				void this._persistence.set("path", this.path);
 				void this._persistence.set("relay", this.relayId || "");
@@ -2543,8 +2560,83 @@ export class SharedFolder extends HasProvider {
 		}
 	}
 
+	/**
+	 * Say what this device is doing with this cloud vault right now.
+	 *
+	 * The live half of `knapMeta.ts`'s device row (`knapPresence.ts`). Called
+	 * on connect and every few seconds from `BackgroundSync`, which is the only
+	 * object that knows what is still queued in each direction.
+	 *
+	 * Nothing here may throw. It runs beside the queues that actually move
+	 * somebody's notes, and a readout on a web page is not worth risking one.
+	 */
+	reportToKnap(
+		owing: { state: DeviceState; up: number; down: number } = {
+			state: "up_to_date",
+			up: 0,
+			down: 0,
+		},
+	): void {
+		if (this.destroyed) return;
+		try {
+			// Only while there is a socket to say it on. Awareness with no
+			// provider is a claim nobody hears.
+			const awareness = this._provider?.awareness;
+			if (!awareness) return;
+			const presence: DevicePresence = {
+				state: owing.state,
+				up: owing.up,
+				down: owing.down,
+				vault: this.vault.getName(),
+				platform: Platform.isMobileApp ? "mobile" : "desktop",
+			};
+			if (this.shouldRepublish(presence)) {
+				publishPresence(awareness, this.appId, presence);
+			}
+		} catch (e) {
+			this.warn("could not publish this device's state", e);
+		}
+	}
+
+	/**
+	 * Whether this report is worth putting on the wire.
+	 *
+	 * A change always is: the counts are what somebody is watching, and a
+	 * number that arrives ten seconds late looks stuck.
+	 *
+	 * An unchanged one still goes out on a slow beat. An awareness entry is
+	 * kept alive by being restated, so a device that went quiet because it had
+	 * nothing new to say would eventually be pruned and read as offline with
+	 * Obsidian open in front of somebody. Ten seconds is well inside the thirty
+	 * the protocol's own timeout uses, and half what restating on every tick
+	 * would cost.
+	 */
+	private shouldRepublish(
+		presence: DevicePresence,
+		now: number = Date.now(),
+	): boolean {
+		const said = JSON.stringify(presence);
+		if (said === this._lastReported && now - this._lastReportedAt < 10_000) {
+			return false;
+		}
+		this._lastReported = said;
+		this._lastReportedAt = now;
+		return true;
+	}
+
+
 	destroy() {
 		this.destroyed = true;
+		// Stop claiming to be here before the socket goes. Politeness rather
+		// than correctness, since the server withdraws this on a close anyway;
+		// the durable row stays, because a device that still syncs this vault
+		// is still one of its devices.
+		try {
+			const awareness = this._provider?.awareness;
+			if (awareness) withdrawPresence(awareness);
+		} catch {
+			// A folder coming down is not the place to report this.
+		}
 		this.unsubscribes.forEach((unsub) => {
 			unsub();
 		});

--- a/src/knapPresence.ts
+++ b/src/knapPresence.ts
@@ -1,0 +1,127 @@
+"use strict";
+
+import type { Awareness } from "y-protocols/awareness";
+
+/**
+ * What this device is doing with a cloud vault *right now*.
+ *
+ * The other half of `knapMeta.ts`'s device row, and the two do different jobs
+ * (ADR-0063 in the admin repository). The row in `knap_devices_v0` is durable:
+ * it survives a shut laptop, which is what keeps a device on Knap's page at
+ * all, and it is rewritten at most hourly because every write is an update
+ * every peer on the vault receives. It therefore cannot carry what a device
+ * owes, which changes every few seconds: an hour-old count would look current.
+ *
+ * This is the live half, and it rides **awareness** on the provider the folder
+ * already holds open. Two properties make it the right channel, both measured
+ * before anything was built on them (`scripts/spikes/vault_presence/` in the
+ * admin repository): nothing here enters the document, so a device restating
+ * itself costs the vault nothing durable, and the server withdraws a client's
+ * awareness within a second of its socket closing, so a page can grey a device
+ * out because it is gone rather than because a timer ran out.
+ *
+ * Knap cannot work any of this out for itself. It sees the folder document and
+ * the copy it keeps, and never the files on this machine, so whether a local
+ * vault is level with its cloud vault is a claim only this side can make.
+ */
+
+/**
+ * The awareness field that is ours.
+ *
+ * Upstream already sets `user` (`HasProvider.ts`), which names the account and
+ * is the same value on every machine one person owns. It answers *somebody of
+ * mine is connected* and never *which*, which is why this carries the install
+ * id: it is the same key `knap_devices_v0` uses, and it is what joins the live
+ * half to the durable one.
+ */
+export const KNAP_AWARENESS_FIELD = "knap";
+
+/** What a device is doing, in the four words both screens share. */
+export type DeviceState = "syncing" | "up_to_date" | "paused" | "signed_out";
+
+/** What one device says about one cloud vault. */
+export interface DevicePresence {
+	state: DeviceState;
+	/** Notes here that the cloud vault does not have yet. */
+	up: number;
+	/** Notes in the cloud vault that are not here yet. */
+	down: number;
+	/** What this vault is called here, for a device whose row has not landed. */
+	vault: string;
+	/** "desktop" or "mobile", as specific as Obsidian will say. */
+	platform: string;
+}
+
+/** Say it, on the socket this folder is already holding. */
+export function publishPresence(
+	awareness: Awareness,
+	installId: string,
+	presence: DevicePresence,
+): void {
+	const install = installId.trim();
+	if (!install) return;
+	awareness.setLocalStateField(KNAP_AWARENESS_FIELD, {
+		install,
+		state: presence.state,
+		up: Math.max(0, Math.round(presence.up)),
+		down: Math.max(0, Math.round(presence.down)),
+		vault: presence.vault.trim(),
+		platform: presence.platform,
+	});
+}
+
+/**
+ * Stop claiming to be here, without waiting for the socket to notice.
+ *
+ * Politeness rather than correctness: the server withdraws this on a close
+ * anyway. The durable row deliberately stays, because a device that still
+ * syncs this vault is still one of its devices; `forgetKnapDevice` is what
+ * takes that out, and only when this device actually stops syncing.
+ */
+export function withdrawPresence(awareness: Awareness): void {
+	awareness.setLocalStateField(KNAP_AWARENESS_FIELD, null);
+}
+
+/**
+ * What this device owes a cloud vault, from the sync queue for that folder.
+ *
+ * Two directions rather than one total, because they ask different things of a
+ * person: notes waiting to go up need this machine left open, notes waiting to
+ * come down clear themselves while Obsidian is running. A single number would
+ * hide the only part somebody can act on.
+ */
+export function owed(group?: {
+	syncs: number;
+	downloads: number;
+	completedSyncs: number;
+	completedDownloads: number;
+}): { up: number; down: number } {
+	if (!group) return { up: 0, down: 0 };
+	return {
+		up: Math.max(0, group.syncs - group.completedSyncs),
+		down: Math.max(0, group.downloads - group.completedDownloads),
+	};
+}
+
+/**
+ * The word for a device, from how it is placed and what it owes.
+ *
+ * Mirrors `syncStatus.syncWord` and takes the counts as well, so a folder with
+ * nothing queued reads as up to date rather than as busy. Signed out and
+ * paused come first: neither is a state the counts can argue with.
+ *
+ * The counts travel beside the word rather than only the word, because Knap
+ * reports a device claiming to be finished while owing notes as still syncing,
+ * and it can only do that if it has the numbers.
+ */
+export function stateFor(input: {
+	signedIn: boolean;
+	paused: boolean;
+	up: number;
+	down: number;
+}): DeviceState {
+	if (!input.signedIn) return "signed_out";
+	if (input.paused) return "paused";
+	if (input.up > 0 || input.down > 0) return "syncing";
+	return "up_to_date";
+}


### PR DESCRIPTION
## Summary

`knapMeta.ts` already tells a cloud vault which local vaults sync it and when each was last there (ADR-0059). That is the half a person reads second. This is the half they read first: **what each device is doing right now, and which way it is behind.**

The panel half is [pantalytics/knap-mcp-admin#126](https://github.com/pantalytics/knap-mcp-admin/pull/126), where a cloud vault's dot becomes the worst of its online devices plus Knap's own copying, and each device gets a row of its own.

One new module, `src/knapPresence.ts`, plus two call sites.

### Why it cannot go in the existing row

`knap_devices_v0` is rewritten at most hourly by design, because every write is an update every peer on the vault receives and the document keeps. What a device owes changes every few seconds, so a count stored there would be an hour old and look current.

So this rides **awareness** on the provider the folder already holds open. Two properties make that the right channel, both measured before anything was built on them ([`scripts/spikes/vault_presence/`](https://github.com/pantalytics/knap-mcp-admin/tree/claude/cloud-vault-sync-status-m22zq7/scripts/spikes/vault_presence) in the admin repo):

- **Nothing enters the document.** Restating this costs the vault nothing durable.
- **The server withdraws a client's awareness within a second of its socket closing.** So the page greys a device out because it is gone, rather than because a timer ran out.

It carries the install id because upstream's own `user` field names the *account* and is identical on every machine one person owns. That id is the same key `knap_devices_v0` uses, which is what joins the live half to the durable one.

### Two decisions worth the review

- **Two directions, not one total.** Notes waiting to go up need this machine left open; notes waiting to come down need nothing from anybody. One number hides the only part somebody can act on.
- **`BackgroundSync` drives it**, on a five-second tick. It is the only object that knows what is queued per folder, and it already holds the login and the pause. An unchanged report goes out at most every ten seconds, which is inside the timeout that would otherwise prune a quiet device and read it as offline with Obsidian open in front of somebody.

## Type of Change

- [x] New feature

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (5 pre-existing warnings, no new ones)
- [ ] Tested in Obsidian
- [x] Changes are minimal and focused

On the unticked box, because it is the one thing this PR cannot claim.

`npx tsc -noEmit -skipLibCheck` is clean and `npm test` passes 695 tests, 12 of them new in `__tests__/knapPresence.test.ts`. Beyond that, the admin repo's `presence_spike.py --with-plugin` bundles **this branch's** `src/knapMeta.ts` and `src/knapPresence.ts`, runs them against a real y-sweet server, and reads both back through the panel's real readers: the row parses, the install id joins the live half to the stored one, the name and platform survive, the milliseconds become seconds, and `up=12 down=3` arrives intact. That is the failure this pair is most likely to have, because the format is written in two repositories that ship separately and neither one's tests can see the other.

What is unproven is the wiring inside Obsidian: that the five-second tick reaches every folder, that `_provider.awareness` is live when `whenSynced` fires, and that a second device on a phone reads the way it should. Worth a run on a real vault with two machines before this ships.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJ1uYTNo6adSyd9fVUVJ9w)_