### PR TITLE
The ADR this points at is 0064

### DIFF
--- a/src/knapPresence.ts
+++ b/src/knapPresence.ts
@@ -6,7 +6,7 @@ import type { Awareness } from "y-protocols/awareness";
  * What this device is doing with a cloud vault *right now*.
  *
  * The other half of `knapMeta.ts`'s device row, and the two do different jobs
- * (ADR-0063 in the admin repository). The row in `knap_devices_v0` is durable:
+ * (ADR-0064 in the admin repository). The row in `knap_devices_v0` is durable:
  * it survives a shut laptop, which is what keeps a device on Knap's page at
  * all, and it is rewritten at most hourly because every write is an update
  * every peer on the vault receives. It therefore cannot carry what a device


### PR DESCRIPTION
## Summary

One comment, one number. `knapPresence.ts` cites the decision behind it as ADR-0063 in the admin repo, and that number moved: [knap-mcp-admin#125](https://github.com/pantalytics/knap-mcp-admin/pull/125) landed while both sides of #69 were open and took 0063, so the decision is [0064](https://github.com/pantalytics/knap-mcp-admin/blob/main/docs/adr/0064-a-vaults-status-is-every-devices-status.md) there.

A pointer to the wrong ADR is worse than no pointer, because 0063 is now a different decision and reads as though it explains this file.

## Type of Change

- [x] Documentation

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (5 pre-existing warnings, no new ones)
- [ ] Tested in Obsidian
- [x] Changes are minimal and focused

Nothing to test in Obsidian: the diff is one line of a comment. `npx tsc -noEmit` is clean and `npm test` passes 667 tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJ1uYTNo6adSyd9fVUVJ9w)_