### PR TITLE
The linked vault's name reads like the choice it is

### DIFF
--- a/src/components/SignIn.svelte
+++ b/src/components/SignIn.svelte
@@ -644,7 +644,7 @@
 					<div class="setting-item-name">{LINKED_TO_LABEL}</div>
 					<div class="setting-item-description">{UNLINK_EXPLANATION}</div>
 				</div>
-				<div class="setting-item-control knap-value">
+				<div class="setting-item-control knap-value knap-linked">
 					<span class="knap-value-text">{syncingWith.path}</span>
 					<button
 						class="knap-btn"
@@ -885,6 +885,29 @@
 	.knap-value-text {
 		min-width: 0;
 		overflow-wrap: anywhere;
+	}
+
+	/* The Linked to row, which carries the one fact on this screen somebody
+	   chose rather than a value the plugin worked out: which cloud vault this
+	   device answers to (ADR-0066). At the muted value size the name read as
+	   fine print and #71 showed what that costs, so it gets full colour and a
+	   size up, and the button sits under it with room instead of beside it in
+	   whatever width the name left over. */
+	.knap-linked {
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 8px;
+	}
+
+	.knap-linked .knap-value-text {
+		color: var(--text-normal);
+		font-size: var(--font-ui-medium, 15px);
+		font-weight: var(--font-semibold, 600);
+	}
+
+	.knap-linked .knap-btn {
+		font-size: var(--font-ui-medium, 15px);
+		padding: 8px 18px;
 	}
 
 	.knap-note {


### PR DESCRIPTION
## Summary

The Linked to row on the settings screen rendered the cloud vault's name and the Unlink button in the muted value column: the name broke mid-word at fine-print size (`260812_RH_Obsi` / `dian_vault`) and the button fit in whatever width the name left over. Both read as too small to matter.

The name is the one fact on this screen somebody chose rather than a value the plugin worked out (ADR-0066), so the row now gets its own layout: the name reads at full colour, one size up and semibold, and the Unlink button sits under it at a matching size with room of its own. No copy changes, no behaviour changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [ ] Tested in Obsidian
- [x] Changes are minimal and focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4FtmkzFVqFhi3K3Nop51z

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4FtmkzFVqFhi3K3Nop51z)_