### PR TITLE
A vault row says nothing about who made it (ADR-0073)

### DIFF
--- a/__tests__/vaultShare.test.ts
+++ b/__tests__/vaultShare.test.ts
@@ -167,14 +167,13 @@ describe("what a row says about a vault", () => {
 		}
 	});
 
-	test("somebody else's vault says so", () => {
-		expect(vaultRowLines(folderShare("Clients", "1", { is_owner: false }))).toEqual([
-			"Someone else's vault",
-		]);
-	});
-
-	test("your own says nothing about ownership, because that is the ordinary case", () => {
-		expect(vaultRowLines(folderShare("V", "1", { is_owner: true }))).toEqual([]);
+	test("nothing about who made it, because it changes nothing (ADR-0073)", () => {
+		// One kind of person is in a vault and they can all do everything to
+		// it, so a row saying whose it is would be a difference a person
+		// cannot act on.
+		for (const is_owner of [true, false, undefined]) {
+			expect(vaultRowLines(folderShare("V", "1", { is_owner }))).toEqual([]);
+		}
 		expect(vaultRowLines(folderShare("V"))).toEqual([]);
 	});
 

--- a/src/vaultShare.ts
+++ b/src/vaultShare.ts
@@ -43,7 +43,11 @@ export interface ShareLike {
 	path: string;
 	/** When the vault was made on Knap. The one fact worth previewing. */
 	created_at?: string;
-	/** False when somebody else owns it and this account is a member of it. */
+	/**
+	 * False when somebody else made it. It says who created the vault and
+	 * nothing about what this account may do with it: everybody in a vault can
+	 * do everything to it (ADR-0073). Nothing on a screen reads it.
+	 */
 	is_owner?: boolean;
 }
 
@@ -160,12 +164,10 @@ export function vaultRowLines(vault: ShareLike): string[] {
 	if (made) {
 		lines.push(`Added to Knap on ${made}`);
 	}
-	if (vault.is_owner === false) {
-		// Not "shared with you". Share is the control plane's noun and stays
-		// off a screen (ADR-0038); what a person needs here is whose vault it
-		// is, which is the same fact in the words the rest of Knap uses.
-		lines.push("Someone else's vault");
-	}
+	// Nothing about who made it. It used to say "Someone else's vault" on a
+	// vault this account did not create, which was true and is now beside the
+	// point: one kind of person is in a vault and they can all do everything
+	// to it (ADR-0073), so the line said a difference that no longer exists.
 	return lines;
 }
 


### PR DESCRIPTION
One kind of person is in a vault now: everybody in it can read it, write it, rename it, let somebody in and delete it (pantalytics/knap-relay#20, pantalytics/knap-mcp-admin#136). "Someone else's vault" said a difference that no longer exists, so a row is the name and the day it was made.

`is_owner` stays on the `ShareLike` interface as the record of who created it. Nothing on a screen reads it.

## Not done, on purpose

Upstream's own share screens still gate on it: `ShareManagementModal` (members, invites, agent keys, web publishing, delete) and `ShareDetailView.svelte`. After the relay change they show a member less than they may. No Knap design uses those screens, and who may read a vault is set on Knap's page (ADR-0057), so widening them would be building out a surface we deliberately do not have. Filed separately.

`npx tsc --noEmit` and `npx jest` (720 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)