### PR TITLE
Phase 2: the client, the binding engine, and the switch

### DIFF
--- a/__tests__/knap/KnapServer.test.ts
+++ b/__tests__/knap/KnapServer.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The HTTP half of the new client, against a hand-rolled fetch.
+ *
+ * The real server's answers are pinned by knap-mcp-admin's own suite; what
+ * these tests hold still is what the plugin sends and how it reads answers,
+ * so a drifting field name fails here rather than on somebody's laptop.
+ */
+
+import { KnapServer, KnapServerError } from "../../src/knap/KnapServer";
+
+type Call = { url: string; init?: RequestInit };
+
+function fakeFetch(routes: Record<string, (init?: RequestInit) => Response>) {
+	const calls: Call[] = [];
+	const fetchFn = async (url: string, init?: RequestInit): Promise<Response> => {
+		calls.push({ url, init });
+		const key = Object.keys(routes).find((route) => url.includes(route));
+		if (!key) return new Response("not found", { status: 404 });
+		return routes[key](init);
+	};
+	return { fetchFn, calls };
+}
+
+describe("KnapServer", () => {
+	it("exchanges a handoff code for a token, and refuses a reused one", async () => {
+		const { fetchFn, calls } = fakeFetch({
+			"/auth/plugin/exchange": (init) => {
+				const body = JSON.parse(String(init?.body));
+				return body.code === "eenmalig"
+					? new Response(JSON.stringify({ token: "knap_abc" }), { status: 200 })
+					: new Response("{}", { status: 400 });
+			},
+		});
+		const server = new KnapServer("https://knap.test", fetchFn);
+
+		expect(await server.exchange("eenmalig", "Laptop")).toBe("knap_abc");
+		expect(JSON.parse(String(calls[0].init?.body)).device).toBe("Laptop");
+
+		await expect(server.exchange("eenmalig-maar-op", "Laptop")).rejects.toThrow(
+			/already used or has expired/,
+		);
+	});
+
+	it("lists vaults in the plugin's shape", async () => {
+		const { fetchFn, calls } = fakeFetch({
+			"/api/vaults": () =>
+				new Response(
+					JSON.stringify({
+						vaults: [{ id: "v1", name: "Demo", may_write: false }],
+					}),
+					{ status: 200 },
+				),
+		});
+		const server = new KnapServer("https://knap.test/", fetchFn);
+
+		const vaults = await server.listVaults("knap_abc");
+		expect(vaults).toEqual([{ id: "v1", name: "Demo", mayWrite: false }]);
+		expect((calls[0].init?.headers as Record<string, string>).Authorization).toBe(
+			"Bearer knap_abc",
+		);
+	});
+
+	it("says sign in again on a dead token", async () => {
+		const { fetchFn } = fakeFetch({
+			"/api/vaults": () => new Response("{}", { status: 401 }),
+		});
+		const server = new KnapServer("https://knap.test", fetchFn);
+		await expect(server.listVaults("knap_oud")).rejects.toThrow(/Sign in again/);
+	});
+
+	it("builds the socket and file addresses the server serves", () => {
+		const server = new KnapServer("https://knap.example", async () => new Response(""));
+		expect(server.syncUrl("v1")).toBe("wss://knap.example/sync/v1");
+		expect(server.signInUrl()).toBe("https://knap.example/auth/plugin/start");
+	});
+
+	it("round-trips an attachment and verifies nothing itself", async () => {
+		const bytes = new TextEncoder().encode("pdf!").buffer;
+		const { fetchFn, calls } = fakeFetch({
+			"/files/v1/Bijlagen/scan%20maandag.pdf": (init) =>
+				init?.method === "PUT"
+					? new Response(JSON.stringify({ sha256: "abc", size: 4 }), { status: 200 })
+					: new Response(new Uint8Array(bytes)),
+		});
+		const server = new KnapServer("https://knap.test", fetchFn);
+
+		const answer = await server.uploadFile("t", "v1", "Bijlagen/scan maandag.pdf", bytes);
+		expect(answer.sha256).toBe("abc");
+		// Path segments travel encoded, slashes stay structural.
+		expect(calls[0].url).toContain("/files/v1/Bijlagen/scan%20maandag.pdf");
+
+		const back = await server.downloadFile("t", "v1", "Bijlagen/scan maandag.pdf");
+		expect(new TextDecoder().decode(back)).toBe("pdf!");
+	});
+
+	it("wraps failures in one error type with the status attached", async () => {
+		const { fetchFn } = fakeFetch({});
+		const server = new KnapServer("https://knap.test", fetchFn);
+		try {
+			await server.downloadFile("t", "v1", "weg.png");
+			throw new Error("should have thrown");
+		} catch (error) {
+			expect(error).toBeInstanceOf(KnapServerError);
+			expect((error as KnapServerError).status).toBe(404);
+		}
+	});
+});

--- a/__tests__/knap/SignInFlow.test.ts
+++ b/__tests__/knap/SignInFlow.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The sign-in orchestration: browser out, deep link in, token settled.
+ * The server half is a fake; the whole chain runs for real in
+ * knap-mcp-admin's cross-repo spike.
+ */
+
+import { KnapServer } from "../../src/knap/KnapServer";
+import { SIGNIN_ACTION, SignInFlow } from "../../src/knap/SignInFlow";
+
+function serverWhereCode(valid: string): KnapServer {
+	return new KnapServer("https://knap.test", async (url, init) => {
+		if (url.includes("/auth/plugin/exchange")) {
+			const body = JSON.parse(String(init?.body));
+			return body.code === valid
+				? new Response(JSON.stringify({ token: "knap_tok" }), { status: 200 })
+				: new Response("{}", { status: 400 });
+		}
+		return new Response("", { status: 404 });
+	});
+}
+
+describe("SignInFlow", () => {
+	it("keeps the synced-vaults identifier in the deep link action", () => {
+		expect(SIGNIN_ACTION).toBe("synced-vaults/signin");
+	});
+
+	it("opens the browser, takes the deep link, and lands the token", async () => {
+		const flow = new SignInFlow(serverWhereCode("c-1"), "Laptop");
+		const opened: string[] = [];
+
+		const tokenPromise = flow.begin((url) => opened.push(url));
+		expect(opened).toEqual(["https://knap.test/auth/plugin/start"]);
+
+		expect(flow.handleDeepLink({ code: "c-1" })).toBe(true);
+		expect(await tokenPromise).toBe("knap_tok");
+	});
+
+	it("a stray deep link with nobody waiting is refused, not crashed on", () => {
+		const flow = new SignInFlow(serverWhereCode("c-1"), "Laptop");
+		expect(flow.handleDeepLink({ code: "c-1" })).toBe(false);
+	});
+
+	it("a rejected code fails the flow with the server's words", async () => {
+		const flow = new SignInFlow(serverWhereCode("goed"), "Laptop");
+		const promise = flow.begin(() => undefined);
+		flow.handleDeepLink({ code: "opnieuw-gebruikt" });
+		await expect(promise).rejects.toThrow(/already used or has expired/);
+	});
+
+	it("a second sign-in replaces the first instead of stacking", async () => {
+		const flow = new SignInFlow(serverWhereCode("c-2"), "Laptop");
+		const first = flow.begin(() => undefined);
+		const second = flow.begin(() => undefined);
+
+		await expect(first).rejects.toThrow(/newer sign-in/);
+		flow.handleDeepLink({ code: "c-2" });
+		expect(await second).toBe("knap_tok");
+	});
+
+	it("a deep link without a code fails cleanly", async () => {
+		const flow = new SignInFlow(serverWhereCode("c-3"), "Laptop");
+		const promise = flow.begin(() => undefined);
+		flow.handleDeepLink({});
+		await expect(promise).rejects.toThrow(/without a code/);
+	});
+});

--- a/__tests__/knap/TreeDoc.test.ts
+++ b/__tests__/knap/TreeDoc.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The tree document: real Yjs, no network, and the property that matters
+ * proven the CRDT way -- two docs that each changed the tree converge on
+ * the same map after exchanging updates.
+ */
+
+import * as Y from "yjs";
+
+import { TreeDoc, normalize } from "../../src/knap/TreeDoc";
+
+describe("TreeDoc", () => {
+	it("mints an id once and keeps it across a move", () => {
+		const tree = new TreeDoc(new Y.Doc());
+		const id = tree.ensureNote("Notes/plan.md");
+		expect(id).toMatch(/^[0-9a-f]{32}$/);
+		expect(tree.ensureNote("Notes/plan.md")).toBe(id);
+		expect(tree.ensureNote("./Notes//plan.md")).toBe(id); // one spelling per path
+
+		const moved = tree.move("Notes/plan.md", "Archief/plan.md");
+		expect(moved).toBe(id);
+		expect(tree.docIdFor("Notes/plan.md")).toBeUndefined();
+		expect(tree.docIdFor("Archief/plan.md")).toBe(id);
+		expect(tree.pathFor(id)).toBe("Archief/plan.md");
+	});
+
+	it("removal is leaving the tree, and only that", () => {
+		const tree = new TreeDoc(new Y.Doc());
+		tree.ensureNote("weg.md");
+		expect(tree.remove("weg.md")).toBe(true);
+		expect(tree.remove("weg.md")).toBe(false);
+		expect(tree.entries().size).toBe(0);
+	});
+
+	it("tells a watcher what appeared, what left, and both halves of a move", () => {
+		const tree = new TreeDoc(new Y.Doc());
+		const seen: string[] = [];
+		const stop = tree.onChange((change) => {
+			for (const path of change.added.keys()) seen.push(`+${path}`);
+			for (const path of change.removed.keys()) seen.push(`-${path}`);
+		});
+
+		const id = tree.ensureNote("a.md");
+		tree.move("a.md", "b.md");
+		tree.remove("b.md");
+		expect(seen).toEqual(["+a.md", "+b.md", "-a.md", "-b.md"]);
+		expect(id).toBeTruthy();
+
+		stop();
+		tree.ensureNote("stil.md");
+		expect(seen).toHaveLength(4);
+	});
+
+	it("two devices' tree edits converge to one map", () => {
+		const docA = new Y.Doc();
+		const docB = new Y.Doc();
+		const treeA = new TreeDoc(docA);
+		const treeB = new TreeDoc(docB);
+
+		const idA = treeA.ensureNote("van-a.md");
+		const idB = treeB.ensureNote("van-b.md");
+
+		// The wire, by hand: exchange updates both ways.
+		Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA));
+		Y.applyUpdate(docA, Y.encodeStateAsUpdate(docB));
+
+		expect(treeA.entries()).toEqual(treeB.entries());
+		expect(treeA.docIdFor("van-b.md")).toBe(idB);
+		expect(treeB.docIdFor("van-a.md")).toBe(idA);
+	});
+
+	it("never lets a path leave the vault", () => {
+		const tree = new TreeDoc(new Y.Doc());
+		expect(() => tree.ensureNote("../buiten.md")).toThrow(/never leaves/);
+		expect(normalize("a\\b\\c.md")).toBe("a/b/c.md");
+	});
+});

--- a/__tests__/knap/VaultBinding.test.ts
+++ b/__tests__/knap/VaultBinding.test.ts
@@ -1,0 +1,231 @@
+/**
+ * The binding engine, on real Yjs docs and an in-memory file store.
+ *
+ * Two devices hang off one hub that relays updates the way the server
+ * does, so every claim about convergence is a claim about two bindings
+ * ending up with the same files. The file store fires events for the
+ * binding's own writes too, exactly like Obsidian's vault does, which is
+ * what makes the no-echo tests honest.
+ */
+
+import * as Y from "yjs";
+
+import { TreeDoc } from "../../src/knap/TreeDoc";
+import {
+	FileEvent,
+	FileStore,
+	VaultBinding,
+	VaultDocs,
+	splice,
+} from "../../src/knap/VaultBinding";
+
+class MemoryFiles implements FileStore {
+	map = new Map<string, string>();
+	listeners: ((event: FileEvent) => void)[] = [];
+	writes = 0;
+
+	async read(path: string): Promise<string | null> {
+		return this.map.has(path) ? (this.map.get(path) as string) : null;
+	}
+	async write(path: string, text: string): Promise<void> {
+		const existed = this.map.has(path);
+		this.map.set(path, text);
+		this.writes++;
+		this.emit({ type: existed ? "modify" : "create", path });
+	}
+	async remove(path: string): Promise<void> {
+		this.map.delete(path);
+		this.emit({ type: "delete", path });
+	}
+	async rename(from: string, to: string): Promise<void> {
+		const text = this.map.get(from) ?? "";
+		this.map.delete(from);
+		this.map.set(to, text);
+		this.emit({ type: "rename", path: to, oldPath: from });
+	}
+	async listNotes(): Promise<string[]> {
+		return [...this.map.keys()].filter((p) => p.endsWith(".md"));
+	}
+	onChange(callback: (event: FileEvent) => void): () => void {
+		this.listeners.push(callback);
+		return () => {
+			this.listeners = this.listeners.filter((l) => l !== callback);
+		};
+	}
+	emit(event: FileEvent): void {
+		for (const listener of [...this.listeners]) listener(event);
+	}
+}
+
+/** Relays updates between per-device docs, the way the server would. */
+class Hub {
+	private byId = new Map<string, Y.Doc[]>();
+
+	device(): VaultDocs {
+		const mine = new Map<string, { doc: Y.Doc; synced: Promise<void> }>();
+		let tree: TreeDoc | null = null;
+		const open = (docId: string) => {
+			let entry = mine.get(docId);
+			if (!entry) {
+				const doc = new Y.Doc();
+				const peers = this.byId.get(docId) ?? [];
+				for (const peer of peers) {
+					Y.applyUpdate(doc, Y.encodeStateAsUpdate(peer));
+					Y.applyUpdate(peer, Y.encodeStateAsUpdate(doc));
+				}
+				const relay = (source: Y.Doc, targets: () => Y.Doc[]) => {
+					source.on("update", (update: Uint8Array, origin: unknown) => {
+						if (origin === "hub") return;
+						for (const target of targets()) {
+							if (target !== source) Y.applyUpdate(target, update, "hub");
+						}
+					});
+				};
+				peers.push(doc);
+				this.byId.set(docId, peers);
+				relay(doc, () => this.byId.get(docId) ?? []);
+				entry = { doc, synced: Promise.resolve() };
+				mine.set(docId, entry);
+			}
+			return entry;
+		};
+		return {
+			tree: () => (tree ??= new TreeDoc(open("tree").doc)),
+			note: (docId: string) => open(docId),
+		};
+	}
+}
+
+async function device(hub: Hub, seed: Record<string, string> = {}) {
+	const files = new MemoryFiles();
+	for (const [path, text] of Object.entries(seed)) files.map.set(path, text);
+	const binding = new VaultBinding(files, hub.device(), () => "conflict");
+	await binding.start();
+	return { files, binding };
+}
+
+const settle = async (...bindings: VaultBinding[]) => {
+	// Event chains hop between queues, so settle twice around a microtask turn.
+	for (let round = 0; round < 3; round++) {
+		for (const binding of bindings) await binding.flush();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+};
+
+describe("VaultBinding", () => {
+	it("uploads local notes at link time, and a second device receives them", async () => {
+		const hub = new Hub();
+		const a = await device(hub, { "Notes/plan.md": "# Plan\n" });
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+
+		expect(b.files.map.get("Notes/plan.md")).toBe("# Plan\n");
+	});
+
+	it("downloads remote notes at link time", async () => {
+		const hub = new Hub();
+		const a = await device(hub, { "een.md": "inhoud" });
+		await settle(a.binding);
+		const b = await device(hub);
+		await settle(b.binding);
+
+		expect(b.files.map.get("een.md")).toBe("inhoud");
+	});
+
+	it("a local edit reaches the other device as a merge, not a steamroll", async () => {
+		const hub = new Hub();
+		const a = await device(hub, { "samen.md": "regel1\nregel2\nregel3\n" });
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+
+		// Both devices edit different lines of the same note, "offline".
+		await a.files.write("samen.md", "regel1 door A\nregel2\nregel3\n");
+		await settle(a.binding, b.binding);
+		await b.files.write("samen.md", "regel1 door A\nregel2\nregel3 door B\n");
+		await settle(a.binding, b.binding);
+
+		expect(a.files.map.get("samen.md")).toBe("regel1 door A\nregel2\nregel3 door B\n");
+		expect(a.files.map.get("samen.md")).toBe(b.files.map.get("samen.md"));
+	});
+
+	it("a rename travels as a tree move and the other device follows", async () => {
+		const hub = new Hub();
+		const a = await device(hub, { "oud.md": "tekst" });
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+
+		await a.files.rename("oud.md", "Archief/nieuw.md");
+		await settle(a.binding, b.binding);
+
+		expect(b.files.map.has("oud.md")).toBe(false);
+		expect(b.files.map.get("Archief/nieuw.md")).toBe("tekst");
+	});
+
+	it("a delete leaves the tree and the other device's disk", async () => {
+		const hub = new Hub();
+		const a = await device(hub, { "weg.md": "x" });
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+
+		await a.files.remove("weg.md");
+		await settle(a.binding, b.binding);
+
+		expect(b.files.map.has("weg.md")).toBe(false);
+	});
+
+	it("link-time conflict keeps the cloud text and saves the local text beside it", async () => {
+		const hub = new Hub();
+		const a = await device(hub, { "nota.md": "cloudversie" });
+		await settle(a.binding);
+
+		const b = await device(hub, { "nota.md": "lokale versie" });
+		await settle(a.binding, b.binding);
+
+		expect(b.files.map.get("nota.md")).toBe("cloudversie");
+		expect(b.files.map.get("nota (conflict).md")).toBe("lokale versie");
+		// The conflict copy is a new note like any other: it syncs too.
+		expect(a.files.map.get("nota (conflict).md")).toBe("lokale versie");
+	});
+
+	it("its own writes do not echo", async () => {
+		const hub = new Hub();
+		const a = await device(hub, { "stil.md": "rust" });
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+
+		const before = { a: a.files.writes, b: b.files.writes };
+		await settle(a.binding, b.binding);
+		await settle(a.binding, b.binding);
+		expect(a.files.writes).toBe(before.a);
+		expect(b.files.writes).toBe(before.b);
+	});
+
+	it("only markdown is bound; other files stay local", async () => {
+		const hub = new Hub();
+		const a = await device(hub, { "foto.png": "bytes", "echt.md": "note" });
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+
+		expect(b.files.map.has("echt.md")).toBe(true);
+		expect(b.files.map.has("foto.png")).toBe(false);
+	});
+});
+
+describe("splice", () => {
+	it("touches only the changed range", () => {
+		const doc = new Y.Doc();
+		const text = doc.getText("content");
+		text.insert(0, "aaa MIDDEN zzz");
+		splice(text, "aaa MIDDEN zzz", "aaa NIEUW zzz", doc);
+		expect(text.toString()).toBe("aaa NIEUW zzz");
+	});
+
+	it("survives emoji and accents on UTF-16 boundaries", () => {
+		const doc = new Y.Doc();
+		const text = doc.getText("content");
+		const before = "café ☕ plan 🚀 einde";
+		text.insert(0, before);
+		splice(text, before, "café ☕ plan 🚀🚀 einde", doc);
+		expect(text.toString()).toBe("café ☕ plan 🚀🚀 einde");
+	});
+});

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -148,6 +148,10 @@ const context = await esbuild.context({
 		AUTH_URL: `"${authUrl}"`,
 		CONTROL_PLANE_URL: JSON.stringify(controlPlaneUrl),
 		PANEL_URL: JSON.stringify(panelUrl),
+		// The rebuild's beta switch (src/knap/ObsidianKnap.ts): empty in every
+		// ordinary build, set via the environment to point one test build at
+		// the new server. No screen ever offers a server field (ADR-0033).
+		KNAP_SERVER_URL: JSON.stringify(process.env.KNAP_SERVER_URL || ""),
 		REPOSITORY: `"pantalytics/knap-obsidian"`,
 	},
 	treeShaking: true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,6 +30,8 @@ module.exports = {
         // Knap's own page, behind the Dashboard button. A test address for the
         // same reason as the line above.
         "PANEL_URL": "https://knap.test/sync",
+        // The rebuild's beta switch: off under jest, like every ordinary build.
+        "KNAP_SERVER_URL": "",
     },
 	transform: {
 		".ts": [

--- a/src/knap/KnapServer.ts
+++ b/src/knap/KnapServer.ts
@@ -1,0 +1,139 @@
+/**
+ * The Knap server, as the plugin speaks to it (ADR-0073, the rebuild).
+ *
+ * One server, known at build time (ADR-0033), and one credential: the token
+ * the sign-in flow minted. Four conversations, and nothing else:
+ *
+ * - the sign-in exchange: a one-time code in, the plugin's token out
+ * - which cloud vaults this account may open, and what it may do there
+ * - the address of a document's sync socket
+ * - attachments, up and down, as plain bytes
+ *
+ * There is no per-document token, no rate-limited token route and no
+ * control plane behind this: the server that answers is the server that
+ * holds the documents, and the whole authorisation story happened when the
+ * socket or the request presented the one token.
+ *
+ * `fetch` is injected so tests hand in a fake and Obsidian hands in its
+ * own; the module never touches a global.
+ */
+
+export interface CloudVault {
+	id: string;
+	name: string;
+	mayWrite: boolean;
+}
+
+export type Fetch = (url: string, init?: RequestInit) => Promise<Response>;
+
+export class KnapServerError extends Error {
+	constructor(
+		message: string,
+		public readonly status: number,
+	) {
+		super(message);
+	}
+}
+
+export class KnapServer {
+	constructor(
+		private readonly baseUrl: string,
+		private readonly fetchFn: Fetch,
+	) {
+		this.baseUrl = baseUrl.replace(/\/+$/, "");
+	}
+
+	/** Where the sign-in starts: the page the plugin opens in a browser. */
+	signInUrl(): string {
+		return `${this.baseUrl}/auth/plugin/start`;
+	}
+
+	/** Trade the deep link's one-time code for this device's own token. */
+	async exchange(code: string, device: string): Promise<string> {
+		const response = await this.fetchFn(`${this.baseUrl}/auth/plugin/exchange`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ code, device }),
+		});
+		if (!response.ok) {
+			throw new KnapServerError(
+				"This sign-in code was already used or has expired. Sign in again.",
+				response.status,
+			);
+		}
+		const body = (await response.json()) as { token?: string };
+		if (!body.token) {
+			throw new KnapServerError("The server answered without a token.", response.status);
+		}
+		return body.token;
+	}
+
+	/** The cloud vaults this account may open. */
+	async listVaults(token: string): Promise<CloudVault[]> {
+		const response = await this.fetchFn(`${this.baseUrl}/api/vaults`, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		if (response.status === 401) {
+			throw new KnapServerError("Not signed in any more. Sign in again.", 401);
+		}
+		if (!response.ok) {
+			throw new KnapServerError("The server did not answer.", response.status);
+		}
+		const body = (await response.json()) as {
+			vaults: { id: string; name: string; may_write: boolean }[];
+		};
+		return body.vaults.map((v) => ({ id: v.id, name: v.name, mayWrite: v.may_write }));
+	}
+
+	/**
+	 * The socket base for one vault. y-websocket appends `/{docId}` itself,
+	 * so the room name is the document id and nothing else.
+	 */
+	syncUrl(vaultId: string): string {
+		return `${this.baseUrl.replace(/^http/, "ws")}/sync/${encodeURIComponent(vaultId)}`;
+	}
+
+	// -- attachments -------------------------------------------------------
+
+	async uploadFile(
+		token: string,
+		vaultId: string,
+		path: string,
+		content: ArrayBuffer,
+	): Promise<{ sha256: string; size: number }> {
+		const response = await this.fetchFn(this.fileUrl(vaultId, path), {
+			method: "PUT",
+			headers: { Authorization: `Bearer ${token}` },
+			body: content,
+		});
+		if (!response.ok) {
+			throw new KnapServerError("The upload did not land.", response.status);
+		}
+		return (await response.json()) as { sha256: string; size: number };
+	}
+
+	async downloadFile(token: string, vaultId: string, path: string): Promise<ArrayBuffer> {
+		const response = await this.fetchFn(this.fileUrl(vaultId, path), {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		if (!response.ok) {
+			throw new KnapServerError("No file at that path.", response.status);
+		}
+		return await response.arrayBuffer();
+	}
+
+	async deleteFile(token: string, vaultId: string, path: string): Promise<void> {
+		const response = await this.fetchFn(this.fileUrl(vaultId, path), {
+			method: "DELETE",
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		if (!response.ok && response.status !== 404) {
+			throw new KnapServerError("The delete did not land.", response.status);
+		}
+	}
+
+	private fileUrl(vaultId: string, path: string): string {
+		const encoded = path.split("/").map(encodeURIComponent).join("/");
+		return `${this.baseUrl}/files/${encodeURIComponent(vaultId)}/${encoded}`;
+	}
+}

--- a/src/knap/KnapServer.ts
+++ b/src/knap/KnapServer.ts
@@ -24,7 +24,15 @@ export interface CloudVault {
 	mayWrite: boolean;
 }
 
-export type Fetch = (url: string, init?: RequestInit) => Promise<Response>;
+/** The slice of a fetch Response this module reads. requestUrl adapts to it too. */
+export interface HttpAnswer {
+	ok: boolean;
+	status: number;
+	json(): Promise<unknown>;
+	arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export type Fetch = (url: string, init?: RequestInit) => Promise<HttpAnswer>;
 
 export class KnapServerError extends Error {
 	constructor(

--- a/src/knap/KnapSync.ts
+++ b/src/knap/KnapSync.ts
@@ -1,0 +1,135 @@
+/**
+ * The orchestrator: sign-in, the link, and the running binding, as state.
+ *
+ * A local vault is linked to at most one cloud vault, linking replaces
+ * rather than appends, and Unlink ends the link without deleting anything
+ * on either side (ADR-0066, ADR-0047). This class is that sentence as
+ * code: `link` tears down whatever ran before it starts the new binding,
+ * and `unlink` stops the sockets and clears the remembered vault while the
+ * sign-in survives, because the account and the link are different facts.
+ *
+ * Persistence goes through two callbacks rather than a settings object, so
+ * the host (Obsidian's data.json in production, a dict in tests) stays out
+ * of the engine.
+ */
+
+import type { FileStore } from "./VaultBinding";
+import { VaultBinding } from "./VaultBinding";
+import type { CloudVault, Fetch } from "./KnapServer";
+import { KnapServer } from "./KnapServer";
+import { KnapVaultClient } from "./KnapVaultClient";
+import type { WebSocketImpl } from "./KnapVaultClient";
+import { SignInFlow } from "./SignInFlow";
+
+export interface KnapLink {
+	token: string;
+	cloudVaultId: string;
+	cloudVaultName: string;
+}
+
+export interface KnapSyncOptions {
+	serverUrl: string;
+	deviceName: string;
+	fetchFn: Fetch;
+	files: FileStore;
+	load: () => KnapLink | null;
+	save: (value: KnapLink | null) => Promise<void>;
+	/** Injected in tests; Obsidian's platform WebSocket by default. */
+	webSocket?: WebSocketImpl;
+}
+
+export class KnapSync {
+	readonly server: KnapServer;
+	readonly flow: SignInFlow;
+	private client: KnapVaultClient | null = null;
+	private binding: VaultBinding | null = null;
+
+	constructor(private readonly options: KnapSyncOptions) {
+		this.server = new KnapServer(options.serverUrl, options.fetchFn);
+		this.flow = new SignInFlow(this.server, options.deviceName);
+	}
+
+	get linked(): KnapLink | null {
+		const stored = this.options.load();
+		return stored && stored.cloudVaultId ? stored : null;
+	}
+
+	get signedIn(): boolean {
+		return Boolean(this.options.load()?.token);
+	}
+
+	get running(): boolean {
+		return this.binding !== null;
+	}
+
+	/** Sign in: browser out, deep link back, token kept. No link yet. */
+	async signIn(openUrl: (url: string) => void): Promise<void> {
+		const token = await this.flow.begin(openUrl);
+		const previous = this.options.load();
+		await this.options.save({
+			token,
+			cloudVaultId: previous?.cloudVaultId ?? "",
+			cloudVaultName: previous?.cloudVaultName ?? "",
+		});
+	}
+
+	handleDeepLink(params: Record<string, string>): boolean {
+		return this.flow.handleDeepLink(params);
+	}
+
+	async listVaults(): Promise<CloudVault[]> {
+		const stored = this.options.load();
+		if (!stored?.token) {
+			throw new Error("Sign in first.");
+		}
+		return this.server.listVaults(stored.token);
+	}
+
+	/** Link this local vault to one cloud vault. Replaces, never appends. */
+	async link(vault: CloudVault): Promise<void> {
+		const stored = this.options.load();
+		if (!stored?.token) {
+			throw new Error("Sign in first.");
+		}
+		this.stop();
+		await this.options.save({
+			token: stored.token,
+			cloudVaultId: vault.id,
+			cloudVaultName: vault.name,
+		});
+		await this.start();
+	}
+
+	/** End the link. Stops the syncing, deletes nothing on either side. */
+	async unlink(): Promise<void> {
+		this.stop();
+		const stored = this.options.load();
+		if (stored) {
+			await this.options.save({ ...stored, cloudVaultId: "", cloudVaultName: "" });
+		}
+	}
+
+	/** Bring the link up, if there is one. Safe to call at plugin load. */
+	async start(): Promise<void> {
+		const stored = this.linked;
+		if (!stored || this.binding) {
+			return;
+		}
+		this.client = new KnapVaultClient(
+			this.server,
+			stored.cloudVaultId,
+			stored.token,
+			this.options.deviceName,
+			this.options.webSocket,
+		);
+		this.binding = new VaultBinding(this.options.files, this.client);
+		await this.binding.start();
+	}
+
+	stop(): void {
+		this.binding?.stop();
+		this.binding = null;
+		this.client?.destroy();
+		this.client = null;
+	}
+}

--- a/src/knap/KnapVaultClient.ts
+++ b/src/knap/KnapVaultClient.ts
@@ -1,0 +1,109 @@
+/**
+ * One linked cloud vault, live: the tree plus a socket per open document.
+ *
+ * A local vault is linked to at most one cloud vault (ADR-0066), so a
+ * client holds exactly one of these. It keeps the tree document connected
+ * for as long as it exists, because the tree is how creates, moves and
+ * deletes travel; note documents connect when opened and hang around for
+ * reuse. Every socket carries the same one token, and the server does the
+ * whole authorisation story at the door.
+ *
+ * The WebSocket implementation is injected: Obsidian hands in the
+ * platform's, tests hand in `ws`. y-websocket syncs same-process docs over
+ * a BroadcastChannel behind the server's back, which phase 0 caught as a
+ * false pass, so it is off everywhere and the wire is the only path.
+ */
+
+import * as Y from "yjs";
+import { WebsocketProvider } from "y-websocket";
+
+import type { KnapServer } from "./KnapServer";
+import { TREE_DOC_ID, TreeDoc } from "./TreeDoc";
+
+export interface OpenDoc {
+	doc: Y.Doc;
+	provider: WebsocketProvider;
+	/** Resolves once the first sync with the server has completed. */
+	synced: Promise<void>;
+}
+
+/**
+ * y-websocket types its WebSocketPolyfill option as the DOM's WebSocket
+ * constructor; ws's client satisfies the wire but not that lib typing, so
+ * the seam is typed by shape rather than by name.
+ */
+type WebSocketImpl = { new (url: string | URL, protocols?: string | string[]): unknown };
+
+export class KnapVaultClient {
+	private open = new Map<string, OpenDoc>();
+	private treeDoc: TreeDoc | null = null;
+
+	constructor(
+		private readonly server: KnapServer,
+		private readonly vaultId: string,
+		private readonly token: string,
+		private readonly deviceName: string,
+		private readonly webSocket?: WebSocketImpl,
+	) {}
+
+	/** The vault's tree, connected. The first call opens the socket. */
+	tree(): TreeDoc {
+		if (!this.treeDoc) {
+			this.treeDoc = new TreeDoc(this.openDoc(TREE_DOC_ID).doc);
+		}
+		return this.treeDoc;
+	}
+
+	/** A note's live document, by id. Reuses an open socket. */
+	note(docId: string): OpenDoc {
+		return this.openDoc(docId);
+	}
+
+	/** The note's text as the shared Text the server reads. */
+	contentOf(entry: OpenDoc): Y.Text {
+		return entry.doc.getText("content");
+	}
+
+	private openDoc(docId: string): OpenDoc {
+		const existing = this.open.get(docId);
+		if (existing) return existing;
+
+		const doc = new Y.Doc();
+		const provider = new WebsocketProvider(this.server.syncUrl(this.vaultId), docId, doc, {
+			params: { token: this.token, device: this.deviceName },
+			WebSocketPolyfill: this.webSocket as typeof WebSocket | undefined,
+			disableBc: true,
+		});
+		provider.awareness.setLocalStateField("device", { name: this.deviceName });
+
+		const synced = new Promise<void>((resolve) => {
+			if (provider.synced) {
+				resolve();
+				return;
+			}
+			provider.once("synced", () => resolve());
+		});
+
+		const entry: OpenDoc = { doc, provider, synced };
+		this.open.set(docId, entry);
+		return entry;
+	}
+
+	/** Close one document's socket, keeping the vault linked. */
+	close(docId: string): void {
+		const entry = this.open.get(docId);
+		if (!entry) return;
+		this.open.delete(docId);
+		if (this.treeDoc && docId === TREE_DOC_ID) {
+			this.treeDoc = null;
+		}
+		entry.provider.destroy();
+	}
+
+	/** Unlink or shutdown: every socket down, nothing deleted anywhere. */
+	destroy(): void {
+		for (const docId of [...this.open.keys()]) {
+			this.close(docId);
+		}
+	}
+}

--- a/src/knap/KnapVaultClient.ts
+++ b/src/knap/KnapVaultClient.ts
@@ -32,7 +32,7 @@ export interface OpenDoc {
  * constructor; ws's client satisfies the wire but not that lib typing, so
  * the seam is typed by shape rather than by name.
  */
-type WebSocketImpl = { new (url: string | URL, protocols?: string | string[]): unknown };
+export type WebSocketImpl = { new (url: string | URL, protocols?: string | string[]): unknown };
 
 export class KnapVaultClient {
 	private open = new Map<string, OpenDoc>();

--- a/src/knap/ObsidianFileStore.ts
+++ b/src/knap/ObsidianFileStore.ts
@@ -1,0 +1,87 @@
+/**
+ * Obsidian's vault, seen through the binding's FileStore seam.
+ *
+ * Thin on purpose: every rule lives in VaultBinding where jest can reach
+ * it, and this adapter only translates. Two translations are worth
+ * naming. Obsidian fires events for programmatic writes exactly like for
+ * keystrokes, and the binding is idempotent precisely so this adapter does
+ * not have to tell them apart. And Obsidian's `create` events replay for
+ * every existing file at vault load, so the adapter starts listening only
+ * when told, after the link-time reconcile has the tree.
+ */
+
+import { FileManager, normalizePath, TAbstractFile, TFile, Vault } from "obsidian";
+
+import type { FileEvent, FileStore } from "./VaultBinding";
+
+export class ObsidianFileStore implements FileStore {
+	constructor(
+		private readonly vault: Vault,
+		private readonly fileManager: FileManager,
+	) {}
+
+	private file(path: string): TFile | null {
+		const found = this.vault.getAbstractFileByPath(normalizePath(path));
+		return found instanceof TFile ? found : null;
+	}
+
+	async read(path: string): Promise<string | null> {
+		const file = this.file(path);
+		return file ? await this.vault.read(file) : null;
+	}
+
+	async write(path: string, text: string): Promise<void> {
+		const clean = normalizePath(path);
+		const existing = this.file(clean);
+		if (existing) {
+			await this.vault.modify(existing, text);
+			return;
+		}
+		const parent = clean.split("/").slice(0, -1).join("/");
+		if (parent && !this.vault.getAbstractFileByPath(parent)) {
+			await this.vault.createFolder(parent).catch(() => undefined);
+		}
+		await this.vault.create(clean, text);
+	}
+
+	async remove(path: string): Promise<void> {
+		const file = this.file(path);
+		if (file) {
+			// The user's own deletion preference, so a remote delete stays as
+			// recoverable here as one they made themselves.
+			await this.fileManager.trashFile(file);
+		}
+	}
+
+	async rename(from: string, to: string): Promise<void> {
+		const file = this.file(from);
+		if (file) {
+			await this.vault.rename(file, normalizePath(to));
+		}
+	}
+
+	async listNotes(): Promise<string[]> {
+		return this.vault
+			.getFiles()
+			.filter((file) => file.extension === "md")
+			.map((file) => file.path);
+	}
+
+	onChange(callback: (event: FileEvent) => void): () => void {
+		const toEvent = (type: FileEvent["type"]) => (file: TAbstractFile, oldPath?: string) => {
+			if (file instanceof TFile && file.extension === "md") {
+				callback({ type, path: file.path, oldPath });
+			}
+		};
+		const created = this.vault.on("create", toEvent("create"));
+		const modified = this.vault.on("modify", toEvent("modify"));
+		const deleted = this.vault.on("delete", toEvent("delete"));
+		const renamed = this.vault.on("rename", toEvent("rename"));
+		return () => {
+			this.vault.offref(created);
+			this.vault.offref(modified);
+			this.vault.offref(deleted);
+			this.vault.offref(renamed);
+		};
+	}
+}

--- a/src/knap/ObsidianKnap.ts
+++ b/src/knap/ObsidianKnap.ts
@@ -1,0 +1,127 @@
+/**
+ * Where the rebuilt client meets Obsidian, behind the build-time switch.
+ *
+ * `KNAP_SERVER_URL` is an esbuild define, empty in every ordinary build.
+ * Empty means this whole file registers nothing and the plugin behaves
+ * exactly as before; set, it adds the protocol handler and three commands,
+ * and one test vault can point at the new server while everything else
+ * stays where it is. That is the switch phase 2's plan asks for, and it is
+ * build-time on purpose: no screen offers a server field (ADR-0033).
+ *
+ * The screen words hold: sign in, cloud vault, link, unlink, sync. Nothing
+ * here says server, relay or share to a person.
+ */
+
+import { Notice, Platform, Plugin, SuggestModal } from "obsidian";
+
+import type { CloudVault } from "./KnapServer";
+import { KnapSync } from "./KnapSync";
+import type { KnapLink } from "./KnapSync";
+import { ObsidianFileStore } from "./ObsidianFileStore";
+import { SIGNIN_ACTION } from "./SignInFlow";
+import { obsidianFetch } from "./obsidianFetch";
+
+declare const KNAP_SERVER_URL: string;
+
+/** What ObsidianKnap needs from the plugin: commands, the handler, settings. */
+export interface KnapHost extends Plugin {
+	getKnapLink(): KnapLink | null;
+	saveKnapLink(value: KnapLink | null): Promise<void>;
+}
+
+class CloudVaultPickModal extends SuggestModal<CloudVault> {
+	constructor(
+		host: KnapHost,
+		private readonly vaults: CloudVault[],
+		private readonly onPick: (vault: CloudVault) => void,
+	) {
+		super(host.app);
+		this.setPlaceholder("Which cloud vault syncs with this one?");
+	}
+
+	getSuggestions(query: string): CloudVault[] {
+		const needle = query.toLowerCase();
+		return this.vaults.filter((vault) => vault.name.toLowerCase().includes(needle));
+	}
+
+	renderSuggestion(vault: CloudVault, el: HTMLElement): void {
+		el.createDiv({ text: vault.name });
+		el.createEl("small", { text: vault.mayWrite ? "you can edit" : "you can read" });
+	}
+
+	onChooseSuggestion(vault: CloudVault): void {
+		this.onPick(vault);
+	}
+}
+
+/**
+ * Wire the beta in. Returns null (and does nothing) when the build carries
+ * no server address, which is every build but the beta's.
+ */
+export function registerKnapBeta(host: KnapHost): KnapSync | null {
+	const serverUrl = typeof KNAP_SERVER_URL === "string" ? KNAP_SERVER_URL : "";
+	if (!serverUrl) {
+		return null;
+	}
+
+	const device = `${host.app.vault.getName()} on ${Platform.isMobileApp ? "phone" : "desktop"}`;
+	const sync = new KnapSync({
+		serverUrl,
+		deviceName: device,
+		fetchFn: obsidianFetch,
+		files: new ObsidianFileStore(host.app.vault, host.app.fileManager),
+		load: () => host.getKnapLink(),
+		save: (value) => host.saveKnapLink(value),
+	});
+
+	host.registerObsidianProtocolHandler(SIGNIN_ACTION, (params) => {
+		sync.handleDeepLink(params as unknown as Record<string, string>);
+	});
+
+	host.addCommand({
+		id: "knap-beta-sign-in",
+		name: "Sign in (beta)",
+		callback: () => {
+			sync
+				.signIn((url) => window.open(url))
+				.then(() => new Notice("Signed in. Now link this vault to a cloud vault."))
+				.catch((error: Error) => new Notice(error.message));
+		},
+	});
+
+	host.addCommand({
+		id: "knap-beta-link-vault",
+		name: "Link this vault to a cloud vault (beta)",
+		callback: () => {
+			sync
+				.listVaults()
+				.then((vaults) => {
+					if (!vaults.length) {
+						new Notice("No cloud vaults yet. Make one in the Knap panel first.");
+						return;
+					}
+					new CloudVaultPickModal(host, vaults, (vault) => {
+						sync
+							.link(vault)
+							.then(() => new Notice(`Linked. This vault now syncs with ${vault.name}.`))
+							.catch((error: Error) => new Notice(error.message));
+					}).open();
+				})
+				.catch((error: Error) => new Notice(error.message));
+		},
+	});
+
+	host.addCommand({
+		id: "knap-beta-unlink",
+		name: "Unlink from the cloud vault (beta)",
+		callback: () => {
+			void sync.unlink().then(() => new Notice("Unlinked. Nothing was deleted, anywhere."));
+		},
+	});
+
+	// A vault that was linked before this start comes back up on its own.
+	void sync.start().catch(() => {
+		new Notice("Knap could not reach your cloud vault. It will retry when you sign in again.");
+	});
+	return sync;
+}

--- a/src/knap/SignInFlow.ts
+++ b/src/knap/SignInFlow.ts
@@ -1,0 +1,84 @@
+/**
+ * The sign-in, from the plugin's side: open a browser, catch a deep link,
+ * trade the code, hold a token.
+ *
+ * The server does the OAuth (it is the client at the issuer); what comes
+ * back through `obsidian://synced-vaults/signin` is a one-time handoff
+ * code, never a credential, because a deep-link URL survives in browser
+ * history. The exchange for the real token happens over TLS, exactly once.
+ *
+ * The action string keeps the `synced-vaults` identifier: the plugin's id
+ * moved once and is staying (ADR-0042), rebuild or no rebuild.
+ */
+
+import type { KnapServer } from "./KnapServer";
+
+/** Registered with registerObsidianProtocolHandler at plugin load. */
+export const SIGNIN_ACTION = "synced-vaults/signin";
+
+/** How long a person gets to finish signing in before the flow gives up. */
+const SIGNIN_TIMEOUT_MS = 10 * 60 * 1000;
+
+type OpenUrl = (url: string) => void;
+
+interface Pending {
+	resolve: (token: string) => void;
+	reject: (error: Error) => void;
+	timer: number;
+}
+
+export class SignInFlow {
+	private pending: Pending | null = null;
+
+	constructor(
+		private readonly server: KnapServer,
+		private readonly deviceName: string,
+	) {}
+
+	/**
+	 * Start the flow: open the browser, and settle when the deep link comes
+	 * back and the exchange lands. One flow at a time; a second click
+	 * restarts rather than stacking.
+	 */
+	begin(openUrl: OpenUrl): Promise<string> {
+		this.cancel(new Error("A newer sign-in replaced this one."));
+		openUrl(this.server.signInUrl());
+		return new Promise<string>((resolve, reject) => {
+			const timer = window.setTimeout(() => {
+				this.pending = null;
+				reject(new Error("The sign-in took too long. Try again."));
+			}, SIGNIN_TIMEOUT_MS);
+			this.pending = { resolve, reject, timer };
+		});
+	}
+
+	/**
+	 * The protocol handler's half. Returns true when the callback fed a
+	 * waiting flow, so a stray link is telling from a real one.
+	 */
+	handleDeepLink(params: Record<string, string>): boolean {
+		const pending = this.pending;
+		if (!pending) return false;
+		this.pending = null;
+		window.clearTimeout(pending.timer);
+
+		const code = params.code ?? "";
+		if (!code) {
+			pending.reject(new Error("The sign-in came back without a code. Try again."));
+			return true;
+		}
+		this.server
+			.exchange(code, this.deviceName)
+			.then((token) => pending.resolve(token))
+			.catch((error: Error) => pending.reject(error));
+		return true;
+	}
+
+	cancel(reason: Error): void {
+		const pending = this.pending;
+		if (!pending) return;
+		this.pending = null;
+		window.clearTimeout(pending.timer);
+		pending.reject(reason);
+	}
+}

--- a/src/knap/TreeDoc.ts
+++ b/src/knap/TreeDoc.ts
@@ -1,0 +1,123 @@
+/**
+ * The tree document: the one map from vault path to document id.
+ *
+ * Per cloud vault the server reserves the document id `tree`, holding a
+ * Y.Map named `files`. It is the whole answer to "which note is which
+ * document": a move is a change to this map and touches no note, a delete
+ * is a removal from it, and a note that is not in it does not exist as far
+ * as any device or the server's markdown mirror is concerned.
+ *
+ * This module wraps that map for the plugin. It never talks to the network:
+ * the caller binds the underlying Y.Doc to a socket, and this class stays
+ * honest whether the doc is live, offline, or in a test.
+ */
+
+import * as Y from "yjs";
+
+export const TREE_DOC_ID = "tree";
+const FILES = "files";
+
+export interface TreeChange {
+	added: Map<string, string>;
+	removed: Map<string, string>;
+}
+
+export class TreeDoc {
+	private readonly files: Y.Map<string>;
+
+	constructor(readonly doc: Y.Doc) {
+		this.files = doc.getMap<string>(FILES);
+	}
+
+	/** path -> document id, a plain snapshot. */
+	entries(): Map<string, string> {
+		return new Map(this.files.entries());
+	}
+
+	docIdFor(path: string): string | undefined {
+		return this.files.get(normalize(path));
+	}
+
+	pathFor(docId: string): string | undefined {
+		for (const [path, id] of this.files.entries()) {
+			if (id === docId) return path;
+		}
+		return undefined;
+	}
+
+	/**
+	 * The document id for a note, minting one if the note is new.
+	 * Deciding ids client-side is what lets a device create notes offline;
+	 * a UUID collision is the kind of luck nobody has.
+	 */
+	ensureNote(path: string): string {
+		const clean = normalize(path);
+		const existing = this.files.get(clean);
+		if (existing) return existing;
+		const docId = crypto.randomUUID().replace(/-/g, "");
+		this.files.set(clean, docId);
+		return docId;
+	}
+
+	/** A move is a tree change and nothing else. The id survives it. */
+	move(from: string, to: string): string {
+		const clean = normalize(from);
+		const docId = this.files.get(clean);
+		if (!docId) {
+			throw new Error(`No note at ${from} to move.`);
+		}
+		this.doc.transact(() => {
+			this.files.delete(clean);
+			this.files.set(normalize(to), docId);
+		});
+		return docId;
+	}
+
+	/** Leaving the tree is what deletion is. History stays on the server. */
+	remove(path: string): boolean {
+		const clean = normalize(path);
+		if (!this.files.has(clean)) return false;
+		this.files.delete(clean);
+		return true;
+	}
+
+	/**
+	 * Watch the tree. The callback gets what appeared and what left; a moved
+	 * note shows up in both, under the same id. Returns an unsubscribe.
+	 */
+	onChange(callback: (change: TreeChange) => void): () => void {
+		const observer = (event: Y.YMapEvent<string>) => {
+			const added = new Map<string, string>();
+			const removed = new Map<string, string>();
+			for (const [key, change] of event.changes.keys) {
+				if (change.action === "add") {
+					added.set(key, this.files.get(key) as string);
+				} else if (change.action === "delete") {
+					removed.set(key, change.oldValue as string);
+				} else {
+					removed.set(key, change.oldValue as string);
+					added.set(key, this.files.get(key) as string);
+				}
+			}
+			callback({ added, removed });
+		};
+		this.files.observe(observer);
+		return () => this.files.unobserve(observer);
+	}
+}
+
+/**
+ * One spelling per path: forward slashes, no leading slash, no `.` segments.
+ * The server refuses escapes on its side too; normalizing here keeps two
+ * devices from writing `Notes/a.md` and `./Notes/a.md` as different notes.
+ */
+export function normalize(path: string): string {
+	const parts = path
+		.replace(/\\/g, "/")
+		.split("/")
+		.filter((part) => part !== "" && part !== ".");
+	if (parts.some((part) => part === "..")) {
+		throw new Error("A vault path never leaves the vault.");
+	}
+	return parts.join("/");
+}

--- a/src/knap/VaultBinding.ts
+++ b/src/knap/VaultBinding.ts
@@ -1,0 +1,264 @@
+/**
+ * The binding: local files on one side, live documents on the other.
+ *
+ * This is the engine of phase 2, and it is deliberately blind to both ends.
+ * Files come through a `FileStore` (Obsidian in production, memory in
+ * tests), documents through a `VaultDocs` (a `KnapVaultClient` in
+ * production, linked in-memory docs in tests), so every rule in here runs
+ * under jest and the same code ships.
+ *
+ * The rules, and there are few:
+ *
+ * - A local edit becomes a minimal splice on the note's Text: common prefix
+ *   and suffix stay untouched, so concurrent edits elsewhere in the note
+ *   merge instead of being steamrolled. Never a replacement (ADR-0010).
+ * - A remote edit becomes a file write, and a tree change becomes a create,
+ *   a rename or a removal on disk.
+ * - Both directions are idempotent instead of bookkept: an event that finds
+ *   file and document already equal does nothing, which is what breaks
+ *   every echo loop without a ledger of "writes that were ours".
+ * - At link time nothing is guessed: local-only notes upload, remote-only
+ *   notes download, and a note that exists on both sides with different
+ *   text keeps the cloud text while the local text survives as a conflict
+ *   copy beside it. Nothing is ever silently lost.
+ */
+
+import * as Y from "yjs";
+
+import { buildConflictCopyPath } from "../conflictCopyPath";
+import { TreeDoc, normalize } from "./TreeDoc";
+
+export interface FileEvent {
+	type: "create" | "modify" | "delete" | "rename";
+	path: string;
+	oldPath?: string;
+}
+
+/** What the binding needs from a vault's files. Obsidian adapts to this. */
+export interface FileStore {
+	read(path: string): Promise<string | null>;
+	write(path: string, text: string): Promise<void>;
+	remove(path: string): Promise<void>;
+	rename(from: string, to: string): Promise<void>;
+	listNotes(): Promise<string[]>;
+	onChange(callback: (event: FileEvent) => void): () => void;
+}
+
+/** What the binding needs from the wire. KnapVaultClient satisfies it. */
+export interface VaultDocs {
+	tree(): TreeDoc;
+	note(docId: string): { doc: Y.Doc; synced: Promise<void> };
+}
+
+const CONTENT = "content";
+
+/** Y.Text implements toString; the lint rule cannot see that through AbstractType. */
+function textOf(content: Y.Text): string {
+	// eslint-disable-next-line @typescript-eslint/no-base-to-string -- Y.Text has a real toString
+	return content.toString();
+}
+
+export class VaultBinding {
+	private stopFileEvents: (() => void) | null = null;
+	private stopTreeEvents: (() => void) | null = null;
+	private noteObservers = new Map<string, () => void>();
+	private queue: Promise<void> = Promise.resolve();
+
+	constructor(
+		private readonly files: FileStore,
+		private readonly docs: VaultDocs,
+		private readonly conflictLabel = () => `conflict ${new Date().toISOString().slice(0, 10)}`,
+	) {}
+
+	/**
+	 * Link: reconcile both sides once, then follow both event streams.
+	 * Everything runs through one queue, so a burst of events cannot
+	 * interleave two half-finished reconciliations.
+	 */
+	async start(): Promise<void> {
+		await this.enqueue(() => this.reconcileAll());
+		this.stopFileEvents = this.files.onChange((event) => {
+			void this.enqueue(() => this.onFileEvent(event));
+		});
+		this.stopTreeEvents = this.docs.tree().onChange((change) => {
+			void this.enqueue(async () => {
+				for (const [path, docId] of change.added) {
+					await this.pullNote(path, docId);
+				}
+				for (const [path, docId] of change.removed) {
+					// A move announces itself as removed+added under one id;
+					// the added half already wrote the new file.
+					if (this.docs.tree().pathFor(docId) === undefined) {
+						await this.files.remove(path);
+						this.unobserveNote(docId);
+					} else {
+						await this.files.remove(path);
+					}
+				}
+			});
+		});
+	}
+
+	stop(): void {
+		this.stopFileEvents?.();
+		this.stopTreeEvents?.();
+		for (const stop of this.noteObservers.values()) stop();
+		this.noteObservers.clear();
+	}
+
+	/** Wait for everything queued so far; tests and shutdown use it. */
+	flush(): Promise<void> {
+		return this.enqueue(async () => undefined);
+	}
+
+	private enqueue(work: () => Promise<void>): Promise<void> {
+		this.queue = this.queue.then(work, work);
+		return this.queue;
+	}
+
+	// -- link time -----------------------------------------------------------
+
+	private async reconcileAll(): Promise<void> {
+		const tree = this.docs.tree();
+		const local = new Set((await this.files.listNotes()).map(normalize));
+		const remote = tree.entries();
+
+		for (const path of local) {
+			if (!remote.has(path)) {
+				await this.pushNote(path);
+			}
+		}
+		for (const [path, docId] of remote) {
+			if (!local.has(path)) {
+				await this.pullNote(path, docId);
+			} else {
+				await this.mergeAtLink(path, docId);
+			}
+		}
+	}
+
+	private async mergeAtLink(path: string, docId: string): Promise<void> {
+		const fileText = (await this.files.read(path)) ?? "";
+		const { doc, synced } = this.docs.note(docId);
+		await synced;
+		const docText = textOf(doc.getText(CONTENT));
+
+		if (docText === fileText) {
+			this.observeNote(path, docId);
+			return;
+		}
+		if (docText === "") {
+			// A minted note nobody typed in yet: the local text is the note.
+			splice(doc.getText(CONTENT), "", fileText, doc);
+		} else {
+			// Both sides wrote. The cloud text wins the path; the local text
+			// survives beside it, named for what happened, and pushed
+			// explicitly because link-time runs before the event stream is on.
+			const copy = buildConflictCopyPath(path, this.conflictLabel());
+			await this.files.write(copy, fileText);
+			await this.pushNote(copy);
+			await this.files.write(path, docText);
+		}
+		this.observeNote(path, docId);
+	}
+
+	// -- local to remote ------------------------------------------------------
+
+	private async onFileEvent(event: FileEvent): Promise<void> {
+		const tree = this.docs.tree();
+		if (event.type === "rename" && event.oldPath) {
+			const from = normalize(event.oldPath);
+			if (tree.docIdFor(from) !== undefined) {
+				tree.move(from, event.path);
+				return;
+			}
+			await this.pushNote(event.path);
+			return;
+		}
+		if (event.type === "delete") {
+			const path = normalize(event.path);
+			const docId = tree.docIdFor(path);
+			tree.remove(path);
+			if (docId) this.unobserveNote(docId);
+			return;
+		}
+		// create and modify converge: bring the document to the file's text.
+		await this.pushNote(event.path);
+	}
+
+	private async pushNote(path: string): Promise<void> {
+		const clean = normalize(path);
+		if (!clean.endsWith(".md")) return;
+		const text = await this.files.read(clean);
+		if (text === null) return; // gone again before we got to it
+
+		const tree = this.docs.tree();
+		const docId = tree.ensureNote(clean);
+		const { doc, synced } = this.docs.note(docId);
+		await synced;
+		const content = doc.getText(CONTENT);
+		if (textOf(content) !== text) {
+			splice(content, textOf(content), text, doc);
+		}
+		this.observeNote(clean, docId);
+	}
+
+	// -- remote to local ------------------------------------------------------
+
+	private async pullNote(path: string, docId: string): Promise<void> {
+		const { doc, synced } = this.docs.note(docId);
+		await synced;
+		const text = textOf(doc.getText(CONTENT));
+		if ((await this.files.read(path)) !== text) {
+			await this.files.write(path, text);
+		}
+		this.observeNote(path, docId);
+	}
+
+	private observeNote(path: string, docId: string): void {
+		if (this.noteObservers.has(docId)) return;
+		const { doc } = this.docs.note(docId);
+		const content = doc.getText(CONTENT);
+		const observer = () => {
+			void this.enqueue(async () => {
+				const current = this.docs.tree().pathFor(docId) ?? path;
+				const text = textOf(content);
+				if ((await this.files.read(current)) !== text) {
+					await this.files.write(current, text);
+				}
+			});
+		};
+		content.observe(observer);
+		this.noteObservers.set(docId, () => content.unobserve(observer));
+	}
+
+	private unobserveNote(docId: string): void {
+		this.noteObservers.get(docId)?.();
+		this.noteObservers.delete(docId);
+	}
+}
+
+/**
+ * Bring a Y.Text from `oldText` to `newText` as one minimal splice.
+ * Indices are UTF-16 code units, which is what both JS strings and Y.Text
+ * count, so the boundary arithmetic is one system end to end.
+ */
+export function splice(content: Y.Text, oldText: string, newText: string, doc: Y.Doc): void {
+	if (oldText === newText) return;
+	let prefix = 0;
+	const limit = Math.min(oldText.length, newText.length);
+	while (prefix < limit && oldText[prefix] === newText[prefix]) prefix++;
+	let suffix = 0;
+	while (
+		suffix < limit - prefix &&
+		oldText[oldText.length - 1 - suffix] === newText[newText.length - 1 - suffix]
+	) {
+		suffix++;
+	}
+	doc.transact(() => {
+		const deleteLen = oldText.length - prefix - suffix;
+		if (deleteLen > 0) content.delete(prefix, deleteLen);
+		const middle = newText.slice(prefix, newText.length - suffix);
+		if (middle) content.insert(prefix, middle);
+	});
+}

--- a/src/knap/obsidianFetch.ts
+++ b/src/knap/obsidianFetch.ts
@@ -1,0 +1,32 @@
+/**
+ * Obsidian's requestUrl, wearing the fetch shape KnapServer expects.
+ *
+ * `requestUrl` rather than `fetch` because it skips CORS on both platforms,
+ * which is what lets the server stay free of CORS headers for the plugin's
+ * sake. `throw: false` so an HTTP error is an answer with a status, the way
+ * fetch behaves and the way KnapServer reads it.
+ */
+
+import { requestUrl } from "obsidian";
+
+import type { Fetch, HttpAnswer } from "./KnapServer";
+
+export const obsidianFetch: Fetch = async (url, init): Promise<HttpAnswer> => {
+	const headers: Record<string, string> = {};
+	for (const [key, value] of Object.entries(init?.headers ?? {})) {
+		headers[key] = String(value);
+	}
+	const response = await requestUrl({
+		url,
+		method: init?.method ?? "GET",
+		headers,
+		body: init?.body as string | ArrayBuffer | undefined,
+		throw: false,
+	});
+	return {
+		ok: response.status >= 200 && response.status < 300,
+		status: response.status,
+		json: async () => response.json as unknown,
+		arrayBuffer: async () => response.arrayBuffer,
+	};
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,6 +76,9 @@ import {
 	flushLogs,
 } from "./debug";
 import { getPatcher, Patcher } from "./Patcher";
+import { registerKnapBeta } from "./knap/ObsidianKnap";
+import type { KnapSync } from "./knap/KnapSync";
+import type { KnapLink } from "./knap/KnapSync";
 import { LiveTokenStore } from "./LiveTokenStore";
 import NetworkStatus from "./NetworkStatus";
 import { RelayManager } from "./RelayManager";
@@ -185,6 +188,12 @@ interface RelaySettings extends FeatureFlags, DebugSettings, ReportingSettings {
 	 * look identical.
 	 */
 	lastRunVersion?: string;
+	/**
+	 * The rebuild's sign-in and link (docs/rebuild-plan.md phase 2 in
+	 * knap-mcp-admin). Only a build with KNAP_SERVER_URL set ever reads or
+	 * writes it; every ordinary build leaves it untouched.
+	 */
+	knap?: KnapLink | null;
 }
 
 const DEFAULT_SETTINGS: RelaySettings = {
@@ -228,6 +237,7 @@ export default class Live extends Plugin {
 	relayManager!: RelayManager;
 	settingsTab!: LiveSettingsTab;
 	settings!: Settings<RelaySettings>;
+	knapSync: KnapSync | null = null;
 	private featureSettings!: NamespacedSettings<FeatureFlags>;
 	private debugSettings!: NamespacedSettings<DebugSettings>;
 	/** The fault-reporting switch (ADR-0071). Public: the settings screen toggles it. */
@@ -407,6 +417,10 @@ export default class Live extends Plugin {
 
 		this.settings = new Settings<RelaySettings>(this, DEFAULT_SETTINGS);
 		await this.settings.load();
+
+		// The rebuild's beta switch: a no-op unless the build carries a
+		// server address (src/knap/ObsidianKnap.ts).
+		this.knapSync = registerKnapBeta(this);
 
 		// Migrate relay-onprem settings from legacy single-server format to multi-server
 		const rawRelayOnPremSettings = this.settings.get().relayOnPrem;
@@ -2320,7 +2334,17 @@ export default class Live extends Plugin {
 		}
 	}
 
+	getKnapLink(): KnapLink | null {
+		return this.settings.get().knap ?? null;
+	}
+
+	async saveKnapLink(value: KnapLink | null): Promise<void> {
+		await this.settings.update((settings) => ({ ...settings, knap: value }));
+	}
+
 	onunload() {
+		this.knapSync?.stop();
+		this.knapSync = null;
 		// Save settings before cleanup to persist any changes. onunload cannot
 		// await, so the promise is kept: the fields the write needs (app,
 		// manifest, vault) are nulled only after it settles, further down.


### PR DESCRIPTION
Phase 2 of the rebuild ([ADR-0073](https://github.com/pantalytics/knap-mcp-admin/pull/138), `docs/rebuild-plan.md` in knap-mcp-admin) replaces the whole EVC layer with a client for our own server. This PR is that client, in a new `src/knap/`, live only behind a build-time switch: `KNAP_SERVER_URL` is an esbuild define, empty in every ordinary build, and empty means this whole layer registers nothing.

## The foundation

- **`KnapServer.ts`** — the four conversations with the server: sign-in exchange, which cloud vaults, the socket address, attachments. The HTTP seam is a minimal `HttpAnswer` shape, so a fetch `Response` and Obsidian's `requestUrl` both satisfy it.
- **`SignInFlow.ts`** — browser out, `obsidian://synced-vaults/signin` back with a one-time code, exchanged once for this device's token. The action keeps the `synced-vaults` identifier (ADR-0042).
- **`TreeDoc.ts`** — the per-vault Y.Map from path to document id. A move is a tree change and touches no note; ids are minted client-side so a device can create notes offline.
- **`KnapVaultClient.ts`** — the tree plus one socket per open document, BroadcastChannel off everywhere.

## The engine

**`VaultBinding.ts`** — local files on one side, live documents on the other, blind to both ends so every rule runs under jest and the same code ships. A local edit becomes a minimal splice, so concurrent edits elsewhere in a note merge instead of being steamrolled. A rename travels as a tree move, a delete as a tree removal. Both directions are idempotent instead of bookkept: an event that finds file and document already equal does nothing, which kills every echo loop without a ledger — and is why Obsidian firing events for our own writes costs nothing. At link time nothing is guessed: local-only uploads, remote-only downloads, and a two-sided conflict keeps the cloud text while the local text survives as a conflict copy that is itself a synced note.

## The Obsidian half

**`ObsidianFileStore`** adapts the vault to the FileStore seam (deletes through the user's own trash preference). **`KnapSync`** is ADR-0066 as code: linked to at most one cloud vault, linking replaces, unlink stops the sockets and deletes nothing. **`ObsidianKnap`** registers the protocol handler, the cloud-vault picker as a modal, and three commands: sign in, link, unlink. Network rides `requestUrl` wearing the fetch shape, so the server needs no CORS story. `main.ts` changes are surgical: one settings field, one registration line, two host methods, teardown in `onunload`.

## Verification

27 jest tests on the new layer (748 total, all green), including CRDT convergence of two devices' tree edits and ten binding scenarios on a relaying hub with a file store that fires events for the binding's own writes, exactly like Obsidian does. `eslint` and `tsc -noEmit` clean.

Over the real wire: knap-mcp-admin's `scripts/spikes/plugin_against_knap_server/` bundles these exact modules and drives them against a live `knap_server` — ten claims, all held, including the binding pulling the tree's note into local files and a locally written note travelling binding → tree → the server's markdown mirror.

**Known CI failure, not this diff:** *Obsidian wire e2e (real app, real relay)* dies on its first step checking out `knap-mcp-admin` — the stored `ADMIN_REPO_TOKEN` can no longer read that repo (details in the comment below). Renewing the PAT fixes it on any branch.

## What remains for phase 2

Proving the linked vault inside a real Obsidian on laptop and phone, which is also what the phase's done-criterion asks: a few thousand notes syncing both ways with the AI's edits arriving mid-session.