### PR TITLE
A beta build that points at the rebuilt server, and a note that never writes over an unsynced file

### DIFF
--- a/.github/workflows/beta-knap.yml
+++ b/.github/workflows/beta-knap.yml
@@ -1,0 +1,117 @@
+name: Beta build (Knap server)
+# A plugin build that points at the rebuilt Knap server, for testing it on a
+# real laptop and a real phone (knap-mcp-admin, docs/rebuild-plan.md phase 2).
+#
+# Deliberately not part of the release path. `KNAP_SERVER_URL` is an esbuild
+# define that is empty in every ordinary build, and empty means the rebuilt
+# client registers nothing at all. This workflow is the only thing that fills
+# it in, it never runs on its own, and what it publishes is a pre-release under
+# its own tag, so nothing here can reach somebody who installed Knap normally.
+#
+# It leaves manifest.json, package.json, versions.json and manifest-beta.json
+# on the default branch alone. CI cross-checks those four for agreement, and a
+# beta that edited one of them would break the next real release.
+#
+# On the phone: BRAT, "Add beta plugin with frozen version", this repository,
+# and the tag this run prints.
+on:
+  workflow_dispatch:
+    inputs:
+      server_url:
+        description: 'The Knap server this build talks to, e.g. https://next.knap.pantalytics.com (no trailing slash)'
+        required: true
+      suffix:
+        description: 'Tag suffix, so two betas can exist at once'
+        required: false
+        default: 'knap-beta.1'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      - name: Refuse a server URL that is not one
+        run: |
+          URL='${{ inputs.server_url }}'
+          case "$URL" in
+            https://*|http://127.0.0.1:*|http://localhost:*) ;;
+            *) echo "::error::server_url must be https, or http on localhost for a laptop test. Got '$URL'"; exit 1;;
+          esac
+          case "$URL" in
+            */) echo "::error::server_url must not end in a slash"; exit 1;;
+          esac
+
+      - run: npm ci || npm install
+
+      # The tag carries the released version plus the suffix, so it sorts
+      # beside the real releases and can never be mistaken for one.
+      - name: Work out the tag
+        id: tag
+        run: |
+          VER=$(node -p "require('./manifest.json').version")
+          echo "tag=${VER}-${{ inputs.suffix }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build with the switch set
+        env:
+          KNAP_SERVER_URL: ${{ inputs.server_url }}
+        run: npm run build
+
+      - name: Prove the switch actually landed in the bundle
+        # A build where the define silently stayed empty is a build that looks
+        # fine and does nothing, which is the one failure worth catching here.
+        env:
+          KNAP_SERVER_URL: ${{ inputs.server_url }}
+        run: |
+          grep -qF "$KNAP_SERVER_URL" main.js || {
+            echo "::error::main.js does not carry $KNAP_SERVER_URL — the define did not take"
+            exit 1
+          }
+
+      # BRAT reads the version out of the manifest it downloads, so it has to
+      # match the tag. Only in the published asset: the file in git is left
+      # exactly as it is.
+      - name: Stamp the beta version into the published manifest
+        run: |
+          node -e '
+            const fs = require("fs");
+            const m = JSON.parse(fs.readFileSync("manifest.json", "utf8"));
+            m.version = process.argv[1];
+            fs.writeFileSync("manifest.json", JSON.stringify(m, null, "\t") + "\n");
+          ' "${{ steps.tag.outputs.tag }}"
+
+      - name: Publish the pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          ASSETS="main.js manifest.json"
+          [ -f styles.css ] && ASSETS="$ASSETS styles.css"
+          NOTES=$(cat <<EOF
+          A beta build of the rebuilt client, pointing at ${{ inputs.server_url }}.
+
+          Not an ordinary release: this build carries a server address baked in
+          at build time, and it is a pre-release so nobody reaches it by
+          accident.
+
+          On a phone: install BRAT, then *Add beta plugin with frozen version*,
+          \`${{ github.repository }}\`, tag \`$TAG\`. Enable **Knap**, then run
+          *Sign in (beta)*, *Link this vault to a cloud vault (beta)*.
+          EOF
+          )
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" $ASSETS --clobber
+          else
+            gh release create "$TAG" $ASSETS \
+              --title "$TAG" --notes "$NOTES" --prerelease \
+              --target "$(git rev-parse HEAD)"
+          fi
+          echo "### Beta published: \`$TAG\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "BRAT: *Add beta plugin with frozen version*, \`${{ github.repository }}\`, tag \`$TAG\`." >> "$GITHUB_STEP_SUMMARY"

--- a/__tests__/knap/VaultBinding.test.ts
+++ b/__tests__/knap/VaultBinding.test.ts
@@ -173,6 +173,26 @@ describe("VaultBinding", () => {
 		expect(b.files.map.has("weg.md")).toBe(false);
 	});
 
+	it("a note arriving where an unsynced local file sits keeps both", async () => {
+		// Not link time: B is already linked and typing, and A makes a note of
+		// the same name on the other side of the world. The tree change reaches
+		// B with a file already at that path, and writing over it would be the
+		// one thing this binding promises never to do.
+		const hub = new Hub();
+		const a = await device(hub);
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+
+		b.files.map.set("Notes/idee.md", "wat ik zelf had");
+		await a.files.write("Notes/idee.md", "wat zij schreef");
+		await settle(a.binding, b.binding);
+
+		expect(b.files.map.get("Notes/idee.md")).toBe("wat zij schreef");
+		const copies = [...b.files.map].filter(([path]) => path.includes("conflict"));
+		expect(copies).toHaveLength(1);
+		expect(copies[0][1]).toBe("wat ik zelf had");
+	});
+
 	it("link-time conflict keeps the cloud text and saves the local text beside it", async () => {
 		const hub = new Hub();
 		const a = await device(hub, { "nota.md": "cloudversie" });

--- a/src/knap/VaultBinding.ts
+++ b/src/knap/VaultBinding.ts
@@ -83,16 +83,16 @@ export class VaultBinding {
 		this.stopTreeEvents = this.docs.tree().onChange((change) => {
 			void this.enqueue(async () => {
 				for (const [path, docId] of change.added) {
-					await this.pullNote(path, docId);
+					await this.bindNote(path, docId);
 				}
 				for (const [path, docId] of change.removed) {
-					// A move announces itself as removed+added under one id;
-					// the added half already wrote the new file.
+					// A move announces itself as removed+added under one id, and
+					// the added half above already wrote the new file, so the old
+					// path goes either way. Only a note that left the tree for
+					// good stops being watched.
+					await this.files.remove(path);
 					if (this.docs.tree().pathFor(docId) === undefined) {
-						await this.files.remove(path);
 						this.unobserveNote(docId);
-					} else {
-						await this.files.remove(path);
 					}
 				}
 			});
@@ -129,37 +129,8 @@ export class VaultBinding {
 			}
 		}
 		for (const [path, docId] of remote) {
-			if (!local.has(path)) {
-				await this.pullNote(path, docId);
-			} else {
-				await this.mergeAtLink(path, docId);
-			}
+			await this.bindNote(path, docId);
 		}
-	}
-
-	private async mergeAtLink(path: string, docId: string): Promise<void> {
-		const fileText = (await this.files.read(path)) ?? "";
-		const { doc, synced } = this.docs.note(docId);
-		await synced;
-		const docText = textOf(doc.getText(CONTENT));
-
-		if (docText === fileText) {
-			this.observeNote(path, docId);
-			return;
-		}
-		if (docText === "") {
-			// A minted note nobody typed in yet: the local text is the note.
-			splice(doc.getText(CONTENT), "", fileText, doc);
-		} else {
-			// Both sides wrote. The cloud text wins the path; the local text
-			// survives beside it, named for what happened, and pushed
-			// explicitly because link-time runs before the event stream is on.
-			const copy = buildConflictCopyPath(path, this.conflictLabel());
-			await this.files.write(copy, fileText);
-			await this.pushNote(copy);
-			await this.files.write(path, docText);
-		}
-		this.observeNote(path, docId);
 	}
 
 	// -- local to remote ------------------------------------------------------
@@ -205,12 +176,41 @@ export class VaultBinding {
 
 	// -- remote to local ------------------------------------------------------
 
-	private async pullNote(path: string, docId: string): Promise<void> {
+	/**
+	 * Take one note from the cloud onto disk, and start watching it.
+	 *
+	 * The three-way choice below is why this is one method rather than a
+	 * download at link time and a simpler one for notes that arrive later.
+	 * A note can turn up in the tree at a path where an unsynced local file
+	 * already sits: somebody wrote it on this laptop while another device
+	 * made a note of the same name. Writing the cloud text over it would be
+	 * the one thing this binding promises never to do.
+	 */
+	private async bindNote(path: string, docId: string): Promise<void> {
 		const { doc, synced } = this.docs.note(docId);
 		await synced;
-		const text = textOf(doc.getText(CONTENT));
-		if ((await this.files.read(path)) !== text) {
-			await this.files.write(path, text);
+		const content = doc.getText(CONTENT);
+		const docText = textOf(content);
+		const fileText = await this.files.read(path);
+
+		if (fileText === null) {
+			await this.files.write(path, docText);
+		} else if (fileText !== docText) {
+			if (docText === "") {
+				// A minted note nobody typed in yet: the local text is the
+				// note. A note somebody deliberately emptied looks exactly the
+				// same from here and nothing can tell them apart, so this goes
+				// the way that cannot lose anything.
+				splice(content, "", fileText, doc);
+			} else {
+				// Both sides wrote. The cloud text wins the path; the local
+				// text survives beside it, named for what happened, and pushed
+				// explicitly because this can run before the event stream is on.
+				const copy = buildConflictCopyPath(path, this.conflictLabel());
+				await this.files.write(copy, fileText);
+				await this.pushNote(copy);
+				await this.files.write(path, docText);
+			}
 		}
 		this.observeNote(path, docId);
 	}


### PR DESCRIPTION
Testing the rebuilt client on a real phone needs a build with `KNAP_SERVER_URL` baked in, and BRAT installs from a GitHub release. This workflow makes one: dispatch it with the server address, it builds, publishes a pre-release under its own tag, and prints the BRAT line into the run summary.

It also carries one fix to the binding, found by reading it beside the server's own scenario walk.

## The workflow: deliberately outside the release path

It never runs on its own, what it publishes is a **pre-release**, and it leaves `manifest.json`, `package.json`, `versions.json` and `manifest-beta.json` in git untouched. CI cross-checks those four for agreement, and a beta that edited one of them would break the next real release. The version is stamped into the *published* manifest only, where BRAT needs it to match the tag.

Two guards, because the failure worth catching is a build that looks fine and does nothing:

- the server URL has to be `https` (or `http` on localhost, for a laptop test) and carry no trailing slash;
- `main.js` has to actually contain it after the build, or the run fails.

### Measured while writing it

Better than expected. With the switch set, the URL and the `synced-vaults/signin` deep-link action are both in the bundle. **Without it, the beta command ids do not appear in the bundle at all**: esbuild folds the empty define, sees the early return in `registerKnapBeta`, and drops the whole layer. So "an ordinary build registers nothing" is not merely a runtime promise, it is dead code elimination.

## The fix: a note arriving from the cloud never writes over an unsynced local file

Link time already handled a note existing on both sides with different text: the cloud text keeps the path, the local text survives as a conflict copy beside it. Every note arriving *later* went through a plain download that wrote the document's text to the path and asked nothing.

That path is reachable without anybody being offline for long. Two devices are linked, somebody writes `Notes/idee.md` on one, and this laptop happens to have an unsynced file of that name. The tree change arrives, the download runs, and the local text is gone with no copy of it anywhere. "Nothing is ever silently lost" is the first thing the module docstring claims.

So there is one method now instead of two. `bindNote` takes a note from the cloud onto disk and starts watching it, and the three-way choice (no local file, same text, or a real disagreement) is made in one place, used by link time and by every tree arrival alike. Link-time behaviour is unchanged; what changed is that later arrivals get the same care. The new test fails against the old download and passes against this.

Also here: the two branches of the tree-removal handler both deleted the same file and differed only in whether they stopped watching the document, so they are one branch and an `if` now. And the comment on an empty cloud document says out loud that a note somebody emptied on purpose looks identical to one nobody has typed in, which is why that case resolves towards the text on disk.

## Using the beta build

1. Actions → **Beta build (Knap server)** → the server address.
2. On the phone: BRAT, *Add beta plugin with frozen version*, `pantalytics/knap-obsidian`, the tag the run printed.
3. Enable **Knap**, then *Sign in (beta)* and *Link this vault to a cloud vault (beta)*.

The server it points at comes from pantalytics/knap-mcp-admin#139.

## CI

Green on ESLint, TypeScript, Jest (749), Build + smoke, manifest version sync, the CI gate and the y-sweet wire e2e.

**Obsidian wire e2e (real app, real relay) is red and is not this diff.** It dies on its first step, checking out `knap-mcp-admin`, so the working tree is never there. The stored `ADMIN_REPO_TOKEN` can no longer read that repository, so the job fails identically on any branch and on `main`. The remedy is a repository secret: renew the fine-grained PAT with `contents: read` on `pantalytics/knap-mcp-admin`.