### PR TITLE
A beta build is one world, not two

### DIFF
--- a/__tests__/knap/oneWorld.test.ts
+++ b/__tests__/knap/oneWorld.test.ts
@@ -1,0 +1,52 @@
+/**
+ * A beta build is one world.
+ *
+ * The first beta pointed at the rebuilt server and still carried the relay:
+ * its settings tab listed the shares of the stack this build exists to
+ * replace, as "cloud vaults", beside the real ones and with nothing on either
+ * screen saying which server it was talking about. Worse than confusing --
+ * the relay's background sync was also running, so the old stack's shares
+ * were being synced into whatever vault the beta was installed in.
+ *
+ * These read main.ts rather than driving the plugin, because standing a whole
+ * Obsidian up in jest to assert three `if`s is a slower test that proves less.
+ * What matters is that each of the three guards exists and reads the same
+ * flag; whether the plugin honours it is what the real-app walk is for.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const main = readFileSync(join(__dirname, "..", "..", "src", "main.ts"), "utf8");
+
+/** The line and everything after it, up to the closing brace of the guard. */
+function guardAround(needle: string): string {
+	const at = main.indexOf(needle);
+	expect(at).toBeGreaterThan(-1);
+	return main.slice(Math.max(0, at - 400), at + needle.length);
+}
+
+describe("a beta build does not also run the relay", () => {
+	it("does not add the relay's settings tab", () => {
+		expect(guardAround("this.addSettingTab(this.settingsTab);")).toMatch(
+			/if \(!this\.knapSync\) \{/,
+		);
+	});
+
+	it("does not start the relay's background sync", () => {
+		expect(guardAround("this.backgroundSync.start();")).toMatch(/if \(!this\.knapSync\) \{/);
+	});
+
+	it("does not load shares from the old control plane", () => {
+		const body = main.slice(main.indexOf("private async loadRelayOnPremShares"));
+		expect(body.slice(0, 800)).toMatch(/if \(this\.knapSync\) \{[\s\S]*?return;/);
+	});
+
+	it("leaves an ordinary build alone: the flag is null without a server url", () => {
+		const registrar = readFileSync(
+			join(__dirname, "..", "..", "src", "knap", "ObsidianKnap.ts"),
+			"utf8",
+		);
+		expect(registrar).toMatch(/if \(!serverUrl\) \{\s*return null;/);
+	});
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1145,6 +1145,16 @@ export default class Live extends Plugin {
 		const log = curryLog("[RelayOnPrem]", "log");
 		const err = curryLog("[RelayOnPrem]", "error");
 
+		// A beta build talks to the rebuilt server and to nothing else. Left
+		// on, this reaches the control plane of the stack that build exists to
+		// replace, lists its shares as "cloud vaults" beside the real ones,
+		// and -- worse than confusing -- starts syncing them into whatever
+		// vault the beta is installed in.
+		if (this.knapSync) {
+			log("Beta build: not loading anything from the control plane.");
+			return;
+		}
+
 		try {
 			log("Loading existing shares from control plane...");
 
@@ -2017,7 +2027,14 @@ export default class Live extends Plugin {
 			void this.loadRelayOnPremShares();
 		}
 
-		this.addSettingTab(this.settingsTab);
+		// One world per build. A beta pointed at the rebuilt server showed the
+		// relay's own settings tab beside it, listing the shares of the stack
+		// this one replaces -- two lists of "cloud vaults" that disagree, with
+		// nothing on either saying which server it is talking about. The
+		// ordinary build is unaffected: knapBeta is null there.
+		if (!this.knapSync) {
+			this.addSettingTab(this.settingsTab);
+		}
 
 		const workspaceLog = curryLog("[Live][Workspace]", "log");
 
@@ -2312,7 +2329,11 @@ export default class Live extends Plugin {
 			void this.openSettings();
 		});
 
-		this.backgroundSync.start();
+		// Same reason as loadRelayOnPremShares: one syncer per build. The
+		// rebuilt client does its own syncing over its own socket.
+		if (!this.knapSync) {
+			this.backgroundSync.start();
+		}
 	}
 
 	removeCommand(command: string): void {


### PR DESCRIPTION
Found while testing the first beta against `next.knap.pantalytics.com`: the
plugin offered a list of cloud vaults that did not match the ones in the
panel.

It was not the new client. The build still carried the relay, so its settings
tab was listing the **old** stack's shares as cloud vaults, beside the real
ones, with nothing on either screen naming the server it meant. And the
relay's background sync was running as well, which means the old stack's
shares were being synced into whatever vault the beta was installed in.

Three guards on the flag that is null in every ordinary build:

- no relay settings tab
- no relay background sync
- nothing loaded from the old control plane

An ordinary build is untouched: `registerKnapBeta` returns null without
`KNAP_SERVER_URL`, which is every build but this one.

749 jest tests pass, plus four new ones that pin each guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)