### PR TITLE
A sign-in that did not start here says so

### DIFF
--- a/__tests__/knap/SignInFlow.test.ts
+++ b/__tests__/knap/SignInFlow.test.ts
@@ -64,3 +64,18 @@ describe("SignInFlow", () => {
 		await expect(promise).rejects.toThrow(/without a code/);
 	});
 });
+
+describe("a deep link nobody is waiting for", () => {
+	it("says so rather than dropping the code in silence", () => {
+		const flow = new SignInFlow(serverWhereCode("c-1"), "Laptop");
+		// Nothing started here: no begin(), so nothing is pending.
+		expect(flow.handleDeepLink({ code: "c-1" })).toBe(false);
+	});
+
+	it("feeds a flow that did start here", async () => {
+		const flow = new SignInFlow(serverWhereCode("c-1"), "Laptop");
+		const waiting = flow.begin(() => {});
+		expect(flow.handleDeepLink({ code: "c-1" })).toBe(true);
+		await expect(waiting).resolves.toBe("knap_tok");
+	});
+});

--- a/src/knap/ObsidianKnap.ts
+++ b/src/knap/ObsidianKnap.ts
@@ -75,7 +75,15 @@ export function registerKnapBeta(host: KnapHost): KnapSync | null {
 	});
 
 	host.registerObsidianProtocolHandler(SIGNIN_ACTION, (params) => {
-		sync.handleDeepLink(params as unknown as Record<string, string>);
+		const fed = sync.handleDeepLink(params as unknown as Record<string, string>);
+		if (!fed) {
+			// A sign-in that was started somewhere other than here: the link
+			// arrives, nothing is waiting for it, and the code is dropped. It
+			// used to be dropped in silence, which reads exactly like the
+			// plugin being broken -- the browser said it worked and Obsidian
+			// said nothing at all.
+			new Notice("That sign-in did not start here. Run Sign in (beta) and try again.");
+		}
 	});
 
 	host.addCommand({

--- a/src/knap/ObsidianKnap.ts
+++ b/src/knap/ObsidianKnap.ts
@@ -82,7 +82,7 @@ export function registerKnapBeta(host: KnapHost): KnapSync | null {
 			// used to be dropped in silence, which reads exactly like the
 			// plugin being broken -- the browser said it worked and Obsidian
 			// said nothing at all.
-			new Notice("That sign-in did not start here. Run Sign in (beta) and try again.");
+			new Notice("That sign-in did not start here. Run sign in (beta) and try again.");
 		}
 	});
 


### PR DESCRIPTION
`handleDeepLink` returns false when nothing is pending, and the caller ignored
that. So a `obsidian://synced-vaults/signin` link that arrives without a flow
waiting for it is dropped in silence.

That is not hypothetical: while debugging a sign-in that never landed, the
suggestion was to open `/auth/plugin/start` in the browser directly. The whole
server side ran -- authorize, Zitadel, callback, a 302 to the deep link -- and
Obsidian dropped the code, because the flow only listens after **Sign in
(beta)** started it. The browser said it worked. Nothing said otherwise.

Now it says: *"That sign-in did not start here. Run Sign in (beta) and try
again."*

Two tests: a stray link is refused, one that belongs to a started flow is fed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)