### PR TITLE
A screen with a sign in button, because that is where people look

### DIFF
--- a/__tests__/knap/KnapServer.test.ts
+++ b/__tests__/knap/KnapServer.test.ts
@@ -46,7 +46,7 @@ describe("KnapServer", () => {
 			"/api/vaults": () =>
 				new Response(
 					JSON.stringify({
-						vaults: [{ id: "v1", name: "Demo", may_write: false }],
+						vaults: [{ id: "v1", name: "Demo" }],
 					}),
 					{ status: 200 },
 				),
@@ -54,7 +54,7 @@ describe("KnapServer", () => {
 		const server = new KnapServer("https://knap.test/", fetchFn);
 
 		const vaults = await server.listVaults("knap_abc");
-		expect(vaults).toEqual([{ id: "v1", name: "Demo", mayWrite: false }]);
+		expect(vaults).toEqual([{ id: "v1", name: "Demo" }]);
 		expect((calls[0].init?.headers as Record<string, string>).Authorization).toBe(
 			"Bearer knap_abc",
 		);

--- a/__tests__/knap/settingsTab.test.ts
+++ b/__tests__/knap/settingsTab.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The screen has a button, and it says the right thing in each of the three
+ * states it can be in.
+ *
+ * It exists because the commands were the only way in, and somebody asked to
+ * try the beta opens Settings first. In a beta build the relay's own tab is
+ * hidden, so they found nothing at all -- which reads as a plugin that does
+ * not work rather than one whose entry point is in the command palette.
+ */
+
+import { KnapSettingsTab } from "../../src/knap/KnapSettingsTab";
+
+type Row = { name: string; desc: string; buttons: string[] };
+
+/** A stand-in for Obsidian's Setting, recording what the screen asked for. */
+function fakeContainer(rows: Row[]) {
+	return {
+		empty: () => rows.splice(0, rows.length),
+		rows,
+	};
+}
+
+jest.mock("obsidian", () => {
+	const rows: Row[] = [];
+	class Setting {
+		private row: Row = { name: "", desc: "", buttons: [] };
+		constructor(container: { rows?: Row[] }) {
+			(container.rows ?? rows).push(this.row);
+		}
+		setName(name: string) {
+			this.row.name = name;
+			return this;
+		}
+		setDesc(desc: string) {
+			this.row.desc = desc;
+			return this;
+		}
+		setHeading() {
+			return this;
+		}
+		addButton(build: (b: unknown) => void) {
+			const button = {
+				setButtonText: (text: string) => {
+					this.row.buttons.push(text);
+					return button;
+				},
+				setCta: () => button,
+				onClick: () => button,
+			};
+			build(button);
+			return this;
+		}
+	}
+	class PluginSettingTab {
+		containerEl: unknown;
+		constructor(
+			public app: unknown,
+			public plugin: unknown,
+		) {}
+	}
+	return { Setting, PluginSettingTab, Notice: class {}, App: class {} };
+});
+
+function tabFor(state: { signedIn: boolean; linked: null | { id: string; name: string } }) {
+	const rows: Row[] = [];
+	const sync = {
+		signedIn: state.signedIn,
+		linked: state.linked
+			? { cloudVaultId: state.linked.id, cloudVaultName: state.linked.name, token: "t" }
+			: null,
+		unlink: async () => {},
+	};
+	const host = { app: {}, signIn: async () => {}, pickAndLink: async () => {} };
+	const tab = new KnapSettingsTab(
+		{} as never,
+		sync as never,
+		host as never,
+		"https://next.knap.test",
+	);
+	tab.containerEl = fakeContainer(rows) as never;
+	tab.display();
+	return rows;
+}
+
+describe("the beta's settings screen", () => {
+	it("offers signing in, and names the server this build talks to", () => {
+		const rows = tabFor({ signedIn: false, linked: null });
+		expect(rows.flatMap((r) => r.buttons)).toContain("Sign in");
+		expect(rows.map((r) => r.desc).join(" ")).toContain("https://next.knap.test");
+		// Nothing to unlink from when nobody is signed in.
+		expect(rows.flatMap((r) => r.buttons)).not.toContain("Unlink");
+	});
+
+	it("offers linking once signed in, and does not offer unlink yet", () => {
+		const rows = tabFor({ signedIn: true, linked: null });
+		expect(rows.flatMap((r) => r.buttons)).toContain("Link a cloud vault");
+		expect(rows.flatMap((r) => r.buttons)).not.toContain("Unlink");
+		expect(rows.map((r) => r.desc).join(" ")).toContain("not linked");
+	});
+
+	it("names the linked vault, and offers unlink beside it", () => {
+		const rows = tabFor({ signedIn: true, linked: { id: "v1", name: "Pantalytics_v03" } });
+		expect(rows.map((r) => r.desc).join(" ")).toContain("Pantalytics_v03");
+		expect(rows.flatMap((r) => r.buttons)).toContain("Unlink");
+		expect(rows.map((r) => r.desc).join(" ")).toContain("Nothing is deleted");
+	});
+});

--- a/src/knap/KnapServer.ts
+++ b/src/knap/KnapServer.ts
@@ -21,7 +21,7 @@
 export interface CloudVault {
 	id: string;
 	name: string;
-	mayWrite: boolean;
+
 }
 
 /** The slice of a fetch Response this module reads. requestUrl adapts to it too. */
@@ -88,9 +88,9 @@ export class KnapServer {
 			throw new KnapServerError("The server did not answer.", response.status);
 		}
 		const body = (await response.json()) as {
-			vaults: { id: string; name: string; may_write: boolean }[];
+			vaults: { id: string; name: string }[];
 		};
-		return body.vaults.map((v) => ({ id: v.id, name: v.name, mayWrite: v.may_write }));
+		return body.vaults.map((v) => ({ id: v.id, name: v.name }));
 	}
 
 	/**

--- a/src/knap/KnapSettingsTab.ts
+++ b/src/knap/KnapSettingsTab.ts
@@ -1,0 +1,107 @@
+/**
+ * The one screen the rebuilt client has: sign in, link, unlink.
+ *
+ * It exists because the three commands were the only way in, and a command
+ * palette is where somebody looks after they already know the thing is there.
+ * Asked to try the beta, the first thing a person does is open Settings and
+ * look for a button -- and in a beta build the relay's own tab is hidden, so
+ * they found nothing at all.
+ *
+ * Three lines and at most two buttons, because there are only ever three
+ * states: signed out, signed in but not linked, and linked. No server field
+ * (ADR-0033): which server this build talks to is baked in, and the screen
+ * says which one rather than offering a choice.
+ */
+
+import { type App, Notice, PluginSettingTab, Setting } from "obsidian";
+
+import type { CloudVault } from "./KnapServer";
+import type { KnapSync } from "./KnapSync";
+
+export interface SignInHost {
+	app: App;
+	/** Starts the browser half and resolves when the deep link comes back. */
+	signIn(): Promise<void>;
+	/** Offers the account's cloud vaults and links the one that is picked. */
+	pickAndLink(): Promise<void>;
+}
+
+export class KnapSettingsTab extends PluginSettingTab {
+	constructor(
+		app: App,
+		private readonly sync: KnapSync,
+		private readonly host: SignInHost,
+		private readonly serverUrl: string,
+	) {
+		super(app, host as never);
+	}
+
+	display(): void {
+		const { containerEl } = this;
+		containerEl.empty();
+
+		const linked: CloudVault | null = this.sync.linked
+			? { id: this.sync.linked.cloudVaultId, name: this.sync.linked.cloudVaultName }
+			: null;
+
+		if (!this.sync.signedIn) {
+			new Setting(containerEl)
+				.setName("Sign in")
+				.setDesc(
+					"Opens your browser. Sign in there and it comes back here. " +
+						`This build talks to ${this.serverUrl}.`,
+				)
+				.addButton((button) =>
+					button
+						.setButtonText("Sign in")
+						.setCta()
+						.onClick(() => {
+							void this.host
+								.signIn()
+								.then(() => {
+									new Notice("Signed in. Now link this vault to a cloud vault.");
+									this.display();
+								})
+								.catch((error: Error) => new Notice(error.message));
+						}),
+				);
+			return;
+		}
+
+		new Setting(containerEl)
+			.setName("This vault")
+			.setDesc(
+				linked?.name
+					? `Syncs with the cloud vault ${linked.name}.`
+					: "Signed in, and not linked to a cloud vault yet.",
+			)
+			.addButton((button) =>
+				button
+					.setButtonText(linked ? "Link a different one" : "Link a cloud vault")
+					.setCta()
+					.onClick(() => {
+						void this.host
+							.pickAndLink()
+							.then(() => this.display())
+							.catch((error: Error) => new Notice(error.message));
+					}),
+			);
+
+		if (linked) {
+			new Setting(containerEl)
+				.setName("Unlink")
+				.setDesc(
+					"Stops the syncing. Nothing is deleted, here or in the cloud vault, " +
+						"and linking again picks up where this left off.",
+				)
+				.addButton((button) =>
+					button.setButtonText("Unlink").onClick(() => {
+						void this.sync.unlink().then(() => {
+							new Notice("Unlinked. Nothing was deleted, anywhere.");
+							this.display();
+						});
+					}),
+				);
+		}
+	}
+}

--- a/src/knap/ObsidianKnap.ts
+++ b/src/knap/ObsidianKnap.ts
@@ -18,6 +18,7 @@ import type { CloudVault } from "./KnapServer";
 import { KnapSync } from "./KnapSync";
 import type { KnapLink } from "./KnapSync";
 import { ObsidianFileStore } from "./ObsidianFileStore";
+import { KnapSettingsTab } from "./KnapSettingsTab";
 import { SIGNIN_ACTION } from "./SignInFlow";
 import { obsidianFetch } from "./obsidianFetch";
 
@@ -45,8 +46,9 @@ class CloudVaultPickModal extends SuggestModal<CloudVault> {
 	}
 
 	renderSuggestion(vault: CloudVault, el: HTMLElement): void {
+		// The name and nothing else. There is one kind of person in a vault,
+		// so there is no access level to qualify it with.
 		el.createDiv({ text: vault.name });
-		el.createEl("small", { text: vault.mayWrite ? "you can edit" : "you can read" });
 	}
 
 	onChooseSuggestion(vault: CloudVault): void {
@@ -74,6 +76,30 @@ export function registerKnapBeta(host: KnapHost): KnapSync | null {
 		save: (value) => host.saveKnapLink(value),
 	});
 
+	const signIn = () => sync.signIn((url) => window.open(url));
+
+	const pickAndLink = () =>
+		sync.listVaults().then(
+			(vaults) =>
+				new Promise<void>((resolve, reject) => {
+					if (!vaults.length) {
+						reject(new Error("No cloud vaults yet. Make one in the Knap panel first."));
+						return;
+					}
+					new CloudVaultPickModal(host, vaults, (vault) => {
+						sync
+							.link(vault)
+							.then(() => {
+								new Notice(`Linked. This vault now syncs with ${vault.name}.`);
+								resolve();
+							})
+							.catch(reject);
+					}).open();
+				}),
+		);
+
+	host.addSettingTab(new KnapSettingsTab(host.app, sync, { app: host.app, signIn, pickAndLink }, serverUrl));
+
 	host.registerObsidianProtocolHandler(SIGNIN_ACTION, (params) => {
 		const fed = sync.handleDeepLink(params as unknown as Record<string, string>);
 		if (!fed) {
@@ -90,8 +116,7 @@ export function registerKnapBeta(host: KnapHost): KnapSync | null {
 		id: "knap-beta-sign-in",
 		name: "Sign in (beta)",
 		callback: () => {
-			sync
-				.signIn((url) => window.open(url))
+			signIn()
 				.then(() => new Notice("Signed in. Now link this vault to a cloud vault."))
 				.catch((error: Error) => new Notice(error.message));
 		},
@@ -101,21 +126,7 @@ export function registerKnapBeta(host: KnapHost): KnapSync | null {
 		id: "knap-beta-link-vault",
 		name: "Link this vault to a cloud vault (beta)",
 		callback: () => {
-			sync
-				.listVaults()
-				.then((vaults) => {
-					if (!vaults.length) {
-						new Notice("No cloud vaults yet. Make one in the Knap panel first.");
-						return;
-					}
-					new CloudVaultPickModal(host, vaults, (vault) => {
-						sync
-							.link(vault)
-							.then(() => new Notice(`Linked. This vault now syncs with ${vault.name}.`))
-							.catch((error: Error) => new Notice(error.message));
-					}).open();
-				})
-				.catch((error: Error) => new Notice(error.message));
+			pickAndLink().catch((error: Error) => new Notice(error.message));
 		},
 	});
 


### PR DESCRIPTION
The rebuilt client had three commands and no screen. Asked to try the beta, the
first thing somebody does is open Settings -- and a beta build hides the
relay's tab, so they find nothing at all.

Three lines and at most two buttons, one per state: signed out, signed in but
not linked, linked. No server field ([ADR-0033](https://github.com/pantalytics/knap-mcp-admin/blob/main/docs/adr/0033-one-server-and-the-plugin-knows-only-that-one.md));
it says which server this build talks to instead. The commands now call the
same two functions the buttons do.

Also drops `mayWrite`: the plugin labelled every vault in the picker "you can
edit" or "you can read" from a field the server stopped sending when a vault
stopped having two kinds of member -- so everything read as "you can read".

759 jest tests, three new ones for the three states of the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)