### PR TITLE
The ribbon icon came back, and a beta layer can no longer take it

### DIFF
--- a/__tests__/knap/oneWorld.test.ts
+++ b/__tests__/knap/oneWorld.test.ts
@@ -42,6 +42,17 @@ describe("a beta build does not also run the relay", () => {
 		expect(body.slice(0, 800)).toMatch(/if \(this\.knapSync\) \{[\s\S]*?return;/);
 	});
 
+	it("cannot take the rest of onload down with it", () => {
+		// registerKnapBeta runs early in onload; the ribbon icon is registered
+		// eighty lines later. A throw in here once meant no icon at all, and
+		// nothing on screen saying why.
+		const at = main.indexOf("registerKnapBeta(this)");
+		expect(at).toBeGreaterThan(-1);
+		const around = main.slice(at - 200, at + 300);
+		expect(around).toMatch(/try \{/);
+		expect(around).toMatch(/catch \(error\)/);
+	});
+
 	it("leaves an ordinary build alone: the flag is null without a server url", () => {
 		const registrar = readFileSync(
 			join(__dirname, "..", "..", "src", "knap", "ObsidianKnap.ts"),

--- a/__tests__/knap/settingsTab.test.ts
+++ b/__tests__/knap/settingsTab.test.ts
@@ -70,11 +70,12 @@ function tabFor(state: { signedIn: boolean; linked: null | { id: string; name: s
 			: null,
 		unlink: async () => {},
 	};
-	const host = { app: {}, signIn: async () => {}, pickAndLink: async () => {} };
+	const plugin = { app: {} };
+	const actions = { signIn: async () => {}, pickAndLink: async () => {} };
 	const tab = new KnapSettingsTab(
-		{} as never,
+		plugin as never,
 		sync as never,
-		host as never,
+		actions as never,
 		"https://next.knap.test",
 	);
 	tab.containerEl = fakeContainer(rows) as never;

--- a/src/knap/KnapSettingsTab.ts
+++ b/src/knap/KnapSettingsTab.ts
@@ -13,13 +13,13 @@
  * says which one rather than offering a choice.
  */
 
-import { type App, Notice, PluginSettingTab, Setting } from "obsidian";
+import { Notice, type Plugin, PluginSettingTab, Setting } from "obsidian";
 
 import type { CloudVault } from "./KnapServer";
 import type { KnapSync } from "./KnapSync";
 
-export interface SignInHost {
-	app: App;
+/** The two acts the buttons perform, so the screen shares them with the commands. */
+export interface SignInActions {
 	/** Starts the browser half and resolves when the deep link comes back. */
 	signIn(): Promise<void>;
 	/** Offers the account's cloud vaults and links the one that is picked. */
@@ -27,13 +27,19 @@ export interface SignInHost {
 }
 
 export class KnapSettingsTab extends PluginSettingTab {
+	/**
+	 * ``plugin`` is the real plugin, not a stand-in. Obsidian registers the tab
+	 * against it, and handing it an object that merely looks like one threw
+	 * during onload -- which took everything registered after that call with
+	 * it, the ribbon icon included.
+	 */
 	constructor(
-		app: App,
+		plugin: Plugin,
 		private readonly sync: KnapSync,
-		private readonly host: SignInHost,
+		private readonly actions: SignInActions,
 		private readonly serverUrl: string,
 	) {
-		super(app, host as never);
+		super(plugin.app, plugin);
 	}
 
 	display(): void {
@@ -56,7 +62,7 @@ export class KnapSettingsTab extends PluginSettingTab {
 						.setButtonText("Sign in")
 						.setCta()
 						.onClick(() => {
-							void this.host
+							void this.actions
 								.signIn()
 								.then(() => {
 									new Notice("Signed in. Now link this vault to a cloud vault.");
@@ -80,7 +86,7 @@ export class KnapSettingsTab extends PluginSettingTab {
 					.setButtonText(linked ? "Link a different one" : "Link a cloud vault")
 					.setCta()
 					.onClick(() => {
-						void this.host
+						void this.actions
 							.pickAndLink()
 							.then(() => this.display())
 							.catch((error: Error) => new Notice(error.message));

--- a/src/knap/ObsidianKnap.ts
+++ b/src/knap/ObsidianKnap.ts
@@ -98,7 +98,7 @@ export function registerKnapBeta(host: KnapHost): KnapSync | null {
 				}),
 		);
 
-	host.addSettingTab(new KnapSettingsTab(host.app, sync, { app: host.app, signIn, pickAndLink }, serverUrl));
+	host.addSettingTab(new KnapSettingsTab(host, sync, { signIn, pickAndLink }, serverUrl));
 
 	host.registerObsidianProtocolHandler(SIGNIN_ACTION, (params) => {
 		const fed = sync.handleDeepLink(params as unknown as Record<string, string>);

--- a/src/main.ts
+++ b/src/main.ts
@@ -420,7 +420,19 @@ export default class Live extends Plugin {
 
 		// The rebuild's beta switch: a no-op unless the build carries a
 		// server address (src/knap/ObsidianKnap.ts).
-		this.knapSync = registerKnapBeta(this);
+		//
+		// Wrapped, because this runs early in onload and everything after it
+		// depends on onload finishing. A first version of the beta's settings
+		// tab threw here, and what a person saw was the ribbon icon gone --
+		// registered eighty lines further down, and never reached. A half-built
+		// beta layer is worth a notice; it is not worth the plugin.
+		try {
+			this.knapSync = registerKnapBeta(this);
+		} catch (error) {
+			this.knapSync = null;
+			console.error("[Knap] the beta layer failed to start", error);
+			new Notice("Knap: the beta layer failed to start. The rest of the plugin is fine.");
+		}
 
 		// Migrate relay-onprem settings from legacy single-server format to multi-server
 		const rawRelayOnPremSettings = this.settings.get().relayOnPrem;


### PR DESCRIPTION
Two bugs, and the second is why the first was invisible.

**The tab was built wrong.** `KnapSettingsTab` handed `PluginSettingTab` an
object that merely looked like a plugin (`{ app, signIn, pickAndLink }`).
Obsidian registers the tab against that, so it threw.

**And the throw was fatal.** `registerKnapBeta` runs early in `onload`; the
ribbon icon is registered eighty lines further down. So the symptom was the
icon disappearing from the sidebar, with nothing on screen connecting it to a
settings tab added the same day.

The tab takes the real plugin now, and the call is wrapped: a half-built beta
layer is worth a notice and a console line, not the rest of the plugin.

763 tests, including one pinning the try/catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)