### PR TITLE
A Sign out button, and it hands the token back

### DIFF
--- a/__tests__/knap/KnapServer.test.ts
+++ b/__tests__/knap/KnapServer.test.ts
@@ -41,6 +41,36 @@ describe("KnapServer", () => {
 		);
 	});
 
+	it("hands the token back on sign out, and takes a dead one for done", async () => {
+		const seen: string[] = [];
+		const { fetchFn, calls } = fakeFetch({
+			"/auth/plugin/signout": (init) => {
+				seen.push((init?.headers as Record<string, string>).Authorization);
+				return new Response(null, { status: 204 });
+			},
+		});
+		const server = new KnapServer("https://knap.test", fetchFn);
+
+		await server.signOut("knap_abc");
+		expect(calls[0].init?.method).toBe("POST");
+		expect(seen).toEqual(["Bearer knap_abc"]);
+
+		// A token the server already forgot is the outcome, not a failure.
+		const gone = fakeFetch({
+			"/auth/plugin/signout": () => new Response("{}", { status: 401 }),
+		});
+		await expect(new KnapServer("https://knap.test", gone.fetchFn).signOut("oud")).resolves
+			.toBeUndefined();
+	});
+
+	it("says the sign out did not land when the server breaks", async () => {
+		const { fetchFn } = fakeFetch({
+			"/auth/plugin/signout": () => new Response("{}", { status: 500 }),
+		});
+		const server = new KnapServer("https://knap.test", fetchFn);
+		await expect(server.signOut("knap_abc")).rejects.toThrow(/did not land/);
+	});
+
 	it("lists vaults in the plugin's shape", async () => {
 		const { fetchFn, calls } = fakeFetch({
 			"/api/vaults": () =>

--- a/__tests__/knap/settingsTab.test.ts
+++ b/__tests__/knap/settingsTab.test.ts
@@ -10,7 +10,7 @@
 
 import { KnapSettingsTab } from "../../src/knap/KnapSettingsTab";
 
-type Row = { name: string; desc: string; buttons: string[] };
+type Row = { name: string; desc: string; buttons: string[]; press?: () => void };
 
 /** A stand-in for Obsidian's Setting, recording what the screen asked for. */
 function fakeContainer(rows: Row[]) {
@@ -45,7 +45,10 @@ jest.mock("obsidian", () => {
 					return button;
 				},
 				setCta: () => button,
-				onClick: () => button,
+				onClick: (run: () => void) => {
+					this.row.press = run;
+					return button;
+				},
 			};
 			build(button);
 			return this;
@@ -61,15 +64,32 @@ jest.mock("obsidian", () => {
 	return { Setting, PluginSettingTab, Notice: class {}, App: class {} };
 });
 
-function tabFor(state: { signedIn: boolean; linked: null | { id: string; name: string } }) {
-	const rows: Row[] = [];
-	const sync = {
-		signedIn: state.signedIn,
-		linked: state.linked
-			? { cloudVaultId: state.linked.id, cloudVaultName: state.linked.name, token: "t" }
-			: null,
-		unlink: async () => {},
+/** A stand-in KnapSync that remembers whether it was signed out. */
+function fakeSync(state: { signedIn: boolean; linked: null | { id: string; name: string } }) {
+	let signedIn = state.signedIn;
+	let linked = state.linked;
+	return {
+		get signedIn() {
+			return signedIn;
+		},
+		get linked() {
+			return linked
+				? { cloudVaultId: linked.id, cloudVaultName: linked.name, token: "t" }
+				: null;
+		},
+		unlink: async () => {
+			linked = null;
+		},
+		signOut: async () => {
+			signedIn = false;
+			linked = null;
+			return { endedRemotely: true };
+		},
 	};
+}
+
+function tabWith(sync: ReturnType<typeof fakeSync>) {
+	const rows: Row[] = [];
 	const plugin = { app: {} };
 	const actions = { signIn: async () => {}, pickAndLink: async () => {} };
 	const tab = new KnapSettingsTab(
@@ -81,6 +101,10 @@ function tabFor(state: { signedIn: boolean; linked: null | { id: string; name: s
 	tab.containerEl = fakeContainer(rows) as never;
 	tab.display();
 	return rows;
+}
+
+function tabFor(state: { signedIn: boolean; linked: null | { id: string; name: string } }) {
+	return tabWith(fakeSync(state));
 }
 
 describe("the beta's settings screen", () => {
@@ -104,5 +128,32 @@ describe("the beta's settings screen", () => {
 		expect(rows.map((r) => r.desc).join(" ")).toContain("Pantalytics_v03");
 		expect(rows.flatMap((r) => r.buttons)).toContain("Unlink");
 		expect(rows.map((r) => r.desc).join(" ")).toContain("Nothing is deleted");
+	});
+
+	it("offers a way back out in both signed-in states", () => {
+		// The screen had no way out at all: the only way to stop being signed
+		// in on a device was to uninstall the plugin, which leaves the token
+		// alive anyway.
+		for (const linked of [null, { id: "v1", name: "Pantalytics_v03" }]) {
+			const rows = tabFor({ signedIn: true, linked });
+			expect(rows.flatMap((r) => r.buttons)).toContain("Sign out");
+			// Unlink stops the syncing; sign out is the account, and says so.
+			const out = rows.find((r) => r.name === "Sign out");
+			expect(out?.desc).toContain("this device");
+			expect(out?.desc).toContain("Your notes stay");
+		}
+	});
+
+	it("signs out when the button is pressed, and comes back offering sign in", async () => {
+		const sync = fakeSync({ signedIn: true, linked: { id: "v1", name: "Pantalytics_v03" } });
+		const rows = tabWith(sync);
+
+		rows.find((r) => r.name === "Sign out")?.press?.();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// The same rows array, redrawn: nothing about the account is left.
+		expect(rows.flatMap((r) => r.buttons)).toEqual(["Sign in"]);
+		expect(rows.map((r) => r.desc).join(" ")).not.toContain("Pantalytics_v03");
 	});
 });

--- a/__tests__/knap/signOut.test.ts
+++ b/__tests__/knap/signOut.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Signing out, as the engine does it: sockets down, token handed back,
+ * settings emptied.
+ *
+ * The plugin had no way out. Sign in, link, unlink -- and then the only way
+ * to stop being signed in on a device was to uninstall, which leaves the
+ * token in the tokens table opening `/sync` and `/mcp` for whoever has the
+ * laptop next. So the local half is not the whole act, and neither is the
+ * remote half: the two tests here are the two halves failing separately.
+ */
+
+import { KnapSync } from "../../src/knap/KnapSync";
+import type { KnapLink } from "../../src/knap/KnapSync";
+import type { FileStore } from "../../src/knap/VaultBinding";
+
+/** Files are beside the point here: nothing in a sign-out touches them. */
+const noFiles: FileStore = {
+	read: async () => null,
+	write: async () => {},
+	remove: async () => {},
+	rename: async () => {},
+	listNotes: async () => [],
+	onChange: () => () => {},
+};
+
+function syncWith(
+	stored: KnapLink | null,
+	fetchFn: (url: string, init?: RequestInit) => Promise<Response>,
+) {
+	let held = stored;
+	const sync = new KnapSync({
+		serverUrl: "https://knap.test",
+		deviceName: "Laptop",
+		fetchFn,
+		files: noFiles,
+		load: () => held,
+		save: async (value) => {
+			held = value;
+		},
+	});
+	return { sync, held: () => held };
+}
+
+const signedIn: KnapLink = { token: "knap_abc", cloudVaultId: "v1", cloudVaultName: "Demo" };
+
+describe("signing out", () => {
+	it("hands the token back and forgets the account and the link", async () => {
+		const calls: { url: string; init?: RequestInit }[] = [];
+		const { sync, held } = syncWith(signedIn, async (url, init) => {
+			calls.push({ url, init });
+			return new Response(null, { status: 204 });
+		});
+
+		expect(await sync.signOut()).toEqual({ endedRemotely: true });
+
+		expect(calls[0].url).toBe("https://knap.test/auth/plugin/signout");
+		expect((calls[0].init?.headers as Record<string, string>).Authorization).toBe(
+			"Bearer knap_abc",
+		);
+		// The link goes with the account: a remembered cloud vault without a
+		// token is a settings row promising a sync that cannot happen.
+		expect(held()).toBeNull();
+		expect(sync.signedIn).toBe(false);
+		expect(sync.linked).toBeNull();
+		expect(sync.running).toBe(false);
+	});
+
+	it("still signs out on this device when nothing can be reached", async () => {
+		const { sync, held } = syncWith(signedIn, async () => {
+			throw new Error("offline");
+		});
+
+		// Somebody pressing this on a train is signing out. Refusing because
+		// the network is gone would leave them signed in with an error.
+		expect(await sync.signOut()).toEqual({ endedRemotely: false });
+		expect(held()).toBeNull();
+		expect(sync.signedIn).toBe(false);
+	});
+
+	it("says nothing to the server when there was no token to hand back", async () => {
+		const calls: string[] = [];
+		const { sync, held } = syncWith(null, async (url) => {
+			calls.push(url);
+			return new Response(null, { status: 204 });
+		});
+
+		expect(await sync.signOut()).toEqual({ endedRemotely: true });
+		expect(calls).toEqual([]);
+		expect(held()).toBeNull();
+	});
+});

--- a/src/knap/KnapServer.ts
+++ b/src/knap/KnapServer.ts
@@ -2,9 +2,10 @@
  * The Knap server, as the plugin speaks to it (ADR-0073, the rebuild).
  *
  * One server, known at build time (ADR-0033), and one credential: the token
- * the sign-in flow minted. Four conversations, and nothing else:
+ * the sign-in flow minted. Five conversations, and nothing else:
  *
  * - the sign-in exchange: a one-time code in, the plugin's token out
+ * - the sign-out: the token handed back, so it stops opening anything
  * - which cloud vaults this account may open, and what it may do there
  * - the address of a document's sync socket
  * - attachments, up and down, as plain bytes
@@ -74,6 +75,25 @@ export class KnapServer {
 			throw new KnapServerError("The server answered without a token.", response.status);
 		}
 		return body.token;
+	}
+
+	/**
+	 * Hand the token back. Signing out that only forgot it here would leave a
+	 * working credential behind on a laptop somebody is passing on, which is
+	 * the one moment a person presses this.
+	 *
+	 * A 401 is the outcome, not a failure: the token is already gone, which
+	 * is what sign out is for. Anything else throws, so the screen can say
+	 * that the token may still be live rather than claim it is not.
+	 */
+	async signOut(token: string): Promise<void> {
+		const response = await this.fetchFn(`${this.baseUrl}/auth/plugin/signout`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		if (!response.ok && response.status !== 401) {
+			throw new KnapServerError("The sign-out did not land.", response.status);
+		}
 	}
 
 	/** The cloud vaults this account may open. */

--- a/src/knap/KnapSettingsTab.ts
+++ b/src/knap/KnapSettingsTab.ts
@@ -1,5 +1,5 @@
 /**
- * The one screen the rebuilt client has: sign in, link, unlink.
+ * The one screen the rebuilt client has: sign in, link, unlink, sign out.
  *
  * It exists because the three commands were the only way in, and a command
  * palette is where somebody looks after they already know the thing is there.
@@ -7,16 +7,32 @@
  * look for a button -- and in a beta build the relay's own tab is hidden, so
  * they found nothing at all.
  *
- * Three lines and at most two buttons, because there are only ever three
+ * Three lines and at most three buttons, because there are only ever three
  * states: signed out, signed in but not linked, and linked. No server field
  * (ADR-0033): which server this build talks to is baked in, and the screen
  * says which one rather than offering a choice.
+ *
+ * Signed in, there is always a way back out. A screen that can only sign in
+ * is one a person cannot hand their laptop on from, and the only alternative
+ * was uninstalling the plugin -- which leaves the token alive anyway.
  */
 
 import { Notice, type Plugin, PluginSettingTab, Setting } from "obsidian";
 
 import type { CloudVault } from "./KnapServer";
 import type { KnapSync } from "./KnapSync";
+
+/**
+ * What to say after a sign-out. One sentence, two entry points: this button
+ * and the command in the palette, which must not drift apart into two
+ * accounts of the same act.
+ */
+export function signOutNotice(endedRemotely: boolean): string {
+	return endedRemotely
+		? "Signed out. Nothing was deleted, anywhere."
+		: "Signed out on this device. Knap could not be reached, so this device may still " +
+				"count as signed in there.";
+}
 
 /** The two acts the buttons perform, so the screen shares them with the commands. */
 export interface SignInActions {
@@ -109,5 +125,20 @@ export class KnapSettingsTab extends PluginSettingTab {
 					}),
 				);
 		}
+
+		new Setting(containerEl)
+			.setName("Sign out")
+			.setDesc(
+				"Ends the sign-in on this device and stops the syncing. Your notes stay " +
+					"where they are, here and in the cloud vault.",
+			)
+			.addButton((button) =>
+				button.setButtonText("Sign out").onClick(() => {
+					void this.sync.signOut().then(({ endedRemotely }) => {
+						new Notice(signOutNotice(endedRemotely));
+						this.display();
+					});
+				}),
+			);
 	}
 }

--- a/src/knap/KnapSync.ts
+++ b/src/knap/KnapSync.ts
@@ -8,6 +8,12 @@
  * and `unlink` stops the sockets and clears the remembered vault while the
  * sign-in survives, because the account and the link are different facts.
  *
+ * `signOut` is the other direction of the same distinction: the account
+ * goes, and the link goes with it, because a link is to a cloud vault of
+ * the account that is leaving. Holding one without a token would be a
+ * settings row that says this vault syncs with something it can no longer
+ * reach, and that is how a device ends up showing somebody else's folders.
+ *
  * Persistence goes through two callbacks rather than a settings object, so
  * the host (Obsidian's data.json in production, a dict in tests) stays out
  * of the engine.
@@ -107,6 +113,35 @@ export class KnapSync {
 		if (stored) {
 			await this.options.save({ ...stored, cloudVaultId: "", cloudVaultName: "" });
 		}
+	}
+
+	/**
+	 * End the sign-in on this device: sockets down, token handed back, and
+	 * everything this vault remembered about the account forgotten.
+	 *
+	 * The local half always happens, network or no network. Somebody
+	 * pressing this on a train is signing out, and a plugin that refused
+	 * because it could not reach anything would leave them signed in with
+	 * an error on screen. `endedRemotely` says which of the two it was, so
+	 * the screen can be honest about a token that may still be live.
+	 */
+	async signOut(): Promise<{ endedRemotely: boolean }> {
+		this.stop();
+		this.flow.cancel(new Error("Signed out before this sign-in finished."));
+		const stored = this.options.load();
+		let endedRemotely = true;
+		if (stored?.token) {
+			try {
+				await this.server.signOut(stored.token);
+			} catch {
+				// Swallowed on purpose: whatever went wrong out there does
+				// not change what happens here, and the only thing the
+				// screen needs from it is that it did not land.
+				endedRemotely = false;
+			}
+		}
+		await this.options.save(null);
+		return { endedRemotely };
 	}
 
 	/** Bring the link up, if there is one. Safe to call at plugin load. */

--- a/src/knap/ObsidianKnap.ts
+++ b/src/knap/ObsidianKnap.ts
@@ -3,7 +3,7 @@
  *
  * `KNAP_SERVER_URL` is an esbuild define, empty in every ordinary build.
  * Empty means this whole file registers nothing and the plugin behaves
- * exactly as before; set, it adds the protocol handler and three commands,
+ * exactly as before; set, it adds the protocol handler and four commands,
  * and one test vault can point at the new server while everything else
  * stays where it is. That is the switch phase 2's plan asks for, and it is
  * build-time on purpose: no screen offers a server field (ADR-0033).
@@ -18,7 +18,7 @@ import type { CloudVault } from "./KnapServer";
 import { KnapSync } from "./KnapSync";
 import type { KnapLink } from "./KnapSync";
 import { ObsidianFileStore } from "./ObsidianFileStore";
-import { KnapSettingsTab } from "./KnapSettingsTab";
+import { KnapSettingsTab, signOutNotice } from "./KnapSettingsTab";
 import { SIGNIN_ACTION } from "./SignInFlow";
 import { obsidianFetch } from "./obsidianFetch";
 
@@ -127,6 +127,16 @@ export function registerKnapBeta(host: KnapHost): KnapSync | null {
 		name: "Link this vault to a cloud vault (beta)",
 		callback: () => {
 			pickAndLink().catch((error: Error) => new Notice(error.message));
+		},
+	});
+
+	host.addCommand({
+		id: "knap-beta-sign-out",
+		name: "Sign out (beta)",
+		callback: () => {
+			void sync
+				.signOut()
+				.then(({ endedRemotely }) => new Notice(signOutNotice(endedRemotely)));
 		},
 	});
 


### PR DESCRIPTION
## Summary

The beta's settings screen had a way in and no way out: sign in, link, unlink. Somebody handing on a laptop, or who signed in as the wrong account, had nothing to press. Uninstalling the plugin is not a sign-out either: the token it minted keeps opening `/sync` and `/mcp`.

- **A Sign out row on the settings screen**, under Unlink, plus a `Sign out (beta)` command that shares the screen's own sentence so the two cannot drift apart.
- **Unlink and sign out stay different acts.** Unlink stops this vault syncing; sign out ends the account on this device, and takes the link with it, because a remembered cloud vault without a token is a settings row promising a sync that cannot happen, and a link nobody can check is how a device ends up holding another vault's folders (ADR-0066).
- **Two halves, and either can fail alone.** The local half always happens: somebody pressing this on a train is signing out, and refusing because the network is gone would leave them signed in with an error on screen. The remote half is `KnapServer.signOut`, against the new `POST /auth/plugin/signout` in the admin repo, which deletes the token's row. When it cannot be reached the notice says so rather than claiming the token is dead. A 401 is the outcome, not a failure: the token is already gone.

Server half: pantalytics/knap-mcp-admin, branch `claude/obsidian-plugin-sign-out-9kosjn`. Merge that first, or a beta build's Sign out reports that Knap could not be reached (and still signs out here).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (six pre-existing warnings, no new ones)
- [ ] Tested in Obsidian -- not yet. The wire itself is measured across both repositories by the admin repo's `plugin_against_knap_server` spike, which now ends by calling this `KnapServer.signOut` and then this `KnapServer.listVaults` with the same token, and the second is refused. What is still unproven is the button in a real Obsidian.
- [x] Changes are minimal and focused

770 tests pass, including three new ones for the engine (`__tests__/knap/signOut.test.ts`: the token goes back, the settings empty, and it still signs out with nothing reachable), two for the screen and two for the HTTP call.

---
_Generated by [Claude Code](https://claude.ai/code/session_013QEBZXY3uiKoSJNnLSpuHk)_