### PR TITLE
A note got a second document, and then no name at all

### DIFF
--- a/__tests__/knap/VaultBinding.test.ts
+++ b/__tests__/knap/VaultBinding.test.ts
@@ -61,6 +61,35 @@ class MemoryFiles implements FileStore {
 class Hub {
 	private byId = new Map<string, Y.Doc[]>();
 
+	/**
+	 * How long the tree takes to arrive after its socket opens. Zero is the
+	 * shape every test had before: the document is full the instant it is
+	 * opened, which no websocket has ever managed. Set it and a device starts
+	 * on an empty tree, which is what a real one does.
+	 */
+	treeDelay = 0;
+
+	/** The tree as the server holds it. */
+	treeOf(): Y.Map<string> {
+		const peers = this.byId.get("tree") ?? [];
+		return (peers[0] ?? new Y.Doc()).getMap<string>("files");
+	}
+
+	/** Every document that has ever been opened, minus the tree. */
+	documentCount(): number {
+		return [...this.byId.keys()].filter((id) => id !== "tree").length;
+	}
+
+	/** Point a path at a different document, with the given text in it. */
+	repoint(path: string, docId: string, text: string): void {
+		const doc = new Y.Doc();
+		doc.getText("content").insert(0, text);
+		const peers = this.byId.get(docId) ?? [];
+		peers.push(doc);
+		this.byId.set(docId, peers);
+		this.treeOf().set(path, docId);
+	}
+
 	device(): VaultDocs {
 		const mine = new Map<string, { doc: Y.Doc; synced: Promise<void> }>();
 		let tree: TreeDoc | null = null;
@@ -69,10 +98,14 @@ class Hub {
 			if (!entry) {
 				const doc = new Y.Doc();
 				const peers = this.byId.get(docId) ?? [];
-				for (const peer of peers) {
-					Y.applyUpdate(doc, Y.encodeStateAsUpdate(peer));
-					Y.applyUpdate(peer, Y.encodeStateAsUpdate(doc));
-				}
+				const late = docId === "tree" && this.treeDelay > 0;
+				const fill = () => {
+					for (const peer of peers) {
+						if (peer === doc) continue;
+						Y.applyUpdate(doc, Y.encodeStateAsUpdate(peer));
+						Y.applyUpdate(peer, Y.encodeStateAsUpdate(doc));
+					}
+				};
 				const relay = (source: Y.Doc, targets: () => Y.Doc[]) => {
 					source.on("update", (update: Uint8Array, origin: unknown) => {
 						if (origin === "hub") return;
@@ -84,13 +117,25 @@ class Hub {
 				peers.push(doc);
 				this.byId.set(docId, peers);
 				relay(doc, () => this.byId.get(docId) ?? []);
-				entry = { doc, synced: Promise.resolve() };
+				let synced = Promise.resolve();
+				if (late) {
+					synced = new Promise<void>((resolve) =>
+						setTimeout(() => {
+							fill();
+							resolve();
+						}, this.treeDelay),
+					);
+				} else {
+					fill();
+				}
+				entry = { doc, synced };
 				mine.set(docId, entry);
 			}
 			return entry;
 		};
 		return {
 			tree: () => (tree ??= new TreeDoc(open("tree").doc)),
+			treeSynced: () => open("tree").synced,
 			note: (docId: string) => open(docId),
 		};
 	}
@@ -159,6 +204,44 @@ describe("VaultBinding", () => {
 
 		expect(b.files.map.has("oud.md")).toBe(false);
 		expect(b.files.map.get("Archief/nieuw.md")).toBe("tekst");
+	});
+
+	it("a device that starts before the tree arrives does not mint a second document", async () => {
+		// Measured on production 2026-08-31: one note ended up with two
+		// documents and then no name in the tree at all, and vanished from
+		// every device. The binding reconciled against a tree that had not
+		// synced yet, so every local file looked new.
+		const hub = new Hub();
+		const a = await device(hub, { "Welkom.md": "# Welkom\n" });
+		await settle(a.binding);
+		const first = a.binding ? hub.treeOf().get("Welkom.md") : undefined;
+
+		hub.treeDelay = 5;
+		const b = await device(hub, { "Welkom.md": "# Welkom\n" });
+		await settle(a.binding, b.binding);
+
+		expect(hub.treeOf().get("Welkom.md")).toBe(first);
+		expect(hub.documentCount()).toBe(1);
+	});
+
+	it("a note whose tree entry changes id stays on disk and in the tree", async () => {
+		// The other half of the same failure: an update to a tree entry was
+		// reported as removed plus added, and the removed half deleted the
+		// file. The delete event that followed then took the path out of the
+		// tree on every device.
+		const hub = new Hub();
+		const a = await device(hub, { "Welkom.md": "# Welkom\n" });
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+
+		// Somebody points the path at a different document, the way a device
+		// starting on an empty tree used to.
+		hub.repoint("Welkom.md", "1111ffff2222aaaa3333bbbb4444cccc", "# Welkom\n");
+		await settle(a.binding, b.binding);
+
+		expect(a.files.map.has("Welkom.md")).toBe(true);
+		expect(b.files.map.has("Welkom.md")).toBe(true);
+		expect(hub.treeOf().has("Welkom.md")).toBe(true);
 	});
 
 	it("a delete leaves the tree and the other device's disk", async () => {

--- a/__tests__/knap/VaultBinding.test.ts
+++ b/__tests__/knap/VaultBinding.test.ts
@@ -244,6 +244,25 @@ describe("VaultBinding", () => {
 		expect(hub.treeOf().has("Welkom.md")).toBe(true);
 	});
 
+	it("a tree that never arrives fails the link with a sentence, not a hang", async () => {
+		// The cost of waiting for the tree: a socket that never syncs would
+		// leave the Link button waiting with nothing on screen.
+		jest.useFakeTimers();
+		try {
+			const hub = new Hub();
+			hub.treeDelay = 10 * 60 * 1000; // longer than the binding waits
+			const files = new MemoryFiles();
+			const binding = new VaultBinding(files, hub.device(), () => "conflict");
+			const started = binding.start();
+			const caught = started.catch((error: Error) => error.message);
+			await jest.advanceTimersByTimeAsync(31_000);
+
+			await expect(caught).resolves.toContain("Could not reach the server");
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
 	it("a delete leaves the tree and the other device's disk", async () => {
 		const hub = new Hub();
 		const a = await device(hub, { "weg.md": "x" });

--- a/src/knap/KnapVaultClient.ts
+++ b/src/knap/KnapVaultClient.ts
@@ -54,6 +54,11 @@ export class KnapVaultClient {
 		return this.treeDoc;
 	}
 
+	/** Resolves once the tree has had its first sync with the server. */
+	treeSynced(): Promise<void> {
+		return this.openDoc(TREE_DOC_ID).synced;
+	}
+
 	/** A note's live document, by id. Reuses an open socket. */
 	note(docId: string): OpenDoc {
 		return this.openDoc(docId);

--- a/src/knap/VaultBinding.ts
+++ b/src/knap/VaultBinding.ts
@@ -60,6 +60,26 @@ export interface VaultDocs {
 
 const CONTENT = "content";
 
+/** How long to wait for the tree's first sync before giving up on a link. */
+const TREE_SYNC_TIMEOUT_MS = 30_000;
+
+/** Reject with `message` if `promise` has not settled in `ms`. */
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = window.setTimeout(() => reject(new Error(message)), ms);
+		promise.then(
+			(value) => {
+				window.clearTimeout(timer);
+				resolve(value);
+			},
+			(error: unknown) => {
+				window.clearTimeout(timer);
+				reject(error instanceof Error ? error : new Error(String(error)));
+			},
+		);
+	});
+}
+
 /** Y.Text implements toString; the lint rule cannot see that through AbstractType. */
 function textOf(content: Y.Text): string {
 	// eslint-disable-next-line @typescript-eslint/no-base-to-string -- Y.Text has a real toString
@@ -139,7 +159,16 @@ export class VaultBinding {
 		// Measured on production 2026-08-31: a device that reconciled against
 		// an empty tree minted a fresh document for a path that already had
 		// one, and the note ended up with two documents and no name.
-		await this.docs.treeSynced();
+		//
+		// Bounded, because a socket that never syncs would otherwise leave
+		// the Link button waiting with nothing on screen. Giving up here is
+		// better than reconciling against a tree that never arrived: the
+		// caller gets a sentence it can show, and the next start tries again.
+		await withTimeout(
+			this.docs.treeSynced(),
+			TREE_SYNC_TIMEOUT_MS,
+			"Could not reach the server. Nothing was changed; try again.",
+		);
 		const tree = this.docs.tree();
 		const local = new Set((await this.files.listNotes()).map(normalize));
 		const remote = tree.entries();

--- a/src/knap/VaultBinding.ts
+++ b/src/knap/VaultBinding.ts
@@ -47,6 +47,14 @@ export interface FileStore {
 /** What the binding needs from the wire. KnapVaultClient satisfies it. */
 export interface VaultDocs {
 	tree(): TreeDoc;
+	/**
+	 * Resolves once the tree has had its first sync with the server.
+	 *
+	 * Opening the tree's socket hands back a document immediately, and for a
+	 * moment that document is empty. Reconciling against it is how a note
+	 * that already exists in the cloud gets a second document minted for it.
+	 */
+	treeSynced(): Promise<void>;
 	note(docId: string): { doc: Y.Doc; synced: Promise<void> };
 }
 
@@ -90,7 +98,15 @@ export class VaultBinding {
 					// the added half above already wrote the new file, so the old
 					// path goes either way. Only a note that left the tree for
 					// good stops being watched.
-					await this.files.remove(path);
+					//
+					// A path in both halves is not a departure: it is the same
+					// note pointed at a different document. Removing the file
+					// there deletes a note nobody deleted, and the delete event
+					// that follows takes the path out of the tree on every
+					// device. Measured on production 2026-08-31.
+					if (!change.added.has(path)) {
+						await this.files.remove(path);
+					}
 					if (this.docs.tree().pathFor(docId) === undefined) {
 						this.unobserveNote(docId);
 					}
@@ -119,6 +135,11 @@ export class VaultBinding {
 	// -- link time -----------------------------------------------------------
 
 	private async reconcileAll(): Promise<void> {
+		// Wait for the tree before deciding anything is missing from it.
+		// Measured on production 2026-08-31: a device that reconciled against
+		// an empty tree minted a fresh document for a path that already had
+		// one, and the note ended up with two documents and no name.
+		await this.docs.treeSynced();
 		const tree = this.docs.tree();
 		const local = new Set((await this.files.listNotes()).map(normalize));
 		const remote = tree.entries();


### PR DESCRIPTION
Closes pantalytics/knap-mcp-admin#146.

Measured on production 2026-08-31, the first day a phone and a Mac had one vault open together. `Welkom.md` ended up with **two** documents holding the same 192 characters, the tree named **neither**, and every device tidied the file away. A line the AI had written into it two minutes earlier went with it.

## Two defects, and it takes both

**1. The binding reconciled against a tree that had not arrived.** `tree()` opens the socket and hands back the document immediately, and for a moment that document is empty. `reconcileAll` read it right then, concluded every local file was absent from the cloud, and called `ensureNote` for each. That mints a fresh id for a path that already has one. There is the second document.

It now waits on `treeSynced()` before deciding anything is missing. `KnapVaultClient` grew the method; it is the `synced` promise the tree's socket already had.

**2. An update to a tree entry deleted the file.** `TreeDoc.onChange` reports an update as removed plus added, and the binding's removed half called `files.remove(path)`. That deletes a note nobody deleted; the delete event that follows calls `tree.remove(path)`, and the removal travels to every device. A path in both halves is the same note pointed at a different document, so the file stays. A move, which is removed and added under two different paths, is unaffected.

## Why no test caught it

The test hub filled the tree the instant it was opened, which no websocket has ever managed, so the window the bug lives in did not exist. The hub now has a `treeDelay`, and two walks use it:

- a device that starts before the tree arrives does not mint a second document
- a note whose tree entry changes id stays on disk and in the tree

Both fail without the fix.

## Checks

- 761 tests pass, `tsc -noEmit` clean, and `src/knap/` lints clean.
- `scripts/spikes/plugin_against_knap_server/` in knap-mcp-admin still holds all ten claims against a real running server, which is the only thing that notices when the two repositories stop agreeing.

**Not covered:** the orphaned documents already on the server. Two of them hold the old `Welkom.md` and nothing names them. Cleaning those up is the server's side of pantalytics/knap-mcp-admin#146 and is not in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)