### PR TITLE
A note deleted here is deleted in the cloud vault

### DIFF
--- a/__tests__/knap/ObsidianSeenTree.test.ts
+++ b/__tests__/knap/ObsidianSeenTree.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The record of what this device last agreed with, on a fake adapter.
+ *
+ * Everything here is about being wrong in the safe direction: an empty
+ * record deletes nothing, and every way of failing to read one produces an
+ * empty record rather than a guess.
+ */
+
+import { ObsidianSeenTree } from "../../src/knap/ObsidianSeenTree";
+
+class FakeAdapter {
+	files = new Map<string, string>();
+
+	async read(path: string): Promise<string> {
+		const found = this.files.get(path);
+		if (found === undefined) throw new Error("ENOENT");
+		return found;
+	}
+	async write(path: string, data: string): Promise<void> {
+		this.files.set(path, data);
+	}
+	async exists(path: string): Promise<boolean> {
+		return this.files.has(path);
+	}
+	async remove(path: string): Promise<void> {
+		this.files.delete(path);
+	}
+}
+
+const PATH = ".obsidian/plugins/synced-vaults/knap-seen.json";
+
+function treeFor(adapter: FakeAdapter, vaultId = "cloud-1") {
+	return new ObsidianSeenTree(adapter as never, PATH, vaultId);
+}
+
+describe("ObsidianSeenTree", () => {
+	it("hands back what it wrote down", async () => {
+		const adapter = new FakeAdapter();
+		const seen = treeFor(adapter);
+		await seen.save(new Map([["Notes/plan.md", "doc-1"]]));
+
+		expect(await treeFor(adapter).load()).toEqual(new Map([["Notes/plan.md", "doc-1"]]));
+	});
+
+	it("says nothing about a different cloud vault", async () => {
+		// Reading one vault's record as another's is how linking to a second
+		// cloud vault would start by deleting notes out of it.
+		const adapter = new FakeAdapter();
+		await treeFor(adapter, "cloud-1").save(new Map([["Notes/plan.md", "doc-1"]]));
+
+		expect(await treeFor(adapter, "cloud-2").load()).toEqual(new Map());
+	});
+
+	it("a record that is not there, or not readable, is an empty one", async () => {
+		const adapter = new FakeAdapter();
+		expect(await treeFor(adapter).load()).toEqual(new Map());
+
+		adapter.files.set(PATH, "{ this is not json");
+		expect(await treeFor(adapter).load()).toEqual(new Map());
+	});
+
+	it("forgetting leaves nothing behind, and forgetting twice is fine", async () => {
+		const adapter = new FakeAdapter();
+		const seen = treeFor(adapter);
+		await seen.save(new Map([["Notes/plan.md", "doc-1"]]));
+
+		await seen.forget();
+		await seen.forget();
+
+		expect(adapter.files.has(PATH)).toBe(false);
+		expect(await seen.load()).toEqual(new Map());
+	});
+});

--- a/__tests__/knap/TreeDoc.test.ts
+++ b/__tests__/knap/TreeDoc.test.ts
@@ -68,6 +68,27 @@ describe("TreeDoc", () => {
 		expect(treeB.docIdFor("van-a.md")).toBe(idA);
 	});
 
+	it("a folder takes the notes under it out of the tree, and nothing else", () => {
+		const tree = new TreeDoc(new Y.Doc());
+		const een = tree.ensureNote("Map/een.md");
+		tree.ensureNote("Map/diep/twee.md");
+		tree.ensureNote("Mapje/anders.md");
+		tree.ensureNote("los.md");
+
+		const gone = tree.removeUnder("Map");
+
+		expect(gone).toContain(een);
+		expect(gone).toHaveLength(2);
+		expect([...tree.entries().keys()].sort()).toEqual(["Mapje/anders.md", "los.md"]);
+	});
+
+	it("there is no deleting the vault itself", () => {
+		const tree = new TreeDoc(new Y.Doc());
+		tree.ensureNote("los.md");
+		expect(tree.removeUnder("")).toEqual([]);
+		expect(tree.entries().size).toBe(1);
+	});
+
 	it("never lets a path leave the vault", () => {
 		const tree = new TreeDoc(new Y.Doc());
 		expect(() => tree.ensureNote("../buiten.md")).toThrow(/never leaves/);

--- a/__tests__/knap/VaultBinding.test.ts
+++ b/__tests__/knap/VaultBinding.test.ts
@@ -14,6 +14,7 @@ import { TreeDoc } from "../../src/knap/TreeDoc";
 import {
 	FileEvent,
 	FileStore,
+	SeenTree,
 	VaultBinding,
 	VaultDocs,
 	splice,
@@ -54,6 +55,21 @@ class MemoryFiles implements FileStore {
 	}
 	emit(event: FileEvent): void {
 		for (const listener of [...this.listeners]) listener(event);
+	}
+}
+
+/** The tree this device last agreed with, surviving a restart in memory. */
+class MemorySeen implements SeenTree {
+	entries: Map<string, string> | null = null;
+
+	async load(): Promise<Map<string, string>> {
+		return new Map(this.entries ?? []);
+	}
+	async save(entries: Map<string, string>): Promise<void> {
+		this.entries = new Map(entries);
+	}
+	async forget(): Promise<void> {
+		this.entries = null;
 	}
 }
 
@@ -141,12 +157,22 @@ class Hub {
 	}
 }
 
-async function device(hub: Hub, seed: Record<string, string> = {}) {
+async function device(hub: Hub, seed: Record<string, string> = {}, seen: SeenTree | null = null) {
 	const files = new MemoryFiles();
 	for (const [path, text] of Object.entries(seed)) files.map.set(path, text);
-	const binding = new VaultBinding(files, hub.device(), () => "conflict");
+	const binding = new VaultBinding(files, hub.device(), () => "conflict", seen);
 	await binding.start();
 	return { files, binding };
+}
+
+/**
+ * The same device, started again: the same disk, the same record, and fresh
+ * documents, because a restart is exactly a set of sockets opening again.
+ */
+async function restart(hub: Hub, files: MemoryFiles, seen: SeenTree | null = null) {
+	const binding = new VaultBinding(files, hub.device(), () => "conflict", seen);
+	await binding.start();
+	return binding;
 }
 
 const settle = async (...bindings: VaultBinding[]) => {
@@ -273,6 +299,134 @@ describe("VaultBinding", () => {
 		await settle(a.binding, b.binding);
 
 		expect(b.files.map.has("weg.md")).toBe(false);
+	});
+
+	it("deleting a folder takes the notes in it out of the tree", async () => {
+		// Obsidian's delete event for a folder names the folder and not the
+		// notes in it. Left at that, the notes stayed in the tree and came
+		// straight back down onto the disk they had just been deleted from.
+		const hub = new Hub();
+		const a = await device(hub, {
+			"Map/een.md": "x",
+			"Map/twee.md": "y",
+			"los.md": "z",
+		});
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+
+		a.files.map.delete("Map/een.md");
+		a.files.map.delete("Map/twee.md");
+		a.files.emit({ type: "delete", path: "Map" });
+		await settle(a.binding, b.binding);
+
+		expect(hub.treeOf().has("Map/een.md")).toBe(false);
+		expect(b.files.map.has("Map/twee.md")).toBe(false);
+		expect(b.files.map.get("los.md")).toBe("z");
+	});
+
+	it("a note deleted while the plugin was not running is deleted in the cloud vault", async () => {
+		// The delete somebody makes with Obsidian closed, or with the plugin
+		// off, or on a laptop that never got back online before it was shut.
+		// No event ever fires for it, so the only trace is a file that is not
+		// where the record says it was.
+		const hub = new Hub();
+		const seen = new MemorySeen();
+		const a = await device(hub, { "weg.md": "x", "blijft.md": "y" }, seen);
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+		expect(b.files.map.get("weg.md")).toBe("x");
+
+		a.binding.stop();
+		a.files.map.delete("weg.md");
+
+		const back = await restart(hub, a.files, seen);
+		await settle(back, b.binding);
+
+		expect(hub.treeOf().has("weg.md")).toBe(false);
+		expect(a.files.map.has("weg.md")).toBe(false);
+		expect(b.files.map.has("weg.md")).toBe(false);
+		expect(b.files.map.get("blijft.md")).toBe("y");
+	});
+
+	it("a note deleted in the cloud vault while the device was away goes from its disk", async () => {
+		// The same fact from the other end: this device kept the note, so on
+		// the next start it used to upload it again under a new document and
+		// undo somebody else's delete on every device.
+		const hub = new Hub();
+		const seen = new MemorySeen();
+		const a = await device(hub, { "weg.md": "x" }, seen);
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+
+		a.binding.stop();
+		await b.files.remove("weg.md");
+		await settle(b.binding);
+
+		const back = await restart(hub, a.files, seen);
+		await settle(back, b.binding);
+
+		expect(a.files.map.has("weg.md")).toBe(false);
+		expect(hub.treeOf().has("weg.md")).toBe(false);
+	});
+
+	it("a note that arrived while the device was away is still downloaded", async () => {
+		// The record may only speak about notes it has seen. Reading a note
+		// it has never heard of as a deletion is how this would eat the work
+		// of every other device.
+		const hub = new Hub();
+		const seen = new MemorySeen();
+		const a = await device(hub, { "eigen.md": "x" }, seen);
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+
+		a.binding.stop();
+		await b.files.write("nieuw.md", "van B");
+		await settle(b.binding);
+
+		const back = await restart(hub, a.files, seen);
+		await settle(back, b.binding);
+
+		expect(a.files.map.get("nieuw.md")).toBe("van B");
+		expect(a.files.map.get("eigen.md")).toBe("x");
+	});
+
+	it("a vault whose files have not loaded deletes nothing", async () => {
+		// A vault Obsidian is still opening answers "which notes are here"
+		// with too few, and a vault somebody emptied answers it with none.
+		// The two are the same answer, and only one of them is worth acting
+		// on, so the empty one is not acted on at all.
+		const hub = new Hub();
+		const seen = new MemorySeen();
+		const a = await device(hub, { "een.md": "x", "twee.md": "y" }, seen);
+		await settle(a.binding);
+		a.binding.stop();
+
+		const unloaded = new MemoryFiles();
+		const back = await restart(hub, unloaded, seen);
+		await settle(back);
+
+		expect(hub.treeOf().has("een.md")).toBe(true);
+		expect(hub.treeOf().has("twee.md")).toBe(true);
+		expect(unloaded.map.get("een.md")).toBe("x");
+	});
+
+	it("without a record a restart deletes nothing on either side", async () => {
+		// A device linking for the first time, and every device before this
+		// record existed: a missing file is a note that has not arrived yet,
+		// so it arrives. Nothing is deleted anywhere on the strength of a
+		// guess.
+		const hub = new Hub();
+		const a = await device(hub, { "weg.md": "x" });
+		await settle(a.binding);
+
+		a.binding.stop();
+		a.files.map.delete("weg.md");
+
+		const back = await restart(hub, a.files);
+		await settle(back);
+
+		expect(hub.treeOf().has("weg.md")).toBe(true);
+		expect(a.files.map.get("weg.md")).toBe("x");
 	});
 
 	it("a note arriving where an unsynced local file sits keeps both", async () => {

--- a/__tests__/knap/settingsTab.test.ts
+++ b/__tests__/knap/settingsTab.test.ts
@@ -126,6 +126,8 @@ describe("the beta's settings screen", () => {
 	it("names the linked vault, and offers unlink beside it", () => {
 		const rows = tabFor({ signedIn: true, linked: { id: "v1", name: "Pantalytics_v03" } });
 		expect(rows.map((r) => r.desc).join(" ")).toContain("Pantalytics_v03");
+		// A person deleting a note is entitled to know it goes on both sides.
+		expect(rows.map((r) => r.desc).join(" ")).toContain("delete here");
 		expect(rows.flatMap((r) => r.buttons)).toContain("Unlink");
 		expect(rows.map((r) => r.desc).join(" ")).toContain("Nothing is deleted");
 	});

--- a/src/knap/KnapSettingsTab.ts
+++ b/src/knap/KnapSettingsTab.ts
@@ -94,7 +94,8 @@ export class KnapSettingsTab extends PluginSettingTab {
 			.setName("This vault")
 			.setDesc(
 				linked?.name
-					? `Syncs with the cloud vault ${linked.name}.`
+					? `Syncs with the cloud vault ${linked.name}. A note you delete here ` +
+						"goes from the cloud vault too, and a note deleted there goes from here."
 					: "Signed in, and not linked to a cloud vault yet.",
 			)
 			.addButton((button) =>

--- a/src/knap/KnapSync.ts
+++ b/src/knap/KnapSync.ts
@@ -14,12 +14,18 @@
  * settings row that says this vault syncs with something it can no longer
  * reach, and that is how a device ends up showing somebody else's folders.
  *
+ * Unlink and sign out also throw away what this device remembered of the
+ * cloud vault's tree. Both say on screen that nothing is deleted anywhere,
+ * and a kept record would make a later relink start by deleting whatever
+ * was removed here in between. No memory means no deletions, which is what
+ * linking has always done.
+ *
  * Persistence goes through two callbacks rather than a settings object, so
  * the host (Obsidian's data.json in production, a dict in tests) stays out
  * of the engine.
  */
 
-import type { FileStore } from "./VaultBinding";
+import type { FileStore, SeenTree } from "./VaultBinding";
 import { VaultBinding } from "./VaultBinding";
 import type { CloudVault, Fetch } from "./KnapServer";
 import { KnapServer } from "./KnapServer";
@@ -42,6 +48,8 @@ export interface KnapSyncOptions {
 	save: (value: KnapLink | null) => Promise<void>;
 	/** Injected in tests; Obsidian's platform WebSocket by default. */
 	webSocket?: WebSocketImpl;
+	/** Where this device remembers a cloud vault's tree, if anywhere. */
+	makeSeen?: (cloudVaultId: string) => SeenTree;
 }
 
 export class KnapSync {
@@ -109,6 +117,7 @@ export class KnapSync {
 	/** End the link. Stops the syncing, deletes nothing on either side. */
 	async unlink(): Promise<void> {
 		this.stop();
+		await this.forgetSeen();
 		const stored = this.options.load();
 		if (stored) {
 			await this.options.save({ ...stored, cloudVaultId: "", cloudVaultName: "" });
@@ -128,6 +137,7 @@ export class KnapSync {
 	async signOut(): Promise<{ endedRemotely: boolean }> {
 		this.stop();
 		this.flow.cancel(new Error("Signed out before this sign-in finished."));
+		await this.forgetSeen();
 		const stored = this.options.load();
 		let endedRemotely = true;
 		if (stored?.token) {
@@ -157,8 +167,29 @@ export class KnapSync {
 			this.options.deviceName,
 			this.options.webSocket,
 		);
-		this.binding = new VaultBinding(this.options.files, this.client);
+		this.binding = new VaultBinding(
+			this.options.files,
+			this.client,
+			undefined,
+			this.options.makeSeen?.(stored.cloudVaultId) ?? null,
+		);
 		await this.binding.start();
+	}
+
+	/**
+	 * Forget the tree this device remembered. Never fatal: the caller is
+	 * unlinking or signing out, and a record that outlives it costs a relink
+	 * that deletes nothing, which is the same thing the record not existing
+	 * would have done.
+	 */
+	private async forgetSeen(): Promise<void> {
+		const id = this.options.load()?.cloudVaultId;
+		if (!id || !this.options.makeSeen) return;
+		try {
+			await this.options.makeSeen(id).forget();
+		} catch {
+			// Nothing to say and nothing to do: see above.
+		}
 	}
 
 	stop(): void {

--- a/src/knap/ObsidianFileStore.ts
+++ b/src/knap/ObsidianFileStore.ts
@@ -8,9 +8,13 @@
  * not have to tell them apart. And Obsidian's `create` events replay for
  * every existing file at vault load, so the adapter starts listening only
  * when told, after the link-time reconcile has the tree.
+ *
+ * One event is not a note and is passed on anyway: deleting a folder
+ * deletes the notes in it, and Obsidian's delete names the folder. The
+ * binding takes every note under that path out of the tree.
  */
 
-import { FileManager, normalizePath, TAbstractFile, TFile, Vault } from "obsidian";
+import { FileManager, normalizePath, TAbstractFile, TFile, TFolder, Vault } from "obsidian";
 
 import type { FileEvent, FileStore } from "./VaultBinding";
 
@@ -73,9 +77,16 @@ export class ObsidianFileStore implements FileStore {
 				callback({ type, path: file.path, oldPath });
 			}
 		};
+		const onDelete = (file: TAbstractFile) => {
+			if (file instanceof TFolder) {
+				callback({ type: "delete", path: file.path });
+				return;
+			}
+			toEvent("delete")(file);
+		};
 		const created = this.vault.on("create", toEvent("create"));
 		const modified = this.vault.on("modify", toEvent("modify"));
-		const deleted = this.vault.on("delete", toEvent("delete"));
+		const deleted = this.vault.on("delete", onDelete);
 		const renamed = this.vault.on("rename", toEvent("rename"));
 		return () => {
 			this.vault.offref(created);

--- a/src/knap/ObsidianKnap.ts
+++ b/src/knap/ObsidianKnap.ts
@@ -18,6 +18,7 @@ import type { CloudVault } from "./KnapServer";
 import { KnapSync } from "./KnapSync";
 import type { KnapLink } from "./KnapSync";
 import { ObsidianFileStore } from "./ObsidianFileStore";
+import { ObsidianSeenTree } from "./ObsidianSeenTree";
 import { KnapSettingsTab, signOutNotice } from "./KnapSettingsTab";
 import { SIGNIN_ACTION } from "./SignInFlow";
 import { obsidianFetch } from "./obsidianFetch";
@@ -74,6 +75,12 @@ export function registerKnapBeta(host: KnapHost): KnapSync | null {
 		files: new ObsidianFileStore(host.app.vault, host.app.fileManager),
 		load: () => host.getKnapLink(),
 		save: (value) => host.saveKnapLink(value),
+		makeSeen: (cloudVaultId) =>
+			new ObsidianSeenTree(
+				host.app.vault.adapter,
+				`${host.app.vault.configDir}/plugins/${host.manifest.id}/knap-seen.json`,
+				cloudVaultId,
+			),
 	});
 
 	const signIn = () => sync.signIn((url) => window.open(url));
@@ -148,9 +155,18 @@ export function registerKnapBeta(host: KnapHost): KnapSync | null {
 		},
 	});
 
-	// A vault that was linked before this start comes back up on its own.
-	void sync.start().catch(() => {
-		new Notice("Knap could not reach your cloud vault. It will retry when you sign in again.");
+	// A vault that was linked before this start comes back up on its own,
+	// and not one moment before the layout is ready. The first thing the
+	// binding does is ask Obsidian which notes this vault holds, and a vault
+	// that has not finished loading answers that with too few. Since a note
+	// missing from disk is now read as a note somebody deleted, starting
+	// early would take the rest of the vault out of the cloud with it.
+	host.app.workspace.onLayoutReady(() => {
+		void sync.start().catch(() => {
+			new Notice(
+				"Knap could not reach your cloud vault. It will retry when you sign in again.",
+			);
+		});
 	});
 	return sync;
 }

--- a/src/knap/ObsidianSeenTree.ts
+++ b/src/knap/ObsidianSeenTree.ts
@@ -1,0 +1,71 @@
+/**
+ * What this device last agreed with, kept in the plugin's own directory.
+ *
+ * The binding needs one fact across a restart: which notes were in the tree
+ * the last time the disk and the tree matched. With it, a file that is gone
+ * is a note somebody deleted; without it, a file that is gone is a note that
+ * has not arrived yet, and the two are indistinguishable.
+ *
+ * It lives beside the plugin rather than in its settings for two reasons.
+ * It is a fact about this device and no other, so it may never ride along
+ * with anything that syncs (ADR-0067 refuses `plugins/**` for exactly this),
+ * and a vault of a few thousand notes makes it far larger than the settings
+ * blob that is rewritten on every change.
+ *
+ * The cloud vault's id is written next to the paths and checked on the way
+ * back in. A record made against one cloud vault says nothing about another,
+ * and reading it as though it did is how a link to a second vault would
+ * start by deleting notes out of it.
+ */
+
+import { normalizePath } from "obsidian";
+import type { DataAdapter } from "obsidian";
+
+import type { SeenTree } from "./VaultBinding";
+
+interface Stored {
+	cloudVaultId: string;
+	files: Record<string, string>;
+}
+
+export class ObsidianSeenTree implements SeenTree {
+	constructor(
+		private readonly adapter: DataAdapter,
+		private readonly path: string,
+		private readonly cloudVaultId: string,
+	) {}
+
+	/**
+	 * The remembered tree, or an empty one.
+	 *
+	 * Every failure lands on empty on purpose. An empty record is the state
+	 * a first link is in, and it deletes nothing on either side: the binding
+	 * only removes a note where the record positively says it used to be
+	 * there. A record that cannot be read is one this device does not have.
+	 */
+	async load(): Promise<Map<string, string>> {
+		try {
+			const raw = await this.adapter.read(normalizePath(this.path));
+			const stored = JSON.parse(raw) as Stored;
+			if (stored.cloudVaultId !== this.cloudVaultId) return new Map();
+			return new Map(Object.entries(stored.files ?? {}));
+		} catch {
+			return new Map();
+		}
+	}
+
+	async save(entries: Map<string, string>): Promise<void> {
+		const stored: Stored = {
+			cloudVaultId: this.cloudVaultId,
+			files: Object.fromEntries(entries),
+		};
+		await this.adapter.write(normalizePath(this.path), JSON.stringify(stored));
+	}
+
+	async forget(): Promise<void> {
+		const clean = normalizePath(this.path);
+		if (await this.adapter.exists(clean)) {
+			await this.adapter.remove(clean);
+		}
+	}
+}

--- a/src/knap/TreeDoc.ts
+++ b/src/knap/TreeDoc.ts
@@ -82,6 +82,32 @@ export class TreeDoc {
 	}
 
 	/**
+	 * Every note under a folder leaves the tree with the folder, in one
+	 * transaction. Deleting a folder in Obsidian deletes the notes in it,
+	 * and the delete that arrives names the folder rather than each note,
+	 * so without this the notes would stay in the tree and come back down
+	 * onto the disk they were just deleted from.
+	 *
+	 * Returns the document ids that left, so the caller can stop watching
+	 * them. An empty prefix removes nothing: there is no deleting the vault.
+	 */
+	removeUnder(folder: string): string[] {
+		const clean = normalize(folder);
+		if (!clean) return [];
+		const prefix = `${clean}/`;
+		const gone: string[] = [];
+		this.doc.transact(() => {
+			for (const [path, docId] of [...this.files.entries()]) {
+				if (path.startsWith(prefix)) {
+					this.files.delete(path);
+					gone.push(docId);
+				}
+			}
+		});
+		return gone;
+	}
+
+	/**
 	 * Watch the tree. The callback gets what appeared and what left; a moved
 	 * note shows up in both, under the same id. Returns an unsubscribe.
 	 */

--- a/src/knap/VaultBinding.ts
+++ b/src/knap/VaultBinding.ts
@@ -21,6 +21,11 @@
  *   notes download, and a note that exists on both sides with different
  *   text keeps the cloud text while the local text survives as a conflict
  *   copy beside it. Nothing is ever silently lost.
+ * - A note deleted here is deleted in the cloud vault, and the other way
+ *   round, whether or not the plugin was running when it happened. That is
+ *   what the `SeenTree` is for: without a record of what this device last
+ *   agreed with, a missing file and a note that never arrived look the
+ *   same, and every restart undid both sides\' deletes.
  */
 
 import * as Y from "yjs";
@@ -58,6 +63,25 @@ export interface VaultDocs {
 	note(docId: string): { doc: Y.Doc; synced: Promise<void> };
 }
 
+/**
+ * What this device last agreed with: path -> document id, as the tree read
+ * the moment the binding had finished applying it to the disk.
+ *
+ * It is the base of a three-way comparison, and it is the only thing that
+ * can tell a note somebody deleted here from a note that has not arrived
+ * yet. A device that has none behaves the way linking always has: nothing
+ * is deleted on either side, both sides merge.
+ *
+ * Per cloud vault, and local to the device. `forget` is what unlink and
+ * sign out call, so a later relink starts from no memory and keeps their
+ * promise that nothing is deleted anywhere.
+ */
+export interface SeenTree {
+	load(): Promise<Map<string, string>>;
+	save(entries: Map<string, string>): Promise<void>;
+	forget(): Promise<void>;
+}
+
 const CONTENT = "content";
 
 /** How long to wait for the tree's first sync before giving up on a link. */
@@ -91,11 +115,14 @@ export class VaultBinding {
 	private stopTreeEvents: (() => void) | null = null;
 	private noteObservers = new Map<string, () => void>();
 	private queue: Promise<void> = Promise.resolve();
+	/** Set whenever this device changed the tree, cleared when it is saved. */
+	private seenDirty = false;
 
 	constructor(
 		private readonly files: FileStore,
 		private readonly docs: VaultDocs,
 		private readonly conflictLabel = () => `conflict ${new Date().toISOString().slice(0, 10)}`,
+		private readonly seen: SeenTree | null = null,
 	) {}
 
 	/**
@@ -110,6 +137,7 @@ export class VaultBinding {
 		});
 		this.stopTreeEvents = this.docs.tree().onChange((change) => {
 			void this.enqueue(async () => {
+				this.seenDirty = true;
 				for (const [path, docId] of change.added) {
 					await this.bindNote(path, docId);
 				}
@@ -148,8 +176,27 @@ export class VaultBinding {
 	}
 
 	private enqueue(work: () => Promise<void>): Promise<void> {
-		this.queue = this.queue.then(work, work);
+		// The record is written only where `work` returned: a unit that threw
+		// half way leaves the disk and the tree disagreeing, and remembering
+		// that as agreed is how the next start deletes what it failed to
+		// write. Work still runs on both settle paths, so one failure does
+		// not wedge the queue.
+		this.queue = this.queue.then(work, work).then(() => this.rememberTree());
 		return this.queue;
+	}
+
+	/** Write down the tree this device now agrees with. Failing is survivable. */
+	private async rememberTree(): Promise<void> {
+		if (!this.seenDirty || !this.seen) return;
+		this.seenDirty = false;
+		try {
+			await this.seen.save(this.docs.tree().entries());
+		} catch {
+			// A record that could not be written is a record that stays
+			// older than it is, and older is the safe direction: every
+			// deletion below needs the record to positively say so.
+			this.seenDirty = true;
+		}
 	}
 
 	// -- link time -----------------------------------------------------------
@@ -172,13 +219,36 @@ export class VaultBinding {
 		const tree = this.docs.tree();
 		const local = new Set((await this.files.listNotes()).map(normalize));
 		const remote = tree.entries();
+		const seen = (await this.seen?.load()) ?? new Map<string, string>();
+
+		// A vault whose files have not been indexed yet reads exactly like a
+		// vault somebody emptied, and only one of those two is worth acting
+		// on. The plugin starts the binding after the layout is ready for
+		// this reason; this is the second lock on the same door, because the
+		// cost of being wrong here is every note in the cloud vault.
+		const emptied = local.size === 0 && seen.size > 0;
 
 		for (const path of local) {
-			if (!remote.has(path)) {
+			if (remote.has(path)) continue;
+			if (seen.has(path)) {
+				// It was in the tree when this device last looked and it is
+				// not now: it was deleted in the cloud vault while this
+				// device was away. A delete is a delete, in both directions.
+				await this.files.remove(path);
+			} else {
 				await this.pushNote(path);
 			}
 		}
 		for (const [path, docId] of remote) {
+			if (!local.has(path) && !emptied && seen.get(path) === docId) {
+				// The same note, at the same path, as this device last had
+				// it on disk, and the file is gone. Somebody deleted it here
+				// while the plugin was not running. Without the record this
+				// downloaded the note back, every time, on every device.
+				tree.remove(path);
+				this.seenDirty = true;
+				continue;
+			}
 			await this.bindNote(path, docId);
 		}
 	}
@@ -191,6 +261,7 @@ export class VaultBinding {
 			const from = normalize(event.oldPath);
 			if (tree.docIdFor(from) !== undefined) {
 				tree.move(from, event.path);
+				this.seenDirty = true;
 				return;
 			}
 			await this.pushNote(event.path);
@@ -198,8 +269,18 @@ export class VaultBinding {
 		}
 		if (event.type === "delete") {
 			const path = normalize(event.path);
+			if (!path.endsWith(".md")) {
+				// A folder. Obsidian deletes the notes inside it, and the
+				// tree has to lose them too, or they come back down onto the
+				// disk they were just deleted from.
+				for (const docId of tree.removeUnder(path)) {
+					this.unobserveNote(docId);
+					this.seenDirty = true;
+				}
+				return;
+			}
 			const docId = tree.docIdFor(path);
-			tree.remove(path);
+			if (tree.remove(path)) this.seenDirty = true;
 			if (docId) this.unobserveNote(docId);
 			return;
 		}
@@ -214,7 +295,9 @@ export class VaultBinding {
 		if (text === null) return; // gone again before we got to it
 
 		const tree = this.docs.tree();
+		const known = tree.docIdFor(clean);
 		const docId = tree.ensureNote(clean);
+		if (known === undefined) this.seenDirty = true;
 		const { doc, synced } = this.docs.note(docId);
 		await synced;
 		const content = doc.getText(CONTENT);


### PR DESCRIPTION
## Summary

A note deleted on a device should be deleted in the cloud vault. With the plugin running it already is: the delete event takes the path out of the tree, and the server drops the markdown and tells every other device. Deletes made while the plugin was *not* running were undone at the next start, in both directions.

The cause is that the plugin keeps no documents on disk (`KnapVaultClient.openDoc` makes a fresh `Y.Doc` per socket, every start), so `reconcileAll` compared two facts where it needed three: the disk on one side, the tree on the other, and no record of what this device last agreed with. A missing file read as a note that had not arrived, so it was downloaded again. A path the tree had lost read as a new local note, so it was uploaded again under a fresh document. Somebody else's delete was undone by any device that had been offline.

So the device writes the tree down, per cloud vault, in its own plugin directory (`ObsidianSeenTree`), and that record is the third fact. The binding only deletes where the record positively vouches for it: a note it has never heard of is still a note that has not arrived.

Also in here:

- **Two locks on the door that costs a whole vault.** A vault Obsidian is still loading answers "which notes are here" with none, exactly like a vault somebody emptied. The binding now starts at `onLayoutReady`, and it refuses to act on an empty answer anyway. The cost is stated plainly: emptying an entire vault with the plugin closed does nothing, and the notes come back.
- **Folders.** Obsidian's delete event for a folder names the folder, and the file store passed on only `.md` `TFile`s, so the notes under a deleted folder stayed in the tree and came back down onto the disk they had just been deleted from. `TreeDoc.removeUnder` takes them all out in one transaction. Whether Obsidian *also* fires a delete per child note is unmeasured; both behaviours give the same result, because taking a note out of the tree twice is a no-op.
- **Unlink and sign out throw the record away.** Both say on screen that nothing is deleted anywhere, and a kept record would make a later relink act on what happened in between.
- One line of copy on the settings screen, because a person deleting a note is entitled to know it goes on both sides.

The decision is written up as ADR-0075, with the server's half of it under test, in [pantalytics/knap-mcp-admin#151](https://github.com/pantalytics/knap-mcp-admin/pull/151).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (no new errors; the 6 warnings are pre-existing)
- [ ] Tested in Obsidian — **not done.** Everything here is covered by jest against real Yjs docs and a relaying hub, including a restart with a deletion in the gap, but the two claims that need a real Obsidian are the ones jest cannot make: that `onLayoutReady` fires after the file index is complete, and what Obsidian's delete event actually emits for a folder.
- [x] Changes are minimal and focused

## Test plan

New in `__tests__/knap/VaultBinding.test.ts`, each one a device stopping, its disk changing underneath it, and the device starting again:

- a note deleted while the plugin was not running is deleted in the cloud vault
- a note deleted in the cloud vault while the device was away goes from its disk
- a note that arrived while the device was away is still downloaded (the record may only speak about notes it has seen)
- a vault whose files have not loaded deletes nothing
- without a record a restart deletes nothing on either side (the old behaviour, kept honest)
- deleting a folder takes the notes in it out of the tree

Plus `TreeDoc.removeUnder` and `ObsidianSeenTree` unit tests. Full suite: 785 tests, all green.
