### PR TITLE
The health poll asks for a route the server serves

### DIFF
--- a/__tests__/NetworkStatus.test.ts
+++ b/__tests__/NetworkStatus.test.ts
@@ -25,14 +25,14 @@ describe("NetworkStatus (TR-26: offline detection dead when url is empty)", () =
 
 	test("start() with a url polls on the interval", async () => {
 		mockRequestUrl.mockResolvedValue({ status: 200, json: { status: "ok" } });
-		const status = new NetworkStatus(timeProvider, "https://cp.example.com/v1/health", 1000);
+		const status = new NetworkStatus(timeProvider, "https://cp.example.com/healthz", 1000);
 		status.start();
 
 		timeProvider.setTime(timeProvider.getTime() + 1000);
 		await Promise.resolve();
 
 		expect(mockRequestUrl).toHaveBeenCalledWith(
-			expect.objectContaining({ url: "https://cp.example.com/v1/health" }),
+			expect.objectContaining({ url: "https://cp.example.com/healthz" }),
 		);
 	});
 
@@ -46,17 +46,17 @@ describe("NetworkStatus (TR-26: offline detection dead when url is empty)", () =
 		timeProvider.setTime(timeProvider.getTime() + 5000);
 		expect(mockRequestUrl).not.toHaveBeenCalled();
 
-		status.updateUrl("https://cp.example.com/v1/health");
+		status.updateUrl("https://cp.example.com/healthz");
 		timeProvider.setTime(timeProvider.getTime() + 1000);
 		await Promise.resolve();
 
 		expect(mockRequestUrl).toHaveBeenCalledWith(
-			expect.objectContaining({ url: "https://cp.example.com/v1/health" }),
+			expect.objectContaining({ url: "https://cp.example.com/healthz" }),
 		);
 	});
 
 	test("offline/online callbacks fire around a failed then recovered check", async () => {
-		const status = new NetworkStatus(timeProvider, "https://cp.example.com/v1/health", 1000);
+		const status = new NetworkStatus(timeProvider, "https://cp.example.com/healthz", 1000);
 		const onOffline = jest.fn();
 		const onOnline = jest.fn();
 		status.addEventListener("offline", onOffline);
@@ -82,7 +82,7 @@ describe("NetworkStatus (TR-26: offline detection dead when url is empty)", () =
 
 	test("stop() actually stops the polling, and start() can resume it", async () => {
 		mockRequestUrl.mockResolvedValue({ status: 200, json: { status: "ok" } });
-		const status = new NetworkStatus(timeProvider, "https://cp.example.com/v1/health", 1000);
+		const status = new NetworkStatus(timeProvider, "https://cp.example.com/healthz", 1000);
 		status.start();
 
 		timeProvider.setTime(timeProvider.getTime() + 1000);
@@ -102,9 +102,28 @@ describe("NetworkStatus (TR-26: offline detection dead when url is empty)", () =
 		expect(mockRequestUrl).toHaveBeenCalledTimes(2);
 	});
 
+	test("a 404 from the health route counts as offline", async () => {
+		// Why the path matters: the plugin polled /v1/health, the old control
+		// plane's route, and knap_server serves /healthz. Every answer was a
+		// 404, and a 404 lands here -- online goes false, the token store
+		// stops, folders disconnect, and the note on screen gets a banner.
+		mockRequestUrl.mockResolvedValue({ status: 404, json: undefined });
+		const status = new NetworkStatus(timeProvider, "https://cp.example.com/healthz", 1000);
+		const onOffline = jest.fn();
+		status.addEventListener("offline", onOffline);
+		status.start();
+
+		timeProvider.setTime(timeProvider.getTime() + 1000);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(status.online).toBe(false);
+		expect(onOffline).toHaveBeenCalledTimes(1);
+	});
+
 	test("destroy() stops the timer, so a torn-down instance cannot keep firing", async () => {
 		mockRequestUrl.mockResolvedValue({ status: 200, json: { status: "ok" } });
-		const status = new NetworkStatus(timeProvider, "https://cp.example.com/v1/health", 1000);
+		const status = new NetworkStatus(timeProvider, "https://cp.example.com/healthz", 1000);
 		status.start();
 		status.destroy();
 

--- a/__tests__/RelayOnPremConfig.test.ts
+++ b/__tests__/RelayOnPremConfig.test.ts
@@ -9,6 +9,7 @@ import {
 	MIN_SUPPORTED_SERVER_VERSION,
 	compareSemver,
 	isServerVersionSupported,
+	healthUrlForServer,
 	knapServer,
 	migrateRelayOnPremSettings,
 	serverCompatMessage,
@@ -292,5 +293,29 @@ describe("what this vault syncs", () => {
 		expect(knapServer()).not.toHaveProperty("lastUserEmail");
 		expect(knapServer()).not.toHaveProperty("syncMode");
 		expect(knapServer("a@b.test").lastUserEmail).toBe("a@b.test");
+	});
+});
+
+describe("the health check asks for a route the server serves", () => {
+	test("it is /healthz, the route knap_server answers", () => {
+		// Measured against a real create_app on 2026-09-01: /healthz answers
+		// 200, and the /v1/health this used to ask for answers 404. Anything
+		// but 200 puts the plugin offline, so the wrong path here is a device
+		// that disconnects itself ten seconds after Obsidian starts and tells
+		// its owner they are offline while they are signed in and online.
+		expect(healthUrlForServer(makeServer())).toBe(
+			"https://cp.tr.entire.vc/healthz",
+		);
+	});
+
+	test("no query string, and one slash however the address was typed", () => {
+		expect(
+			healthUrlForServer(makeServer({ controlPlaneUrl: "https://cp.test///" })),
+		).toBe("https://cp.test/healthz");
+	});
+
+	test("no server, or one without an address, means no polling at all", () => {
+		expect(healthUrlForServer(undefined)).toBe("");
+		expect(healthUrlForServer(makeServer({ controlPlaneUrl: "" }))).toBe("");
 	});
 });

--- a/src/RelayOnPremConfig.ts
+++ b/src/RelayOnPremConfig.ts
@@ -104,6 +104,30 @@ export function knapServer(lastUserEmail?: string): RelayOnPremServer {
 	};
 }
 
+/**
+ * Where the plugin asks whether the server is answering.
+ *
+ * `/healthz` is the route knap_server serves (knap_server/app.py), and the
+ * deploy waits on the same one. It was `/v1/health` until 2026-09-01, which
+ * was the old EVC control plane's path and does not exist here: measured
+ * against a real `create_app`, `/v1/health` answers 404 and `/healthz`
+ * answers 200. A 404 is not a status the poll treats gently -- anything but
+ * 200 means offline, so every device with a working connection went offline
+ * ten seconds after start, stopped its token store, disconnected every folder
+ * and put "You're offline" over the note somebody was reading.
+ *
+ * No version in the query string: that was for the old control plane's
+ * version gate, which this server does not have. The `Relay-Version` header
+ * NetworkStatus already sends is the same fact for anything that ever wants
+ * to read it.
+ */
+export function healthUrlForServer(server?: RelayOnPremServer): string {
+	if (!server?.controlPlaneUrl) {
+		return "";
+	}
+	return `${server.controlPlaneUrl.replace(/\/+$/, "")}/healthz`;
+}
+
 export const DEFAULT_RELAY_ONPREM_SETTINGS: RelayOnPremSettings = {
 	// Knap always uses relay-onprem mode (no System 3 cloud)
 	enabled: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,6 +111,7 @@ import {
 	type RelayOnPremServer,
 	migrateRelayOnPremSettings,
 	getDefaultServer,
+	healthUrlForServer,
 } from "./RelayOnPremConfig";
 import { RelayOnPremTokenProvider } from "./auth/RelayOnPremTokenProvider";
 import {
@@ -214,16 +215,6 @@ const DEFAULT_SETTINGS: RelaySettings = {
 };
 
 declare const GIT_TAG: string;
-
-// relay-onprem control-plane URLs are runtime/per-server config (multi-server,
-// user-editable), not a build-time constant — unlike the EndpointManager's
-// System-3 API_URL/AUTH_URL, there is no fixed default to bake in at build time.
-function healthUrlForServer(server?: RelayOnPremServer): string {
-	if (!server?.controlPlaneUrl) {
-		return "";
-	}
-	return `${server.controlPlaneUrl.replace(/\/+$/, "")}/v1/health?version=${GIT_TAG}`;
-}
 
 export default class Live extends Plugin {
 	appId!: string;


### PR DESCRIPTION
## Summary

The plugin polled `{controlPlaneUrl}/v1/health` every ten seconds. That is the old EVC control plane's route; `knap_server` serves `/healthz` and has since the rebuild. Measured against a real `create_app`: `/v1/health` answers 404, `/healthz` answers 200.

`NetworkStatus` reads anything but a 200 as offline, and offline is not just a label. Ten seconds after Obsidian starts, a signed-in device on a working connection stopped its token store, disconnected every shared folder and put "You're offline -- click to reconnect" across the note on screen. Clicking re-ran the same poll, so it never came back.

What changed:

- `healthUrlForServer` asks for `/healthz`, and moves from `main.ts` into `RelayOnPremConfig.ts`, beside the one server it builds a URL for, so it can be tested.
- The `?version=` query is gone with the control plane that read it. The `Relay-Version` header `NetworkStatus` already sends says the same thing.
- Tests: the URL the poll is built from, and a 404 landing as offline, which is the path that was hit in production.

The companion change in `knap-mcp-admin` puts the claim where it can fail: the cross-repo spike now takes the URL from the plugin's own `healthUrlForServer` and asks a real `knap_server` for it. Verified both ways: `/healthz` passes, `/v1/health` exits non-zero.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [ ] Tested in Obsidian -- **not done.** Verified instead against a real `knap_server`: 863 jest tests pass, and the admin repo's `plugin_against_knap_server` spike bundles this branch's code and gets a 200 on the URL it builds. A run in real Obsidian against the live server is still owed.
- [x] Changes are minimal and focused

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmeV3jnxmrN9ERwzje597d)_