### PR TITLE
Notes take turns on a small pool of sockets (#115)

### DIFF
--- a/__tests__/knap/VaultBinding.test.ts
+++ b/__tests__/knap/VaultBinding.test.ts
@@ -160,10 +160,21 @@ class Hub {
 			}
 			return entry;
 		};
+		// The real client hands a note's document out for the length of one
+		// piece of work and closes the socket again (KnapVaultClient's pool).
+		// This hub lends the same way, synced first, but keeps the documents:
+		// what a device does with a note it has finished with is the pool's
+		// business, and every rule in this file is about what the binding
+		// does while it has one.
 		return {
 			tree: () => (tree ??= new TreeDoc(open("tree").doc)),
 			treeSynced: () => open("tree").synced,
-			note: (docId: string) => open(docId),
+			withNote: async <T,>(docId: string, use: (note: { doc: Y.Doc }) => Promise<T>) => {
+				const entry = open(docId);
+				await entry.synced;
+				return use({ doc: entry.doc });
+			},
+			onNoteClosed: () => () => undefined,
 		};
 	}
 }

--- a/__tests__/knap/socketPool.test.ts
+++ b/__tests__/knap/socketPool.test.ts
@@ -1,0 +1,393 @@
+/**
+ * The socket pool, against a network that runs out of sockets like a browser.
+ *
+ * Issue #115, measured on 2026-08-31: a vault of 2612 notes filled to 297
+ * and stopped, with 258 connections to the server that never moved again,
+ * because every note opened a websocket and none of them ever closed. A
+ * renderer gets 255 of them, and the 256th handshake does not fail: it waits
+ * in a queue nobody answers, so the note that asked for it waits forever and
+ * every note behind it waits on that.
+ *
+ * So the fake network here has a ceiling and goes quiet above it, exactly
+ * the way the real one did. The claims are about what the client does under
+ * that ceiling: it never holds more sockets than the pool allows, a fill of
+ * more notes than a browser has sockets runs to the end, two vaults in one
+ * process both fill, and a note is never closed until what was written into
+ * it has reached the server.
+ *
+ * Real `WebsocketProvider`s over a real y-protocol exchange, because the
+ * thing under test is when a socket exists, and a fake provider would decide
+ * that question itself.
+ */
+
+import * as Y from "yjs";
+import * as encoding from "lib0/encoding";
+import * as decoding from "lib0/decoding";
+import * as syncProtocol from "y-protocols/sync";
+
+import { KnapServer } from "../../src/knap/KnapServer";
+import { KnapVaultClient, NOTE_SOCKET_CAP } from "../../src/knap/KnapVaultClient";
+import { TREE_DOC_ID } from "../../src/knap/TreeDoc";
+import type { FileEvent, FileStore } from "../../src/knap/VaultBinding";
+import { VaultBinding } from "../../src/knap/VaultBinding";
+
+/** What one renderer gets. Above it Chromium queues rather than refuses. */
+const SOCKET_CEILING = 255;
+
+const messageSync = 0;
+
+/**
+ * The server, as far as a socket can tell: one document per room, and every
+ * update relayed to the other sockets in that room.
+ */
+class FakeNetwork {
+	/** Sockets open right now, across every vault in this process. */
+	live = 0;
+	/** The most that were ever open at one instant. The claim of this file. */
+	peak = 0;
+	/** Sockets that asked for a connection above the ceiling and got silence. */
+	refused = 0;
+	/** How many times a room has been connected to, ever. */
+	opens = new Map<string, number>();
+	/** What the room's document held when its last socket closed. */
+	closedWith = new Map<string, string>();
+	docs = new Map<string, Y.Doc>();
+	sockets = new Map<string, Set<FakeSocket>>();
+
+	doc(room: string): Y.Doc {
+		let doc = this.docs.get(room);
+		if (!doc) {
+			doc = new Y.Doc();
+			doc.on("update", (update: Uint8Array, origin: unknown) => {
+				for (const socket of this.sockets.get(room) ?? []) {
+					if (socket !== origin) socket.deliver(update);
+				}
+			});
+			this.docs.set(room, doc);
+		}
+		return doc;
+	}
+
+	text(room: string): string {
+		// eslint-disable-next-line @typescript-eslint/no-base-to-string
+		return this.doc(room).getText("content").toString();
+	}
+
+	/** The WebSocket implementation to hand a client. */
+	get socket(): { new (url: string | URL): unknown } {
+		const network = this;
+		return class Bound extends FakeSocket {
+			constructor(url: string | URL) {
+				super(network, String(url));
+			}
+		};
+	}
+}
+
+class FakeSocket {
+	static readonly OPEN = 1;
+	readonly OPEN = 1;
+	binaryType = "arraybuffer";
+	readyState = 0;
+	bufferedAmount = 0;
+	onopen: (() => void) | null = null;
+	onmessage: ((event: { data: ArrayBuffer }) => void) | null = null;
+	onclose: ((event: unknown) => void) | null = null;
+	onerror: ((event: unknown) => void) | null = null;
+	private readonly room: string;
+
+	constructor(
+		private readonly network: FakeNetwork,
+		url: string,
+	) {
+		this.room = new URL(url).pathname;
+		network.live += 1;
+		network.peak = Math.max(network.peak, network.live);
+		network.opens.set(this.room, (network.opens.get(this.room) ?? 0) + 1);
+		if (network.live > SOCKET_CEILING) {
+			// The bug this file is about: no error, no close, no handshake.
+			network.refused += 1;
+			return;
+		}
+		const room = network.sockets.get(this.room) ?? new Set<FakeSocket>();
+		room.add(this);
+		network.sockets.set(this.room, room);
+		setTimeout(() => {
+			if (this.readyState !== 0) return;
+			this.readyState = 1;
+			this.onopen?.();
+		}, 0);
+	}
+
+	/**
+	 * Send, with a buffer that drains a turn later, the way a real one does.
+	 * A client that closes without waiting for it loses whatever was in it.
+	 */
+	send(data: Uint8Array): void {
+		if (this.readyState !== 1) return;
+		this.bufferedAmount += data.byteLength;
+		const copy = data.slice();
+		setTimeout(() => {
+			this.bufferedAmount -= copy.byteLength;
+			if (this.readyState !== 1) return;
+			this.receive(copy);
+		}, 0);
+	}
+
+	private receive(data: Uint8Array): void {
+		const decoder = decoding.createDecoder(data);
+		const encoder = encoding.createEncoder();
+		if (decoding.readVarUint(decoder) !== messageSync) return; // awareness
+		encoding.writeVarUint(encoder, messageSync);
+		syncProtocol.readSyncMessage(decoder, encoder, this.network.doc(this.room), this);
+		if (encoding.length(encoder) > 1) this.deliver(encoding.toUint8Array(encoder), true);
+	}
+
+	/** A message from the server. `framed` says it is already a sync message. */
+	deliver(payload: Uint8Array, framed = false): void {
+		let message = payload;
+		if (!framed) {
+			const encoder = encoding.createEncoder();
+			encoding.writeVarUint(encoder, messageSync);
+			syncProtocol.writeUpdate(encoder, payload);
+			message = encoding.toUint8Array(encoder);
+		}
+		const bytes = message.slice();
+		setTimeout(() => {
+			if (this.readyState !== 1) return;
+			this.onmessage?.({
+				data: bytes.buffer.slice(
+					bytes.byteOffset,
+					bytes.byteOffset + bytes.byteLength,
+				) as ArrayBuffer,
+			});
+		}, 0);
+	}
+
+	close(): void {
+		if (this.readyState === 3) return;
+		const wasOpen = this.readyState === 1;
+		this.readyState = 3;
+		this.network.live -= 1;
+		this.network.sockets.get(this.room)?.delete(this);
+		if (wasOpen) this.network.closedWith.set(this.room, this.network.text(this.room));
+		this.onclose?.({});
+	}
+}
+
+/** The note half of a vault on disk, in memory. */
+class MemoryFiles implements FileStore {
+	map = new Map<string, string>();
+
+	async read(path: string): Promise<string | null> {
+		return this.map.has(path) ? (this.map.get(path) as string) : null;
+	}
+	async write(path: string, text: string): Promise<void> {
+		this.map.set(path, text);
+	}
+	async remove(path: string): Promise<void> {
+		this.map.delete(path);
+	}
+	async rename(from: string, to: string): Promise<void> {
+		this.map.set(to, this.map.get(from) ?? "");
+		this.map.delete(from);
+	}
+	async readBinary(): Promise<ArrayBuffer | null> {
+		return null;
+	}
+	async writeBinary(): Promise<void> {
+		throw new Error("This store holds notes.");
+	}
+	async listNotes(): Promise<string[]> {
+		return [...this.map.keys()].filter((path) => path.endsWith(".md"));
+	}
+	async listAttachments(): Promise<string[]> {
+		return [];
+	}
+	onChange(_callback: (event: FileEvent) => void): () => void {
+		return () => undefined;
+	}
+}
+
+function clientFor(network: FakeNetwork, vaultId: string): KnapVaultClient {
+	const server = new KnapServer("https://knap.test", async () => new Response("{}"));
+	return new KnapVaultClient(server, vaultId, "knap_token", "Laptop", network.socket);
+}
+
+function vaultOf(count: number, prefix = "Notes"): MemoryFiles {
+	const files = new MemoryFiles();
+	for (let index = 0; index < count; index++) {
+		files.map.set(`${prefix}/note-${index}.md`, `# Note ${index}\n`);
+	}
+	return files;
+}
+
+/** The room a document lives in, as the fake network keys it. */
+const roomOf = (vaultId: string, docId: string) => `/sync/${vaultId}/${docId}`;
+
+describe("the note socket pool", () => {
+	jest.setTimeout(60_000);
+
+	// y-websocket registers a process listener per provider when it thinks it
+	// is on Node, and this file has two vaults' worth of pools open at once.
+	// Obsidian is not Node by that test, so this is jest's noise and not the
+	// plugin's.
+	process.setMaxListeners(0);
+
+	it("fills a vault of more than three hundred notes without ever holding more sockets than the pool", async () => {
+		const network = new FakeNetwork();
+		const client = clientFor(network, "v1");
+		const files = vaultOf(320);
+		const binding = new VaultBinding(files, client, () => "conflict");
+
+		await binding.start();
+		await binding.flush();
+
+		// The whole point: one tree, one pool, and nothing else standing open.
+		expect(network.peak).toBeLessThanOrEqual(NOTE_SOCKET_CAP + 1);
+		expect(network.refused).toBe(0);
+		expect(client.socketCount).toBeLessThanOrEqual(NOTE_SOCKET_CAP + 1);
+		expect(binding.problems).toBe(0);
+
+		// Every note arrived, and the tree names every one of them.
+		const tree = client.tree().entries();
+		expect(tree.size).toBe(320);
+		for (const [path, docId] of tree) {
+			expect(network.text(roomOf("v1", docId))).toBe(files.map.get(path));
+		}
+
+		// And none of them was closed before what it held had got there. A
+		// close that beats the send buffer is an edit nobody ever sees again.
+		let closed = 0;
+		for (const [path, docId] of tree) {
+			const room = roomOf("v1", docId);
+			if (!network.closedWith.has(room)) continue;
+			closed += 1;
+			expect(network.closedWith.get(room)).toBe(files.map.get(path));
+		}
+		expect(closed).toBeGreaterThanOrEqual(320 - NOTE_SOCKET_CAP);
+
+		binding.stop();
+		client.destroy();
+	});
+
+	it("fills two vaults in one process, which is where the ceiling used to be reached", async () => {
+		// The second face of #115, seen 2026-09-01: with the big vault open,
+		// a second vault got its tree socket and then nothing, and said
+		// "could not reach server" over a sign-in that had worked.
+		const network = new FakeNetwork();
+		const first = clientFor(network, "v1");
+		const second = clientFor(network, "v2");
+		const filesOne = vaultOf(300, "Een");
+		const filesTwo = vaultOf(300, "Twee");
+		const one = new VaultBinding(filesOne, first, () => "conflict");
+		const two = new VaultBinding(filesTwo, second, () => "conflict");
+
+		await Promise.all([one.start(), two.start()]);
+		await Promise.all([one.flush(), two.flush()]);
+
+		expect(network.peak).toBeLessThanOrEqual(2 * (NOTE_SOCKET_CAP + 1));
+		expect(network.refused).toBe(0);
+		expect(first.tree().entries().size).toBe(300);
+		expect(second.tree().entries().size).toBe(300);
+		for (const [path, docId] of second.tree().entries()) {
+			expect(network.text(roomOf("v2", docId))).toBe(filesTwo.map.get(path));
+		}
+
+		one.stop();
+		two.stop();
+		first.destroy();
+		second.destroy();
+	});
+
+	it("promotes a note an editor opens instead of reconnecting it, and keeps it through the fill", async () => {
+		const network = new FakeNetwork();
+		const client = clientFor(network, "v1");
+		const tree = client.tree();
+		await client.treeSynced();
+
+		// A note the pool has open, which is what a note somebody opens
+		// during a fill is.
+		const docId = tree.ensureNote("Open.md");
+		await client.withNote(docId, async ({ doc }) => {
+			doc.getText("content").insert(0, "de eerste regel\n");
+		});
+		const room = roomOf("v1", docId);
+		expect(network.opens.get(room)).toBe(1);
+
+		// Obsidian opens it in an editor. Same document, same socket, same
+		// first sync: nothing about it happens twice.
+		const open = client.pin(docId);
+		expect(open.provider.synced).toBe(true);
+		// eslint-disable-next-line @typescript-eslint/no-base-to-string
+		expect(open.text.toString()).toBe("de eerste regel\n");
+
+		// And now the fill goes on around it, several pools deep.
+		const others: string[] = [];
+		for (let index = 0; index < NOTE_SOCKET_CAP * 5; index++) {
+			const other = tree.ensureNote(`Vulling/${index}.md`);
+			others.push(other);
+			await client.withNote(other, async ({ doc }) => {
+				doc.getText("content").insert(0, `nummer ${index}\n`);
+			});
+		}
+
+		// The note the editor is holding was never closed and never asked
+		// for a second connection, so nothing re-synced under the cursor.
+		expect(network.opens.get(room)).toBe(1);
+		expect(network.closedWith.has(room)).toBe(false);
+		expect(open.provider.wsconnected).toBe(true);
+		// The pool did recycle around it, which is what makes that a claim.
+		expect(others.some((id) => network.closedWith.has(roomOf("v1", id)))).toBe(true);
+		expect(network.peak).toBeLessThanOrEqual(NOTE_SOCKET_CAP + 2);
+
+		// Typing in the editor still reaches the server over that socket.
+		open.text.insert(open.text.length, "en de tweede\n");
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(network.text(room)).toBe("de eerste regel\nen de tweede\n");
+
+		open.release();
+		client.destroy();
+	});
+
+	it("leaves nothing open when the vault is unlinked in the middle of a fill", async () => {
+		// Unlink stops the binding and destroys the client, and the fill that
+		// was running does not stop with it: it is a queue of promises, not a
+		// thread. Every note still in the air used to be able to open a fresh
+		// socket to a vault this device had just let go of.
+		const network = new FakeNetwork();
+		const client = clientFor(network, "v1");
+		const binding = new VaultBinding(vaultOf(200), client, () => "conflict");
+
+		const filling = binding.start();
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(network.live).toBeGreaterThan(1); // it really was filling
+		binding.stop();
+		client.destroy();
+		await filling.catch(() => undefined);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		expect(network.live).toBe(0);
+	});
+
+	it("keeps the tree's socket whatever the pool is doing", async () => {
+		const network = new FakeNetwork();
+		const client = clientFor(network, "v1");
+		const tree = client.tree();
+		await client.treeSynced();
+
+		for (let index = 0; index < NOTE_SOCKET_CAP * 3; index++) {
+			const docId = tree.ensureNote(`Vulling/${index}.md`);
+			await client.withNote(docId, async ({ doc }) => {
+				doc.getText("content").insert(0, `nummer ${index}\n`);
+			});
+		}
+
+		expect(network.opens.get(roomOf("v1", TREE_DOC_ID))).toBe(1);
+		expect(network.closedWith.has(roomOf("v1", TREE_DOC_ID))).toBe(false);
+		expect(client.connected).toBe(true);
+		expect(client.settled).toBe(true);
+
+		client.destroy();
+	});
+});

--- a/src/knap/KnapSync.ts
+++ b/src/knap/KnapSync.ts
@@ -273,20 +273,36 @@ export class KnapSync {
 	 * fill it, so the note would arrive a moment later and be merged with a
 	 * copy of itself. The editor asks again on its next update, and by then
 	 * the answer is a real document.
+	 *
+	 * Pinning is what keeps the note out of the socket pool for as long as
+	 * the editor has it. A note that is already open in the pool, which is
+	 * what a note somebody opens during a fill usually is, is promoted where
+	 * it stands: same document, same socket, same sync, nothing repeated.
 	 */
 	openNote(path: string): LiveNoteHandle | null {
 		const clean = normalize(path);
 		if (!this.client || !this.binding) return null;
 		const docId = this.client.tree().docIdFor(clean);
 		if (!docId) return null;
-		const entry = this.client.note(docId);
-		if (!entry.provider.synced) return null;
-		const release = this.binding.hold(clean);
+		const note = this.client.pin(docId);
+		if (!note.provider.synced) {
+			// Handed straight back, so a note the editor did not take is a
+			// note the pool may still close.
+			note.release();
+			return null;
+		}
+		const unhold = this.binding.hold(clean);
 		return {
-			text: this.client.contentOf(entry),
-			awareness: entry.provider.awareness,
+			text: note.text,
+			awareness: note.provider.awareness,
 			deviceName: this.options.deviceName,
-			release,
+			// The file is caught up from the document first, and only then
+			// does the note go back into the pool, where it stays open until
+			// the pool needs the socket for something else.
+			release: () => {
+				unhold();
+				note.release();
+			},
 		};
 	}
 

--- a/src/knap/KnapVaultClient.ts
+++ b/src/knap/KnapVaultClient.ts
@@ -1,16 +1,27 @@
 /**
- * One linked cloud vault, live: the tree plus a socket per open document.
+ * One linked cloud vault, live: the tree, the notes an editor has open, and
+ * a small pool of sockets that every other note takes its turn in.
  *
- * A local vault is linked to at most one cloud vault (ADR-0066), so a
- * client holds exactly one of these. It keeps the tree document connected
- * for as long as it exists, because the tree is how creates, moves and
- * deletes travel; note documents connect when opened and hang around for
- * reuse. Every socket carries the same one token, and the server does the
- * whole authorisation story at the door.
+ * A local vault is linked to at most one cloud vault (ADR-0066), so a client
+ * holds exactly one of these. Two documents earn a socket of their own and
+ * keep it: the tree, because that is how creates, moves and deletes travel,
+ * and a note somebody has open in an editor, because a caret cannot live on
+ * a socket that comes and goes. Every other note borrows one.
  *
- * The WebSocket implementation is injected: Obsidian hands in the
- * platform's, tests hand in `ws`. y-websocket syncs same-process docs over
- * a BroadcastChannel behind the server's back, which phase 0 caught as a
+ * The pool is not tidiness. Chromium allows 255 websockets per renderer and
+ * then queues the 256th handshake in silence rather than failing it, and
+ * Obsidian is one renderer for every vault window on the machine. Measured
+ * on 2026-08-31: a vault of 2612 notes filled to 297 and stopped there, with
+ * 258 established connections that never moved again, and a second vault
+ * opened in the same Obsidian got its tree socket and nothing else, which
+ * reached the person as "could not reach server" over a sign-in that had
+ * worked (issue #115).
+ *
+ * The wire is untouched. This is which sockets exist and for how long.
+ *
+ * The WebSocket implementation is injected: Obsidian hands in the platform's,
+ * tests hand in `ws` or one of their own. y-websocket syncs same-process docs
+ * over a BroadcastChannel behind the server's back, which phase 0 caught as a
  * false pass, so it is off everywhere and the wire is the only path.
  */
 
@@ -20,11 +31,43 @@ import { WebsocketProvider } from "y-websocket";
 import type { KnapServer } from "./KnapServer";
 import { TREE_DOC_ID, TreeDoc } from "./TreeDoc";
 
-export interface OpenDoc {
+/**
+ * How many notes may hold a socket at once, beside the tree and whatever an
+ * editor has open.
+ *
+ * Low on purpose. The ceiling to stay under is 255 per renderer, and the
+ * things sharing it are not this vault's business: a second vault in the
+ * same Obsidian, a popout window, a phone that is stricter than any desktop
+ * browser. Eight leaves a linked vault costing about ten sockets while it
+ * fills, so a machine can hold a dozen of them and still be nowhere near the
+ * ceiling. It is also enough concurrency to matter: a fill runs eight notes
+ * deep instead of one, and the round trips overlap.
+ *
+ * Raising it buys a faster fill and spends the headroom that this whole
+ * change is about, so it stays a constant with a reason rather than a
+ * setting somebody can turn into the bug again.
+ */
+export const NOTE_SOCKET_CAP = 8;
+
+/** How long one note may take to sync before its turn is given up. */
+const NOTE_SYNC_TIMEOUT_MS = 20_000;
+
+/** How long to wait for what a note wrote to leave the socket. */
+const FLUSH_TIMEOUT_MS = 10_000;
+
+/** How often to look at what is still queued on the socket. */
+const FLUSH_POLL_MS = 20;
+
+/** One note's document while somebody is using it. */
+export interface NoteHandle {
 	doc: Y.Doc;
 	provider: WebsocketProvider;
-	/** Resolves once the first sync with the server has completed. */
-	synced: Promise<void>;
+}
+
+/** A note held open for an editor. `release` hands it back to the pool. */
+export interface PinnedNote extends NoteHandle {
+	text: Y.Text;
+	release: () => void;
 }
 
 /**
@@ -34,9 +77,46 @@ export interface OpenDoc {
  */
 export type WebSocketImpl = { new (url: string | URL, protocols?: string | string[]): unknown };
 
+interface PoolEntry {
+	doc: Y.Doc;
+	provider: WebsocketProvider;
+	/** Resolves once the first sync with the server has completed. */
+	synced: Promise<void>;
+	/** Ends that wait when the socket goes down before the sync arrives. */
+	failSynced: (error: Error) => void;
+	/** Editors holding this note. Above zero, the pool leaves it alone. */
+	pins: number;
+	/** Pieces of work borrowing it right now. */
+	leases: number;
+	/** Bumped on every borrow, so the smallest is the least recently used. */
+	used: number;
+}
+
+/** Reject with `message` if `promise` has not settled in `ms`. */
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = window.setTimeout(() => reject(new Error(message)), ms);
+		promise.then(
+			(value) => {
+				window.clearTimeout(timer);
+				resolve(value);
+			},
+			(error: unknown) => {
+				window.clearTimeout(timer);
+				reject(error instanceof Error ? error : new Error(String(error)));
+			},
+		);
+	});
+}
+
 export class KnapVaultClient {
-	private open = new Map<string, OpenDoc>();
+	private open = new Map<string, PoolEntry>();
 	private treeDoc: TreeDoc | null = null;
+	private clock = 0;
+	private destroyed = false;
+	/** Work waiting for a socket to come free. */
+	private waiting: (() => void)[] = [];
+	private closeWatchers: ((docId: string) => void)[] = [];
 
 	constructor(
 		private readonly server: KnapServer,
@@ -49,14 +129,14 @@ export class KnapVaultClient {
 	/** The vault's tree, connected. The first call opens the socket. */
 	tree(): TreeDoc {
 		if (!this.treeDoc) {
-			this.treeDoc = new TreeDoc(this.openDoc(TREE_DOC_ID).doc);
+			this.treeDoc = new TreeDoc(this.entryFor(TREE_DOC_ID).doc);
 		}
 		return this.treeDoc;
 	}
 
 	/** Resolves once the tree has had its first sync with the server. */
 	treeSynced(): Promise<void> {
-		return this.openDoc(TREE_DOC_ID).synced;
+		return this.entryFor(TREE_DOC_ID).synced;
 	}
 
 	/**
@@ -76,19 +156,205 @@ export class KnapVaultClient {
 		return this.open.get(TREE_DOC_ID)?.provider.synced ?? false;
 	}
 
-	/** A note's live document, by id. Reuses an open socket. */
-	note(docId: string): OpenDoc {
-		return this.openDoc(docId);
+	/** How many sockets this vault is holding, the tree included. */
+	get socketCount(): number {
+		return this.open.size;
 	}
 
-	/** The note's text as the shared Text the server reads. */
-	contentOf(entry: OpenDoc): Y.Text {
-		return entry.doc.getText("content");
+	/**
+	 * Borrow one note's document for the length of `use`.
+	 *
+	 * What the caller gets is a document that has finished its first sync,
+	 * on a socket that stays up until `use` has returned and everything it
+	 * wrote has left this process. Waits for a turn when the pool is full,
+	 * and gives up on a note that cannot sync rather than waiting on it
+	 * forever, because a note that hangs used to take every note behind it
+	 * down with it.
+	 */
+	async withNote<T>(docId: string, use: (note: NoteHandle) => Promise<T>): Promise<T> {
+		const entry = await this.acquire(docId);
+		try {
+			await withTimeout(
+				entry.synced,
+				NOTE_SYNC_TIMEOUT_MS,
+				"This note did not sync in time. It will be tried again.",
+			);
+			const result = await use({ doc: entry.doc, provider: entry.provider });
+			await this.flushed(entry);
+			return result;
+		} finally {
+			entry.leases -= 1;
+			entry.used = ++this.clock;
+			this.wake();
+		}
 	}
 
-	private openDoc(docId: string): OpenDoc {
+	/**
+	 * Hold a note open for an editor, above the pool and outside its count.
+	 *
+	 * An editor never queues behind a fill: it says which note it is showing
+	 * and gets it. A note the pool already has open is promoted rather than
+	 * reopened, which is the point. The document, the socket and the sync
+	 * that has already happened are the ones it was using a moment ago, so
+	 * nothing re-syncs and no text goes through a second first exchange.
+	 *
+	 * `release` gives it back to the pool, where it stays open until the
+	 * pool needs the socket for something else.
+	 */
+	pin(docId: string): PinnedNote {
+		const entry = this.entryFor(docId);
+		entry.pins += 1;
+		entry.used = ++this.clock;
+		let released = false;
+		return {
+			doc: entry.doc,
+			provider: entry.provider,
+			text: entry.doc.getText("content"),
+			release: () => {
+				if (released) return;
+				released = true;
+				entry.pins -= 1;
+				entry.used = ++this.clock;
+				// One pin fewer is one pooled socket more, and somebody may
+				// be waiting for exactly that.
+				this.wake();
+			},
+		};
+	}
+
+	/**
+	 * Told when a note's socket goes down, so whoever was watching that
+	 * document can let go of it. The pool closes notes on its own schedule,
+	 * and an observer on a document nobody is syncing any more is a callback
+	 * that will never fire and a document that cannot be collected.
+	 */
+	onNoteClosed(callback: (docId: string) => void): () => void {
+		this.closeWatchers.push(callback);
+		return () => {
+			this.closeWatchers = this.closeWatchers.filter((watcher) => watcher !== callback);
+		};
+	}
+
+	/** Close one document's socket, keeping the vault linked. */
+	close(docId: string): void {
+		const entry = this.open.get(docId);
+		if (!entry) return;
+		this.open.delete(docId);
+		if (docId === TREE_DOC_ID) {
+			this.treeDoc = null;
+		}
+		entry.provider.destroy();
+		// Anybody still waiting for this document's first sync is waiting for
+		// something that has stopped being on its way.
+		entry.failSynced(new Error("This note's connection closed before it synced."));
+		// Watchers first, so whoever was following this document lets go of a
+		// document that is still whole, and then the document itself.
+		for (const watcher of [...this.closeWatchers]) watcher(docId);
+		entry.doc.destroy();
+	}
+
+	/** Unlink or shutdown: every socket down, nothing deleted anywhere. */
+	destroy(): void {
+		// Set before the closing, because work that was already in flight is
+		// not cancelled by any of this and would otherwise be handed a fresh
+		// socket to a vault this device has just unlinked from.
+		this.destroyed = true;
+		for (const docId of [...this.open.keys()]) {
+			this.close(docId);
+		}
+		this.wake();
+	}
+
+	// -- the pool ------------------------------------------------------------
+
+	private async acquire(docId: string): Promise<PoolEntry> {
+		for (;;) {
+			const existing = this.open.get(docId);
+			if (existing) {
+				existing.leases += 1;
+				existing.used = ++this.clock;
+				return existing;
+			}
+			if (this.makeRoom()) {
+				const entry = this.entryFor(docId);
+				entry.leases += 1;
+				entry.used = ++this.clock;
+				return entry;
+			}
+			await this.slot();
+		}
+	}
+
+	/**
+	 * Whether a note may open a socket now, closing the one that has gone
+	 * unused longest if it may not.
+	 *
+	 * Only pooled notes are counted: the tree and the notes an editor is
+	 * holding are not the pool's to close, and they are what the cap is kept
+	 * low for in the first place.
+	 */
+	private makeRoom(): boolean {
+		const pooled = [...this.open.entries()].filter(
+			([docId, entry]) => docId !== TREE_DOC_ID && entry.pins === 0,
+		);
+		if (pooled.length < NOTE_SOCKET_CAP) return true;
+		let oldest: [string, PoolEntry] | null = null;
+		for (const candidate of pooled) {
+			if (candidate[1].leases > 0) continue;
+			if (!oldest || candidate[1].used < oldest[1].used) oldest = candidate;
+		}
+		if (!oldest) return false;
+		this.close(oldest[0]);
+		return true;
+	}
+
+	/** A turn, when one comes free. */
+	private slot(): Promise<void> {
+		return new Promise<void>((resolve) => this.waiting.push(resolve));
+	}
+
+	private wake(): void {
+		const waiting = this.waiting;
+		this.waiting = [];
+		for (const resolve of waiting) resolve();
+	}
+
+	/**
+	 * Wait for what this note wrote to leave the process before its socket
+	 * can be closed.
+	 *
+	 * y-websocket sends every local update the moment it is made, so the
+	 * only thing between a splice and the server is the socket's own send
+	 * buffer. A close with bytes still in it is an update nobody will ever
+	 * see again, because the document goes with it.
+	 *
+	 * A socket that went down while the note was being written has not sent
+	 * anything, and saying so is the honest outcome: the caller counts it as
+	 * a failure, the file stays on the disk it came from, and the next
+	 * reconciliation pushes it again.
+	 */
+	private async flushed(entry: PoolEntry): Promise<void> {
+		const deadline = Date.now() + FLUSH_TIMEOUT_MS;
+		for (;;) {
+			const socket = entry.provider.ws;
+			if (!entry.provider.wsconnected || !socket) {
+				throw new Error("The connection dropped before this note was sent.");
+			}
+			if (!socket.bufferedAmount) return;
+			if (Date.now() > deadline) {
+				throw new Error("This note could not be sent in time. It will be tried again.");
+			}
+			await new Promise<void>((resolve) => window.setTimeout(resolve, FLUSH_POLL_MS));
+		}
+	}
+
+	/** The open entry for a document, opening the socket if there is none. */
+	private entryFor(docId: string): PoolEntry {
 		const existing = this.open.get(docId);
 		if (existing) return existing;
+		if (this.destroyed) {
+			throw new Error("This vault is not linked any more.");
+		}
 
 		const doc = new Y.Doc();
 		const provider = new WebsocketProvider(this.server.syncUrl(this.vaultId), docId, doc, {
@@ -98,34 +364,34 @@ export class KnapVaultClient {
 		});
 		provider.awareness.setLocalStateField("device", { name: this.deviceName });
 
-		const synced = new Promise<void>((resolve) => {
+		let failSynced: (error: Error) => void = () => undefined;
+		const synced = new Promise<void>((resolve, reject) => {
+			failSynced = reject;
 			if (provider.synced) {
 				resolve();
 				return;
 			}
 			provider.once("synced", () => resolve());
 		});
+		// A first sync that will now never come is worth saying out loud to
+		// whoever is waiting on it, and worth saying to nobody at all when
+		// nobody is: an unhandled rejection in Obsidian's console is a bug
+		// report about a vault somebody unlinked on purpose.
+		void synced.catch(() => undefined);
 
-		const entry: OpenDoc = { doc, provider, synced };
+		// The tree is pinned for the life of the link: it is how every create,
+		// move and delete travels, and a pool that could close it would take
+		// the vault's index down to make room for one note.
+		const entry: PoolEntry = {
+			doc,
+			provider,
+			synced,
+			failSynced,
+			pins: docId === TREE_DOC_ID ? 1 : 0,
+			leases: 0,
+			used: ++this.clock,
+		};
 		this.open.set(docId, entry);
 		return entry;
-	}
-
-	/** Close one document's socket, keeping the vault linked. */
-	close(docId: string): void {
-		const entry = this.open.get(docId);
-		if (!entry) return;
-		this.open.delete(docId);
-		if (this.treeDoc && docId === TREE_DOC_ID) {
-			this.treeDoc = null;
-		}
-		entry.provider.destroy();
-	}
-
-	/** Unlink or shutdown: every socket down, nothing deleted anywhere. */
-	destroy(): void {
-		for (const docId of [...this.open.keys()]) {
-			this.close(docId);
-		}
 	}
 }

--- a/src/knap/VaultBinding.ts
+++ b/src/knap/VaultBinding.ts
@@ -21,6 +21,13 @@
  *   notes download, and a note that exists on both sides with different
  *   text keeps the cloud text while the local text survives as a conflict
  *   copy beside it. Nothing is ever silently lost.
+ * - A note's document is borrowed and handed back, never held. Only the tree
+ *   and the notes an editor has open keep a socket of their own, and every
+ *   other note takes its turn in a small pool, because a browser has 255
+ *   sockets and a vault has thousands of notes (issue #115). The cost is
+ *   real and worth writing down: a note nobody has open here stops hearing
+ *   somebody else's edit the moment it arrives, and catches up the next time
+ *   this binding reconciles or the next time anything touches that note.
  * - A note deleted here is deleted in the cloud vault, and the other way
  *   round, whether or not the plugin was running when it happened. That is
  *   what the `SeenTree` is for: without a record of what this device last
@@ -61,6 +68,11 @@ export interface FileStore {
 	onChange(callback: (event: FileEvent) => void): () => void;
 }
 
+/** One note's document, for as long as somebody is holding it. */
+export interface NoteDoc {
+	doc: Y.Doc;
+}
+
 /** What the binding needs from the wire. KnapVaultClient satisfies it. */
 export interface VaultDocs {
 	tree(): TreeDoc;
@@ -72,7 +84,22 @@ export interface VaultDocs {
 	 * that already exists in the cloud gets a second document minted for it.
 	 */
 	treeSynced(): Promise<void>;
-	note(docId: string): { doc: Y.Doc; synced: Promise<void> };
+	/**
+	 * Borrow one note's document for the length of `use`.
+	 *
+	 * A borrow rather than a getter, because a note's socket is not this
+	 * binding's to keep: there are 255 of them per Obsidian and thousands of
+	 * notes in a vault (issue #115). What the caller is promised is a
+	 * document that has synced before `use` runs and a socket that stays up
+	 * until everything `use` wrote has left the process. Whoever hands one
+	 * over decides when it closes after that.
+	 */
+	withNote<T>(docId: string, use: (note: NoteDoc) => Promise<T>): Promise<T>;
+	/**
+	 * Told when a note's document goes down, so this binding can stop
+	 * watching a document that will never change again.
+	 */
+	onNoteClosed(callback: (docId: string) => void): () => void;
 }
 
 /**
@@ -98,6 +125,17 @@ const CONTENT = "content";
 
 /** How long to wait for the tree's first sync before giving up on a link. */
 const TREE_SYNC_TIMEOUT_MS = 30_000;
+
+/**
+ * How many notes a fill works on at once.
+ *
+ * One at a time is one round trip at a time, and a vault of a few thousand
+ * notes would still be arriving tomorrow. This is a queue width and not a
+ * socket count: how many sockets exist is the client's business, and it caps
+ * them at the same number, so a note that finds the pool full waits for a
+ * turn instead of opening the 256th socket Chromium never answers.
+ */
+const FILL_WIDTH = 8;
 
 /** Reject with `message` if `promise` has not settled in `ms`. */
 function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
@@ -125,6 +163,7 @@ function textOf(content: Y.Text): string {
 export class VaultBinding {
 	private stopFileEvents: (() => void) | null = null;
 	private stopTreeEvents: (() => void) | null = null;
+	private stopNoteCloses: (() => void) | null = null;
 	private noteObservers = new Map<string, () => void>();
 	private queue: Promise<void> = Promise.resolve();
 	private failures = 0;
@@ -146,6 +185,11 @@ export class VaultBinding {
 	 * interleave two half-finished reconciliations.
 	 */
 	async start(): Promise<void> {
+		// Before anything opens a document: a note whose socket the client
+		// closed is a note this binding may not go on watching, and the entry
+		// has to go too, or the next borrow of that note finds itself already
+		// watched and nothing observes the document that replaced it.
+		this.stopNoteCloses = this.docs.onNoteClosed((docId) => this.unobserveNote(docId));
 		await this.enqueue(() => this.reconcileAll());
 		this.stopFileEvents = this.files.onChange((event) => {
 			// The store reports both kinds, and each binding takes its own.
@@ -187,6 +231,7 @@ export class VaultBinding {
 	stop(): void {
 		this.stopFileEvents?.();
 		this.stopTreeEvents?.();
+		this.stopNoteCloses?.();
 		for (const stop of this.noteObservers.values()) stop();
 		this.noteObservers.clear();
 	}
@@ -241,12 +286,13 @@ export class VaultBinding {
 		const tree = this.docs.tree();
 		const docId = tree.docIdFor(path);
 		if (!docId) return;
-		const { doc } = this.docs.note(docId);
-		const text = textOf(doc.getText(CONTENT));
-		const at = tree.pathFor(docId) ?? path;
-		if ((await this.files.read(at)) !== text) {
-			await this.files.write(at, text);
-		}
+		await this.docs.withNote(docId, async ({ doc }) => {
+			const text = textOf(doc.getText(CONTENT));
+			const at = tree.pathFor(docId) ?? path;
+			if ((await this.files.read(at)) !== text) {
+				await this.files.write(at, text);
+			}
+		});
 	}
 
 	private enqueue(work: () => Promise<void>): Promise<void> {
@@ -313,8 +359,11 @@ export class VaultBinding {
 		// cost of being wrong here is every note in the cloud vault.
 		const emptied = local.size === 0 && seen.size > 0;
 
-		for (const path of local) {
-			if (remote.has(path)) continue;
+		// Both halves run several notes deep. The tree above is read first and
+		// in full, so what each note does is its own business and the width
+		// only decides how many are waiting for a socket at once.
+		await this.inWaves([...local], async (path) => {
+			if (remote.has(path)) return;
 			if (seen.has(path)) {
 				// It was in the tree when this device last looked and it is
 				// not now: it was deleted in the cloud vault while this
@@ -323,8 +372,8 @@ export class VaultBinding {
 			} else {
 				await this.pushNote(path);
 			}
-		}
-		for (const [path, docId] of remote) {
+		});
+		await this.inWaves([...remote], async ([path, docId]) => {
 			if (!local.has(path) && !emptied && seen.get(path) === docId) {
 				// The same note, at the same path, as this device last had
 				// it on disk, and the file is gone. Somebody deleted it here
@@ -332,10 +381,36 @@ export class VaultBinding {
 				// downloaded the note back, every time, on every device.
 				tree.remove(path);
 				this.seenDirty = true;
-				continue;
+				return;
 			}
 			await this.bindNote(path, docId);
-		}
+		});
+	}
+
+	/**
+	 * Run `work` over `items`, a few at a time, counting what fails instead
+	 * of stopping.
+	 *
+	 * One note that cannot be reached is one note, not a link that failed.
+	 * The file it came from is still on the disk, the next start tries it
+	 * again, and the count is what puts Problem on the screen in the
+	 * meantime. A fill of a few thousand notes that gave up on the first
+	 * refusal is how somebody ends up restarting Obsidian to make progress.
+	 */
+	private async inWaves<T>(items: T[], work: (item: T) => Promise<void>): Promise<void> {
+		let next = 0;
+		const worker = async (): Promise<void> => {
+			while (next < items.length) {
+				const item = items[next++];
+				try {
+					await work(item);
+				} catch {
+					this.failures += 1;
+				}
+			}
+		};
+		const width = Math.max(1, Math.min(FILL_WIDTH, items.length));
+		await Promise.all(Array.from({ length: width }, () => worker()));
 	}
 
 	// -- local to remote ------------------------------------------------------
@@ -388,13 +463,13 @@ export class VaultBinding {
 		const known = tree.docIdFor(clean);
 		const docId = tree.ensureNote(clean);
 		if (known === undefined) this.seenDirty = true;
-		const { doc, synced } = this.docs.note(docId);
-		await synced;
-		const content = doc.getText(CONTENT);
-		if (textOf(content) !== text) {
-			splice(content, textOf(content), text, doc);
-		}
-		this.observeNote(clean, docId);
+		await this.docs.withNote(docId, async ({ doc }) => {
+			const content = doc.getText(CONTENT);
+			if (textOf(content) !== text) {
+				splice(content, textOf(content), text, doc);
+			}
+			this.observeNote(clean, docId, content);
+		});
 	}
 
 	// -- remote to local ------------------------------------------------------
@@ -410,44 +485,56 @@ export class VaultBinding {
 	 * the one thing this binding promises never to do.
 	 */
 	private async bindNote(path: string, docId: string): Promise<void> {
-		const { doc, synced } = this.docs.note(docId);
-		await synced;
-		const content = doc.getText(CONTENT);
-		const docText = textOf(content);
-		const fileText = await this.files.read(path);
+		const copy = await this.docs.withNote(docId, async ({ doc }) => {
+			const content = doc.getText(CONTENT);
+			const docText = textOf(content);
+			const fileText = await this.files.read(path);
+			let conflict: string | null = null;
 
-		if (fileText === null) {
-			await this.files.write(path, docText);
-		} else if (fileText !== docText) {
-			if (docText === "") {
-				// A minted note nobody typed in yet: the local text is the
-				// note. A note somebody deliberately emptied looks exactly the
-				// same from here and nothing can tell them apart, so this goes
-				// the way that cannot lose anything.
-				splice(content, "", fileText, doc);
-			} else {
-				// Both sides wrote. The cloud text wins the path; the local
-				// text survives beside it, named for what happened, and pushed
-				// explicitly because this can run before the event stream is on.
-				const copy = buildConflictCopyPath(path, this.conflictLabel());
-				await this.files.write(copy, fileText);
-				await this.pushNote(copy);
+			if (fileText === null) {
 				await this.files.write(path, docText);
+			} else if (fileText !== docText) {
+				if (docText === "") {
+					// A minted note nobody typed in yet: the local text is the
+					// note. A note somebody deliberately emptied looks exactly
+					// the same from here and nothing can tell them apart, so
+					// this goes the way that cannot lose anything.
+					splice(content, "", fileText, doc);
+				} else {
+					// Both sides wrote. The cloud text wins the path; the local
+					// text survives beside it, named for what happened.
+					conflict = buildConflictCopyPath(path, this.conflictLabel());
+					await this.files.write(conflict, fileText);
+					await this.files.write(path, docText);
+				}
 			}
-		}
-		this.observeNote(path, docId);
+			this.observeNote(path, docId, content);
+			return conflict;
+		});
+		// The copy is a note of its own and needs a document of its own, so it
+		// is pushed after this note has handed its socket back rather than
+		// from inside: a borrow that waits on a second borrow is how a pool
+		// this small deadlocks. Explicitly, because this can run before the
+		// event stream is on.
+		if (copy) await this.pushNote(copy);
 	}
 
-	private observeNote(path: string, docId: string): void {
+	/**
+	 * Follow one note's document for as long as it stays open.
+	 *
+	 * The text is read the moment the change arrives rather than when the
+	 * write comes up in the queue, because by then the document may have been
+	 * handed back and closed. What was observed is what gets written, and a
+	 * second change writes again, so the last one still wins.
+	 */
+	private observeNote(path: string, docId: string, content: Y.Text): void {
 		if (this.noteObservers.has(docId)) return;
-		const { doc } = this.docs.note(docId);
-		const content = doc.getText(CONTENT);
 		const observer = () => {
+			const text = textOf(content);
 			void this.enqueue(async () => {
 				const current = this.docs.tree().pathFor(docId) ?? path;
 				// An open editor already has this change and owns the file.
 				if (this.held.has(current)) return;
-				const text = textOf(content);
 				if ((await this.files.read(current)) !== text) {
 					await this.files.write(current, text);
 				}


### PR DESCRIPTION
## Summary

Fixes #115. Every note opened a websocket of its own and none of them ever closed. A Chromium renderer allows 255, and the 256th handshake does not fail: it sits in a queue nobody answers. The vault of 2612 notes filled to 297 and stopped with 258 connections that never moved again, and because `pushNote` does `await synced` inside the one queue every file and tree event also runs through, note 256 took everything behind it down with it. The second face of the same bug is in the issue comment: with the big vault open, a second vault got its tree socket and then nothing, and said "could not reach server" over a sign-in that had actually worked.

Two documents keep a socket now, and everything else borrows one:

- **The tree**, for the life of the link, because that is how creates, moves and deletes travel.
- **A note an editor has open**, because a caret cannot live on a socket that comes and goes.
- **Every other note** takes a turn in a pool: open, sync, write the difference, wait for the send buffer to drain, close, hand the socket back.

The wire protocol is untouched. Same `/sync/{vault}/{doc}`, same y-protocol, same messages. This is only which sockets exist and for how long.

### The cap, and why eight

`NOTE_SOCKET_CAP = 8` in `src/knap/KnapVaultClient.ts`, a constant with the reasoning beside it, no setting (a setting is how this becomes the same bug again with a number the person picked).

The ceiling to stay under is 255 per renderer, and the things sharing it are not one vault's business: a second vault in the same Obsidian, a popout window, a phone that is stricter than any desktop browser. At eight, a linked vault costs about ten sockets while it fills (tree, pool, whatever is open in editors), so a dozen linked vaults in one process is still nowhere near the ceiling, and the two-vault case from the issue comment has two orders of magnitude of headroom instead of none. Eight is also enough concurrency to matter: the fill runs eight notes deep instead of one, so the round trips overlap and a 2612-note fill is minutes rather than an afternoon. Going to sixteen buys a faster fill and spends the headroom this whole change is about.

### How an open note is promoted

`KnapVaultClient.pin(docId)` takes a note out of the pool's reach and `release()` hands it back. `KnapSync.openNote`, which is what the CodeMirror plugin calls when Obsidian shows a note, pins instead of opening.

The point is that pinning a note the pool already has open promotes it where it stands: same `Y.Doc`, same `WebsocketProvider`, same first sync. Nothing reconnects and nothing re-syncs under somebody's cursor, which is what a note opened during a fill would otherwise do. A note the pool does not have open gets a socket immediately rather than queueing behind the fill, because a pinned socket is outside the cap; that is deliberate, and it is why the cap is low enough to afford it. Closing the editor writes the file from the document once (unchanged) and only then hands the note back to the pool, where it stays open until the pool needs the socket for something else.

The pool never closes a pinned note, and it never closes the tree.

### What it costs, written down in the module

A note nobody has open here stops hearing somebody else's edit the moment it arrives. It catches up on the next reconciliation, or the next time anything touches that note. There is no version of one socket per note that survives a vault of thousands, so this is the trade the issue asks for rather than a regression that slipped in, and it is stated in `VaultBinding`'s header next to the other rules. Making unopened notes live again needs something on the wire (one channel that says which documents changed), which is a separate decision and a separate change.

### What this changes for #106 and #56

Neither is fixed here.

**#106 (the screen says nothing while it fills):** no progress reporting is added. What changes is that the note count the status bar already reads off the tree now climbs to the end instead of stopping at about 297, so "the number is not moving" starts meaning what it says. And a note that cannot be reached now increments the failure count the bar reads as *Problem*, where before the first failure ended the whole reconciliation.

**#56 (the fill reports done while notes stay empty):** the sweep that issue asks for is not here. Two things move: a note that fails to push is now counted and the fill carries on past it, instead of one note ending the pass, and a note is never closed until what was written into it has left the send buffer, so "the update was made but never sent" stops being one of the ways a note can end up empty. The window #56 names is still open: `ensureNote` writes the tree entry before the content lands, so a note is briefly in the tree with an empty document, and if its push fails it stays that way until the next reconciliation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (0 errors; the 6 warnings are the ones already on main)
- [ ] Tested in Obsidian
- [x] Changes are minimal and focused

`npm test`: 864 passing, up from 859 on main. The five new ones are `__tests__/knap/socketPool.test.ts`.

## The test

Real `WebsocketProvider`s over a real y-protocol exchange against a fake network that behaves like the browser's: it counts what is open, and above 255 it goes quiet instead of failing, exactly the way the measured one did. A fake provider would have decided the question under test for itself.

- 320 notes fill through one client. The peak socket count never passes the pool plus the tree, nothing is refused, every note's text is on the server, and every note that closed had its final text there before it closed.
- 300 notes in each of two vaults in one process both fill, with the peak under two pools.
- A note the pool has open is pinned, forty more notes are pushed through the pool around it, and it is never closed and never connected a second time. Typing into it still reaches the server. The other notes did get recycled, which is what makes that a claim.
- Unlinking in the middle of a fill leaves nothing open.
- The tree's socket is never the one the pool takes.

Raise `NOTE_SOCKET_CAP` past 255 and all five fail, three of them by hanging exactly the way the vault did.

## Still to be tested by hand, against the real server

`app.knap.pantalytics.com` is not reachable from the cloud session this was written in, so none of this has been near a real server or a real Obsidian:

- The fill that this is about: link the 2612-note vault and watch it reach the end. `lsof` on Obsidian's network process should sit at roughly ten connections to the server for the whole fill, not climb.
- Two vaults linked in one Obsidian at the same time, which is the issue comment's case. Both should fill, and neither should say "could not reach server".
- Open a note in an editor while the fill is running, type in it, and watch for a hiccup: the text should not flicker, re-arrive or merge with itself, and a second device's cursor should still show.
- The phone half, iOS and Android, on a real vault. Same code, but the socket ceiling and the backgrounding behaviour are not the desktop's.
- The conflict-copy path against the real server. `bindNote` now writes the copy inside the borrow and pushes it after handing the socket back, because a borrow that waits on a second borrow deadlocks a pool this small. The order of the two file writes is unchanged; the push happens one step later than it did.
- Unlink and sign out during a fill, checking that connections to the server actually go to zero.

## Not done here

`src/knap/VaultBinding.ts` is 576 lines now, over the 500 the sibling repo holds itself to. Splitting it is owed and is its own change; doing it in this one would have buried the diff.