### PR TITLE
The bar waits for a link, and the fold folds

### DIFF
--- a/__tests__/knap/settingsTab.test.ts
+++ b/__tests__/knap/settingsTab.test.ts
@@ -221,6 +221,19 @@ describe("the screen, signed in", () => {
 		expect(rows.find((r) => r.name === "Cloud vault")?.desc).toContain("Not linked");
 	});
 
+	it("draws no bar until there is a link, because it has no vault to be about", () => {
+		// The bar settled on Up to date over a vault that syncs with nothing,
+		// which is #40's lie in a new place. The Cloud vault row underneath
+		// says Not linked, and that is both truer and the way out.
+		const { container } = drawFor({ signedIn: true, linked: null });
+		expect(find(container, "knap-status")).toBeUndefined();
+	});
+
+	it("draws the bar once a cloud vault is linked", () => {
+		const { container } = drawFor({ signedIn: true, linked: { id: "v1", name: "Work notes" } });
+		expect(find(container, "knap-status")).toBeDefined();
+	});
+
 	it("names the linked vault and offers only unlink beside it", () => {
 		// No Change: linking somewhere else is Unlink and then Choose, which
 		// is what happens underneath either way.

--- a/__tests__/knap/syncStatusWord.test.ts
+++ b/__tests__/knap/syncStatusWord.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The one word the engine puts on a vault, in the states no socket is open in.
+ *
+ * A vault that has an account and no cloud vault behind it read Up to date,
+ * green, over notes that had never left the device. Nothing was syncing, so
+ * nothing was behind, so the last branch won. That is #40's lie arriving by a
+ * different road, and the fix is the word #42 already settled on for a vault
+ * waiting to be told where it belongs.
+ */
+
+import { KnapSync } from "../../src/knap/KnapSync";
+import type { KnapLink } from "../../src/knap/KnapSync";
+import type { FileStore } from "../../src/knap/VaultBinding";
+import { PAUSED, SIGNED_OUT } from "../../src/syncStatus";
+
+/** Nothing here opens a socket or touches a file. */
+const noFiles: FileStore = {
+	read: async () => null,
+	write: async () => {},
+	remove: async () => {},
+	rename: async () => {},
+	listNotes: async () => [],
+	onChange: () => () => {},
+};
+
+function syncFor(stored: KnapLink | null): KnapSync {
+	return new KnapSync({
+		serverUrl: "https://knap.test",
+		deviceName: "Laptop",
+		fetchFn: async () => new Response(null, { status: 204 }),
+		files: noFiles,
+		load: () => stored,
+		save: async () => {},
+	});
+}
+
+describe("what a vault with no link says it is doing", () => {
+	it("reads Paused rather than Up to date, and wears the yellow dot", () => {
+		const status = syncFor({ token: "knap_abc", cloudVaultId: "", cloudVaultName: "" }).status();
+
+		expect(status.word).toBe(PAUSED);
+		expect(status.dot).toBe("wait");
+		// And it does not claim a vault it has not got.
+		expect(status.vaultName).toBe("");
+	});
+
+	it("still puts the missing account first, because that is the fix to make", () => {
+		expect(syncFor(null).status().word).toBe(SIGNED_OUT);
+	});
+});

--- a/docs/ui-ux.md
+++ b/docs/ui-ux.md
@@ -64,6 +64,15 @@ is first because it is what somebody came to find out. **Account** is who.
 **Cloud vault** is what this vault syncs with. The two rows under the bar are
 what somebody came to change, which is rarer than wanting to know.
 
+**The bar waits for a link**, which is why it is absent from both the small
+screens above. How it is going is a question about a cloud vault, and before
+there is one every word is wrong for the state: nothing is syncing, so nothing
+is behind, so it settled on *Up to date* over notes that had never left the
+device. The row underneath says *Not linked*, which is truer and is also the way
+out of it. A vault with an account and no link reads **Paused** where it has to
+be said in one word, in the corner of the window: nothing is moving, and nothing
+is going to until somebody picks a cloud vault.
+
 The screen exists at all because the commands were the only way in, and a
 command palette is where somebody looks after they already know the thing is
 there. Asked to try the beta, the first thing a person does is open Settings and

--- a/src/knap/KnapSettingsTab.ts
+++ b/src/knap/KnapSettingsTab.ts
@@ -9,6 +9,8 @@
  *
  * **Two rows and a bar, and each of the three earns its place**: the bar says
  * how it is going, Account is who, Cloud vault is what this vault syncs with.
+ * The bar waits for a link, because how it is going is a question about a
+ * cloud vault and there is not one yet.
  * That last row keeps one sentence the shortening did not touch, because a
  * delete travels both ways and somebody is entitled to know that before they
  * press it rather than after (#116).
@@ -128,7 +130,14 @@ export class KnapSettingsTab extends PluginSettingTab {
 			return;
 		}
 
-		this.drawStatus(containerEl);
+		const linked = this.sync.linked;
+
+		// The bar only appears once there is a link. Before that it has no
+		// vault to be about, and the words are all wrong for it: nothing is
+		// syncing, so it settled on Up to date, over a vault that was going
+		// nowhere. That is #40's lie in a new place, and the row underneath
+		// already says Not linked, which is both truer and the way out.
+		if (linked) this.drawStatus(containerEl);
 
 		new Setting(containerEl)
 			.setName("Account")
@@ -142,7 +151,6 @@ export class KnapSettingsTab extends PluginSettingTab {
 				}),
 			);
 
-		const linked = this.sync.linked;
 		const vault = new Setting(containerEl)
 			.setName("Cloud vault")
 			.setDesc(

--- a/src/knap/KnapSync.ts
+++ b/src/knap/KnapSync.ts
@@ -115,6 +115,10 @@ export class KnapSync {
 	 * the token, the link, the socket and the queue's failure count, and
 	 * hands them to `syncWord`, which owns the order those facts win in.
 	 *
+	 * A vault with no link is Paused rather than Up to date: nothing is
+	 * moving, nothing is going to, and green over it would say the notes
+	 * were safe somewhere they have never been.
+	 *
 	 * Syncing is "linked, connected, and the tree has not settled yet". Once
 	 * the tree has been through its first exchange there is nothing this side
 	 * is waiting for, and a spinner that never stops is worse than no spinner.
@@ -125,7 +129,14 @@ export class KnapSync {
 		const problems = this.binding?.problems ?? 0;
 		const word = syncWord({
 			signedIn: this.signedIn,
-			paused: false,
+			// Signed in with nowhere to sync to is not up to date, it is
+			// standing still: nothing is moving and nothing is going to
+			// until somebody picks a cloud vault. Green over that vault is
+			// the same lie #40 was about, and #42 already settled the word
+			// for a vault waiting to be told which cloud vault it belongs
+			// to. The screen says Not linked in full; the corner of the
+			// window has one word to do it in.
+			paused: !linked,
 			syncing: Boolean(this.client) && !this.client?.settled,
 			// Not linked is not offline: there is no socket because there is
 			// nothing to open one to, and saying Offline would send somebody

--- a/styles.css
+++ b/styles.css
@@ -584,6 +584,13 @@
 	gap: var(--size-2-3);
 }
 
+/* `hidden` has to beat this rule's `display`, or the fold never folds: the
+   browser's own [hidden] rule loses to a class selector, and the bar came up
+   with its facts already out and an empty strip under any word that had none. */
+.knap-status-body[hidden] {
+	display: none;
+}
+
 .knap-status-say {
 	color: var(--text-muted);
 	font-size: var(--font-ui-small);


### PR DESCRIPTION
## Summary

Signed in with no cloud vault behind it, the Knap screen said **Up to date** under a green dot, directly above a row saying **Not linked**. Nothing was syncing, so nothing was behind, so the last branch of `syncWord` won: green over notes that had never left the device. That is #40's lie arriving by another road.

Three parts:

- **The bar is not drawn until there is a link** (`KnapSettingsTab`). How it is going is a question about a cloud vault, and before there is one there is nothing for it to be about. The Cloud vault row underneath already says Not linked, which is truer and is also the way out of it. This is what `docs/ui-ux.md`'s "signed in, not linked yet" screen already showed; the code did not.
- **`KnapSync.status` reads a vault with an account and no link as Paused** rather than Up to date, for the corner of the window, where it has to be said in one word. #42 settled that word for a vault waiting to be told where it belongs, and `vaultStatus.ts` has read it that way since. Not Offline: there is no socket because there is nothing to open one to.
- **`.knap-status-body` set `display: flex`**, which beats the browser's own `[hidden]` rule, so the fold never folded. The bar came up with its facts already out, and an empty strip under any word that had none. That empty strip is the second row in the screenshot this came from.

`docs/ui-ux.md` gains the paragraph saying the bar waits for a link, and why.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] `npm run build` succeeds (`tsc -noEmit -skipLibCheck` clean)
- [x] `npm run lint` passes (0 errors; the 6 pre-existing warnings are unchanged)
- [ ] Tested in Obsidian — not run here; covered by `__tests__/knap/settingsTab.test.ts` (no bar without a link, bar once linked) and a new `__tests__/knap/syncStatusWord.test.ts` (Paused, yellow, no vault name). Full suite: 872 passed.
- [x] Changes are minimal and focused

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRqaW58hDjS3AjQGkCpHQW)_