### PR TITLE
The bar fits a phone, and the fold stops repeating the head

### DIFF
--- a/__tests__/knap/settingsTab.test.ts
+++ b/__tests__/knap/settingsTab.test.ts
@@ -9,6 +9,7 @@
 
 import {
 	KnapSettingsTab,
+	hasFold,
 	hasRetry,
 	signOutNotice,
 	statusFacts,
@@ -118,7 +119,7 @@ jest.mock("obsidian", () => {
 			public plugin: unknown,
 		) {}
 	}
-	return { Setting, PluginSettingTab, Notice: class {}, App: class {} };
+	return { Setting, PluginSettingTab, Notice: class {}, App: class {}, setIcon: () => {} };
 });
 
 interface FakeState {
@@ -291,7 +292,43 @@ describe("the bar", () => {
 		});
 		expect(find(container, "knap-status-word")?.text).toBe("Up to date");
 		expect(find(container, "knap-dot-ok")).toBeDefined();
-		expect(find(container, "knap-status-detail")?.text).toBe("Work notes · 1,202 notes");
+		expect(find(container, "knap-status-vault")?.text).toBe("Work notes");
+		expect(find(container, "knap-status-count")?.text).toBe("1,202 notes");
+	});
+
+	it("keeps the name and the count apart, because they shrink differently", () => {
+		// One string could only be cut from the end, which on a phone is the
+		// count: the half somebody opened the screen for (#125).
+		const { container } = drawFor({
+			signedIn: true,
+			linked: { id: "v1", name: "260812_RH_Obsidian_vault" },
+			status: { word: UP_TO_DATE, dot: "ok", vaultName: "260812_RH_Obsidian_vault", notes: 1 },
+		});
+		expect(find(container, "knap-status-count")?.text).toBe("1 note");
+	});
+
+	it("does not open at all when the fold would be empty", () => {
+		// Up to date carries no instruction, and with nothing stuck there is
+		// nothing behind the head. A head that opens onto an empty strip is
+		// worse than a head that does not open (#125).
+		const { container } = drawFor({
+			signedIn: true,
+			linked: { id: "v1", name: "Work notes" },
+			status: { word: UP_TO_DATE, dot: "ok", vaultName: "Work notes", notes: 1202 },
+		});
+		const head = find(container, "knap-status-head");
+		expect(head?.getAttribute("aria-expanded")).toBeNull();
+		expect(head?.listeners).toEqual([]);
+		expect(find(container, "knap-status-chevron")).toBeUndefined();
+	});
+
+	it("wears a chevron when it opens, because a phone has no hover to find it with", () => {
+		const { container } = drawFor({
+			signedIn: true,
+			linked: { id: "v1", name: "Work notes" },
+			status: { word: SYNCING, dot: "working", vaultName: "Work notes", notes: 3 },
+		});
+		expect(find(container, "knap-status-chevron")).toBeDefined();
 	});
 
 	it("starts folded, and opens when the head is pressed", () => {
@@ -339,19 +376,25 @@ describe("what the fold holds", () => {
 		expect(statusFacts({ ...baseStatus() } as never)).toEqual([]);
 	});
 
-	it("groups the note count the way the rest of the screen does", () => {
+	it("does not repeat the vault or the count the head already carries", () => {
+		// Three copies of one name on a phone screen was #125: in the head,
+		// behind the fold, and on the Cloud vault row underneath.
 		expect(
 			statusFacts({ ...baseStatus(), vaultName: "Work notes", notes: 1202 } as never),
-		).toEqual([
-			["Cloud vault", "Work notes"],
-			["Notes", "1,202"],
-		]);
+		).toEqual([]);
 	});
 
 	it("counts one stuck change as a change, not as changes", () => {
 		expect(statusFacts({ ...baseStatus(), problems: 1 } as never)).toEqual([
 			["Could not sync", "1 change"],
 		]);
+	});
+
+	it("folds nothing away on the happy path, and something under every other word", () => {
+		expect(hasFold({ ...baseStatus(), word: UP_TO_DATE, notes: 1202 } as never)).toBe(false);
+		expect(hasFold({ ...baseStatus(), word: UP_TO_DATE, problems: 2 } as never)).toBe(true);
+		expect(hasFold({ ...baseStatus(), word: SYNCING } as never)).toBe(true);
+		expect(hasFold({ ...baseStatus(), word: OFFLINE } as never)).toBe(true);
 	});
 
 	it("offers the button only for the two words a person can act on", () => {

--- a/docs/ui-ux.md
+++ b/docs/ui-ux.md
@@ -129,9 +129,13 @@ Three rules keep it honest on a narrow window:
 
 - **The row shrinks rather than overflowing.** Without `min-width: 0` the flex
   items refuse to give, the head runs past its own padding, and the card's
-  `overflow: hidden` cuts it at both ends: the dot off the left, the count off
-  the right. That leaves the word as the only carrier, which is the one thing
-  the two-carrier rule exists to prevent.
+  `overflow: hidden` cuts it. Measured at 390px, the cut is 9px at Obsidian's
+  smaller UI font and 44px at its larger one, and it is the note count that
+  goes: negative free space in a flex row packs the items left and spills the
+  tail. **The dot is never cut**, which #125 and the PR that closed it both
+  claimed off a screenshot before anybody measured it.
+  [`scripts/spikes/status_bar_on_a_phone/`](../scripts/spikes/status_bar_on_a_phone/README.md)
+  is where that was settled, and it fails against the stylesheet as it stood.
 - **The name gives way before the count.** They are two spans rather than one
   string precisely so they can shrink differently. A vault name is a name, and
   it is spelled out in full on the Cloud vault row a thumb below; *1,368 notes*

--- a/docs/ui-ux.md
+++ b/docs/ui-ux.md
@@ -38,8 +38,6 @@ either side of it rather than like a panel we built.
   │ ├──────────────────────────────────────────────────────────┤ │
   │ │ Leave Obsidian open until it finishes. It picks up       │ │
   │ │ where it left off if you close it.                       │ │
-  │ │ Cloud vault      Work notes                              │ │
-  │ │ Notes            312                                     │ │
   │ └──────────────────────────────────────────────────────────┘ │
   │                                                              │
   │ Account                                       [ Sign out ]   │
@@ -105,12 +103,49 @@ asks:
 | Behind the fold | When |
 |---|---|
 | The instruction for this word | Whenever the word carries one |
-| Cloud vault, Notes | When there is a link, and when notes have arrived |
 | Could not sync, *N* changes | When something failed and stayed failed |
 | **Try again** | Only under *Problem* and *Offline*, the two words a person can act on |
 
 Nothing deeper is kept here at all. What went wrong in detail is the server's;
 this device only ever tells it four content-free facts (ADR-0071).
+
+**The fold holds nothing the head already carries, and where it would hold
+nothing at all the head does not open.** Under *Up to date* there is no
+instruction and, with nothing stuck, no rows and no button, so the bar is a
+line rather than a control: a head that opens onto an empty strip is worse than
+a head that does not open. The vault and its note count used to be behind it as
+well as on it, which put the vault's name on one phone screen three times, in
+the head, behind the fold and again on the Cloud vault row (#125). A desktop
+width spreads those three far enough apart to hide it. Stacked into one column
+they are within a thumb of each other.
+
+**The chevron is not decoration.** A touch screen has no hover, so without it
+there is nothing on a phone saying the bar opens at all.
+
+### On a phone
+
+The bar was drawn for a width it does not always have, and #125 was the bill.
+Three rules keep it honest on a narrow window:
+
+- **The row shrinks rather than overflowing.** Without `min-width: 0` the flex
+  items refuse to give, the head runs past its own padding, and the card's
+  `overflow: hidden` cuts it at both ends: the dot off the left, the count off
+  the right. That leaves the word as the only carrier, which is the one thing
+  the two-carrier rule exists to prevent.
+- **The name gives way before the count.** They are two spans rather than one
+  string precisely so they can shrink differently. A vault name is a name, and
+  it is spelled out in full on the Cloud vault row a thumb below; *1,368 notes*
+  is what somebody opened the screen for.
+- **Hover only where there is a pointer.** On iOS `:hover` sticks after the tap
+  and the head sat shaded, reading as jammed down.
+
+Two things about the mobile screen are not ours to fix and are worth knowing
+anyway. Obsidian stacks `setting-item` into a column, so *Sign out* and *Unlink*
+render as full width pills: the two loudest controls on the screen are both
+undos, which is the reverse of the weight they have on a desktop. And the host
+line, muted grey under the sheet title with a back arrow above it, sits exactly
+where a browser puts an address. It stays, because a beta build talks somewhere
+other than a release does, but that is the frame it is read in.
 
 ## The words
 
@@ -275,7 +310,7 @@ believing they are gone.
 
 ## Changing any of this
 
-- The screen is `src/knap/KnapSettingsTab.ts`. `statusFacts` and `hasRetry` are
+- The screen is `src/knap/KnapSettingsTab.ts`. `statusFacts`, `hasFold` and `hasRetry` are
   exported and pure precisely so the branching is pinned in
   `__tests__/knap/settingsTab.test.ts` rather than asserted against a screen.
 - The words are `src/syncStatus.ts`, and adding one means the rule above.

--- a/scripts/spikes/status_bar_on_a_phone/README.md
+++ b/scripts/spikes/status_bar_on_a_phone/README.md
@@ -1,0 +1,61 @@
+# Does the status bar's head fit a phone?
+
+The bar was drawn for a desktop width and #125 was the bill: on an iPhone the
+head ran past its card and `.knap-status { overflow: hidden }` cut it, taking
+the note count with it. The fix was reasoned off the CSS. This measures it.
+
+Run it:
+
+```sh
+node scripts/spikes/status_bar_on_a_phone/measure.mjs
+```
+
+It needs `playwright-core` and a Chromium, neither of which is a dependency of
+this plugin, so it installs nothing and skips with exit code 2 when they are
+not there. Where Playwright's own browser does not match its version, point it
+at one: `KNAP_CHROMIUM=/path/to/chrome node .../measure.mjs`. In this repo's own CI they are not, which is why this is a spike
+rather than a test: it is run by a person changing the bar, not by a robot.
+
+## What it does
+
+Renders the head exactly as `KnapSettingsTab.drawStatus()` builds it, inside a
+card the width Obsidian's settings sheet gives it on a 390px screen, against
+the real `styles.css`. Then it asks one question of every rendering: **is
+anything outside the card?**
+
+The vault name is the one from the #125 screenshot, `260812_RH_Obsidian_vault`,
+because a name that long is what made a comfortable row into a broken one.
+
+## The thing it cannot know, and what it does instead
+
+**Obsidian's own font sizes on a phone.** `--font-ui-small` and the base size
+are the app's, not ours, and there is no Obsidian on the machine that runs this
+(the real-app e2e needs a docker daemon). So it sweeps them instead of guessing
+one, and every size in the sweep has to pass.
+
+That sweep is what caught the fix's first measurement being worthless: at a
+desktop-ish 13px the old CSS did not overflow at all, and the bug only appears
+from about 15px, which is where a phone starts.
+
+## What it measured on 2026-09-01
+
+Point `styles.css` at the commit before the fix and the cut grows with the font
+size, on the same *Syncing* head this script renders:
+
+| base / `--font-ui-small` | cut off the right |
+|---|---|
+| 16 / 13 | none |
+| 16 / 15 | 9px |
+| 17 / 16 | 27px |
+| 18 / 17 | 44px |
+
+A longer word in front of it costs more: *Up to date* rather than *Syncing*
+puts the same row 28px, 46px and 65px outside.
+
+**The overflow is to the right only, and the dot is never cut.** #125 and this
+PR both said the dot went off the left edge, read off a screenshot. It does
+not: negative free space in a flex row packs the items left and spills the tail,
+so the count is what is lost and the dot stays where it is. The claim is
+corrected in `docs/ui-ux.md`; this table is where it was settled.
+
+After the fix, nothing is outside the card at any size in the sweep.

--- a/scripts/spikes/status_bar_on_a_phone/measure.mjs
+++ b/scripts/spikes/status_bar_on_a_phone/measure.mjs
@@ -1,0 +1,139 @@
+/**
+ * Is anything in the status bar's head outside its card on a phone?
+ *
+ * Renders the head as KnapSettingsTab.drawStatus() builds it, against the real
+ * styles.css, in a card the width Obsidian's settings sheet gives it at 390px.
+ * Obsidian's own font sizes are the app's rather than ours and there is no
+ * Obsidian here to read them from, so they are swept and every size has to
+ * pass. See README.md for what this settled and what it cannot know.
+ *
+ * Exit codes: 0 nothing is cut, 1 something is, 2 the environment is not there.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const STYLES = join(HERE, "..", "..", "..", "styles.css");
+
+let chromium;
+try {
+	({ chromium } = await import("playwright-core"));
+} catch {
+	console.error("playwright-core is not installed. This spike installs nothing; see README.md.");
+	process.exit(2);
+}
+
+/** The name from the #125 screenshot. A short one hides the bug. */
+const VAULT = "260812_RH_Obsidian_vault";
+const COUNT = "1,368 notes";
+
+/** Obsidian's tokens, as far as they matter to this row. */
+const tokens = (base, small) => `
+:root {
+  --size-2-2:4px; --size-2-3:6px;
+  --size-4-1:4px; --size-4-2:8px; --size-4-3:12px; --size-4-4:16px;
+  --font-ui-smaller:${small - 1}px; --font-ui-small:${small}px; --font-semibold:600;
+  --radius-m:8px; --icon-s:16px;
+  --text-normal:#222; --text-muted:#666; --text-faint:#999;
+  --background-secondary:#f2f3f5; --background-modifier-border:#ddd;
+  --background-modifier-hover:rgba(0,0,0,.075);
+  --color-green:#0a0; --color-yellow:#ca0; --color-red:#c00; --interactive-accent:#7b6cd9;
+}
+* { box-sizing: border-box; }
+body { margin: 0; font-family: -apple-system, sans-serif; font-size: ${base}px; }
+/* Obsidian sets this on its buttons, and the head is one whenever it folds. */
+button { white-space: nowrap; }
+/* The settings sheet on a 390px screen, 16px either side. */
+#sheet { width: 358px; }
+`;
+
+/** The head with a fold behind it, which is the wider of the two shapes. */
+const HEAD = `<div id="sheet"><div class="knap-status">
+ <button type="button" class="knap-status-head knap-status-opens" aria-expanded="false"
+  ><span class="knap-dot knap-dot-ok"></span
+  ><span class="knap-status-word">Syncing</span
+  ><span class="knap-status-detail"
+    ><span class="knap-status-vault">${VAULT}</span
+    ><span class="knap-status-count">${COUNT}</span
+  ></span
+  ><span class="knap-status-chevron"></span
+ ></button>
+ <div class="knap-status-body" hidden></div>
+</div></div>`;
+
+const css = readFileSync(STYLES, "utf8");
+
+// Whichever Chromium is on the machine. A spike installs nothing, so it takes
+// the one Playwright manages if the versions happen to line up, and otherwise
+// the one named in KNAP_CHROMIUM. Neither is this plugin's dependency.
+async function launch() {
+	try {
+		return await chromium.launch();
+	} catch (first) {
+		if (!process.env.KNAP_CHROMIUM) {
+			console.error(String(first).split("\n")[0]);
+			console.error("No Chromium. Set KNAP_CHROMIUM to one, or run npx playwright install.");
+			process.exit(2);
+		}
+		return chromium.launch({ executablePath: process.env.KNAP_CHROMIUM });
+	}
+}
+
+const browser = await launch();
+const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+
+/** Everything the card would clip, in whole pixels. */
+async function probe(base, small) {
+	await page.setContent(`<style>${tokens(base, small)}\n${css}</style>${HEAD}`);
+	return page.evaluate(() => {
+		const rect = (sel) => document.querySelector(sel)?.getBoundingClientRect();
+		const card = rect(".knap-status");
+		const head = document.querySelector(".knap-status-head");
+		const last = rect(".knap-status-chevron") ?? rect(".knap-status-count");
+		return {
+			cutLeft: Math.round(Math.max(0, card.left - rect(".knap-dot").left)),
+			cutRight: Math.round(Math.max(0, last.right - card.right)),
+			overflow: Math.round(head.scrollWidth - head.clientWidth),
+			countShown: Math.round(rect(".knap-status-count").width) > 0,
+		};
+	});
+}
+
+// From a desktop-ish size up through where a phone actually sits. The bug this
+// spike exists for only appears from about 15px, so a single small size proves
+// nothing.
+const SIZES = [
+	[16, 13],
+	[16, 15],
+	[17, 15],
+	[17, 16],
+	[18, 16],
+	[18, 17],
+	[19, 17],
+];
+
+const failures = [];
+console.log("base/small   cut left   cut right   overflow   count shown");
+for (const [base, small] of SIZES) {
+	const out = await probe(base, small);
+	console.log(
+		`${base}/${small}` +
+			`${String(out.cutLeft).padStart(11)}` +
+			`${String(out.cutRight).padStart(12)}` +
+			`${String(out.overflow).padStart(11)}` +
+			`${String(out.countShown).padStart(14)}`,
+	);
+	if (out.cutLeft > 0) failures.push(`${base}/${small}: the dot is ${out.cutLeft}px outside`);
+	if (out.cutRight > 0) failures.push(`${base}/${small}: the row is ${out.cutRight}px outside`);
+	if (!out.countShown) failures.push(`${base}/${small}: the count has no width left`);
+}
+
+await browser.close();
+
+if (failures.length) {
+	console.error("\nFAIL");
+	for (const line of failures) console.error(`  ${line}`);
+	process.exit(1);
+}
+console.log("\nPASS: nothing is outside the card, at any size in the sweep");

--- a/src/knap/KnapSettingsTab.ts
+++ b/src/knap/KnapSettingsTab.ts
@@ -30,9 +30,9 @@
  * uninstalling the plugin, which leaves the token alive anyway.
  */
 
-import { Notice, type Plugin, PluginSettingTab, Setting } from "obsidian";
+import { Notice, type Plugin, PluginSettingTab, Setting, setIcon } from "obsidian";
 
-import { OFFLINE, PROBLEM, SIGNED_OUT, syncInstruction } from "../syncStatus";
+import { OFFLINE, PROBLEM, syncInstruction } from "../syncStatus";
 import type { KnapStatus, KnapSync } from "./KnapSync";
 
 /**
@@ -52,15 +52,17 @@ export function signOutNotice(endedRemotely: boolean): string {
  * Pure, and exported, because it is the half of the bar worth pinning in a
  * test: which facts appear depends on the word, and a fact that appears with
  * nothing to say is the sort of empty row this screen exists to be rid of.
+ *
+ * **The vault and its note count are not here**, because the head already
+ * carries them and the fold's whole justification is holding what the head
+ * does not. They were in both until #125, which is how one phone screen came
+ * to say the vault's name three times: in the head, behind the fold, and again
+ * on the Cloud vault row. On a desktop width those three sit far apart and the
+ * repetition is quiet. Stacked into one column on a phone they are within a
+ * thumb of each other.
  */
 export function statusFacts(status: KnapStatus): Array<[string, string]> {
 	const facts: Array<[string, string]> = [];
-	if (status.vaultName) {
-		facts.push(["Cloud vault", status.vaultName]);
-	}
-	if (status.notes > 0) {
-		facts.push(["Notes", status.notes.toLocaleString("en-US")]);
-	}
 	if (status.problems > 0) {
 		facts.push([
 			"Could not sync",
@@ -68,6 +70,18 @@ export function statusFacts(status: KnapStatus): Array<[string, string]> {
 		]);
 	}
 	return facts;
+}
+
+/**
+ * Whether the bar has anything folded away at all.
+ *
+ * On the happy path it does not: no instruction under *Up to date*, nothing
+ * stuck, nothing to retry. A head that opens onto an empty strip is worse than
+ * a head that does not open, so the bar only becomes a button when there is
+ * something under it.
+ */
+export function hasFold(status: KnapStatus): boolean {
+	return Boolean(syncInstruction(status.word)) || statusFacts(status).length > 0 || hasRetry(status);
 }
 
 /** Only the two words a person can do something about get a button here. */
@@ -192,28 +206,55 @@ export class KnapSettingsTab extends PluginSettingTab {
 	 * description and controls on the right, and this is none of those. It is
 	 * the first thing on the screen because it is what somebody came to find
 	 * out; the two rows under it are what they came to change, which is rarer.
+	 *
+	 * **The head is a button only when something is folded behind it** (#125).
+	 * Under *Up to date* there is no instruction, nothing stuck and nothing to
+	 * retry, so the head opens onto an empty strip, and a control that does
+	 * nothing is worse than no control.
+	 *
+	 * The detail is two spans rather than one string because they shrink
+	 * differently. On a phone the whole line is wider than the card, and the
+	 * count is the half worth keeping: a long vault name is a name, while
+	 * *1,368 notes* is the answer to what somebody opened the screen for. So the
+	 * name truncates and the count never does.
 	 */
 	private drawStatus(containerEl: HTMLElement): void {
 		const status = this.sync.status();
 		const block = containerEl.createDiv({ cls: "knap-status" });
+		const folds = hasFold(status);
 
 		const body = block.createDiv({ cls: "knap-status-body" });
 		body.hidden = true;
 
-		const head = block.createEl("button", { cls: "knap-status-head" });
-		head.type = "button";
-		head.setAttribute("aria-expanded", "false");
+		const head = folds
+			? block.createEl("button", { cls: "knap-status-head knap-status-opens" })
+			: block.createDiv({ cls: "knap-status-head" });
+		if (folds) (head as HTMLButtonElement).type = "button";
 		head.createSpan({ cls: `knap-dot knap-dot-${status.dot}` });
 		head.createSpan({ cls: "knap-status-word", text: status.word });
-		const detail = detailLine(status);
-		if (detail) {
-			head.createSpan({ cls: "knap-status-detail", text: detail });
+		const detail = head.createSpan({ cls: "knap-status-detail" });
+		if (status.vaultName) {
+			detail.createSpan({ cls: "knap-status-vault", text: status.vaultName });
 		}
-		head.addEventListener("click", () => {
-			const open = head.getAttribute("aria-expanded") === "true";
-			head.setAttribute("aria-expanded", String(!open));
-			body.hidden = open;
-		});
+		if (status.notes > 0) {
+			detail.createSpan({
+				cls: "knap-status-count",
+				text: `${status.notes.toLocaleString("en-US")} note${status.notes === 1 ? "" : "s"}`,
+			});
+		}
+
+		if (folds) {
+			// A touch screen has no hover to discover the fold with, so the
+			// chevron is the only thing that says the bar opens (#125).
+			const chevron = head.createSpan({ cls: "knap-status-chevron" });
+			setIcon(chevron as HTMLElement, "chevron-down");
+			head.setAttribute("aria-expanded", "false");
+			head.addEventListener("click", () => {
+				const open = head.getAttribute("aria-expanded") === "true";
+				head.setAttribute("aria-expanded", String(!open));
+				body.hidden = open;
+			});
+		}
 		// The head is written after the body so the click handler can close
 		// over it, and moved above it here, where the reader expects it.
 		block.insertBefore(head, body);
@@ -234,23 +275,7 @@ export class KnapSettingsTab extends PluginSettingTab {
 				void this.sync.retry().then(() => this.display());
 			});
 		}
-		if (status.word === SIGNED_OUT) {
-			// Unreachable from here, because a signed-out screen never draws
-			// the bar. Kept as the one place that would have to change if the
-			// bar ever appeared before the account did.
-			body.createDiv({ cls: "knap-status-say", text: "Sign in above to carry on." });
-		}
 	}
-}
-
-/** "Work notes, 312 notes", or as much of it as is true. */
-function detailLine(status: KnapStatus): string {
-	const parts: string[] = [];
-	if (status.vaultName) parts.push(status.vaultName);
-	if (status.notes > 0) {
-		parts.push(`${status.notes.toLocaleString("en-US")} note${status.notes === 1 ? "" : "s"}`);
-	}
-	return parts.join(" · ");
 }
 
 /** The address without its scheme, because nobody reads https to a person. */

--- a/styles.css
+++ b/styles.css
@@ -556,24 +556,81 @@
 	border: none;
 	box-shadow: none;
 	text-align: left;
-	cursor: pointer;
 	color: var(--text-normal);
+	/* A phone is narrower than this row wants to be, and without this the
+	   flex items refuse to shrink, the row overflows its own padding and the
+	   card's `overflow: hidden` clips it at both ends: the dot off the left,
+	   the note count off the right (#125). */
+	min-width: 0;
 }
 
-.knap-status-head:hover {
-	background: var(--background-modifier-hover);
+.knap-status-opens {
+	cursor: pointer;
+}
+
+/* Only where there is a pointer to hover with. On a touch screen `:hover`
+   sticks after the tap, and the head sat shaded as if jammed down (#125). */
+@media (hover: hover) {
+	.knap-status-opens:hover {
+		background: var(--background-modifier-hover);
+	}
 }
 
 .knap-status-word {
 	font-weight: var(--font-semibold);
+	flex-shrink: 0;
 }
 
 /* Pushed to the far end rather than following the word, so the eye finds the
-   word in the same place whatever it is about. */
+   word in the same place whatever it is about. Where there is no far end, it
+   takes what is left and the two halves inside it shrink differently. */
 .knap-status-detail {
+	display: flex;
+	gap: var(--size-4-1);
 	margin-left: auto;
+	min-width: 0;
 	color: var(--text-muted);
 	font-size: var(--font-ui-small);
+}
+
+.knap-status-detail > * + *::before {
+	content: "·";
+	margin-right: var(--size-4-1);
+	color: var(--text-faint);
+}
+
+/* The name gives way first. It is a name, and it is spelled out in full on
+   the Cloud vault row a thumb below; the count is the answer somebody opened
+   the screen for, so it is the half that survives a narrow window. */
+.knap-status-vault {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 3em;
+}
+
+.knap-status-count {
+	flex-shrink: 0;
+	white-space: nowrap;
+	font-variant-numeric: tabular-nums;
+}
+
+/* The only thing saying the bar opens. A touch screen has no hover to find
+   that out with, and the fold was undiscoverable without it (#125). */
+.knap-status-chevron {
+	display: flex;
+	flex-shrink: 0;
+	color: var(--text-faint);
+	transition: transform 100ms ease-in-out;
+}
+
+.knap-status-chevron svg {
+	width: var(--icon-s);
+	height: var(--icon-s);
+}
+
+.knap-status-head[aria-expanded="true"] .knap-status-chevron {
+	transform: rotate(180deg);
 }
 
 .knap-status-body {
@@ -602,12 +659,14 @@
 	font-size: var(--font-ui-small);
 }
 
+/* An 8em gutter spent a third of a phone's width on a label (#125). The value
+   is pushed to the far end instead, which lines up at any width. */
 .knap-status-key {
 	color: var(--text-faint);
-	min-width: 8em;
 }
 
 .knap-status-value {
+	margin-left: auto;
 	color: var(--text-normal);
 	font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
Closes #125, items 1 through 4 and the smaller one. Items 5 and 6 of that issue are judgement calls about weight, left open.

## Summary

The settings tab was drawn for a desktop width, and a phone showed it.

**The head overflowed its card and the note count was cut off.** `.knap-status-head` is a one line flex row with no `min-width: 0`, so its items refused to shrink, the row ran past its own padding, and `.knap-status { overflow: hidden }` cut the tail. Measured at 390px: 9px outside at Obsidian's smaller UI font, 44px at its larger one, and the count is what goes. The row shrinks now, and the vault name and the count are two spans rather than one string so they give way in the right order. The name truncates, because it is a name and it is spelled out in full on the Cloud vault row a thumb below. The count never does, because it is what somebody opened the screen for.

**The fold repeated the head.** `statusFacts()` emitted `Cloud vault` and `Notes`, which `detailLine()` had already put in the head and the Cloud vault row put on screen a third time. On the happy path that left the fold holding two rows that said nothing new. It now holds only what the head does not: the instruction, `Could not sync`, and `Try again`. Where that comes to nothing, which is every *Up to date* with nothing stuck, the head is not a button at all. A control that opens onto an empty strip is worse than no control.

**Nothing said the bar folded.** `docs/ui-ux.md` draws a `▾` and the code never had one. A touch screen has no hover to discover it with, so the bar read as a static banner. Added, via `setIcon`, and it rotates.

**The hover stuck after a tap.** On iOS `:hover` holds until the next tap elsewhere, so the head sat shaded as if jammed down. The rule is behind `@media (hover: hover)` now.

**`.knap-status-key { min-width: 8em }`** spent a third of a phone's width on a label gutter. The value is pushed to the far end instead, which lines up at any width.

## Corrected: the dot is not cut

The first version of this description, and #125 before it, said the dot went off the left edge and left the word as the only carrier of the state. **That is wrong**, and it was read off a screenshot rather than measured. Negative free space in a flex row packs the items left and spills the tail, so the dot stays where it is at every size tested. The case for the fix is unchanged, the count is the half worth keeping, but the two-carrier rule was never at stake. `docs/ui-ux.md` carries the correction.

## The spike

`scripts/spikes/status_bar_on_a_phone/` renders the head as `drawStatus()` builds it, in a card the width Obsidian's settings sheet gives it at 390px, against the real `styles.css`, and asks whether anything is outside the card. It sweeps Obsidian's font sizes rather than picking one, because those are the app's and there is no Obsidian on the machine that runs this.

That sweep earned its place immediately: at a desktop-ish 13px the stylesheet before the fix does not overflow at all, so one small size would have reported the bug fixed before it was written. Pointed at the previous commit it fails; pointed at this one it passes at every size.

It installs nothing and exits 2 when `playwright-core` or a Chromium is missing, which is why it is a spike rather than a test.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (one pre-existing warning about the declarative settings API, untouched here)
- [ ] Tested in Obsidian
- [x] Changes are minimal and focused

`npx jest` is green: 876 passed, 4 skipped. `__tests__/knap/settingsTab.test.ts` gains four cases: the name and count as separate spans, the head that does not open when the fold would be empty, the chevron, and `hasFold` across the words.

**Still not seen on a real phone.** The geometry is measured now, in Chromium at 390px against the real stylesheet. What that harness cannot know is Obsidian's own CSS, which is why it sweeps the fonts. The chevron, the fold and the stuck hover are reasoned, not measured. That is what the unticked box is.