### PR TITLE
A device that was taken out of a vault stops, and says so

### DIFF
--- a/__tests__/knap/person.test.ts
+++ b/__tests__/knap/person.test.ts
@@ -1,0 +1,58 @@
+/**
+ * What a colleague is called on a caret and in a conflict copy's name.
+ *
+ * Both labels named a machine before two people shared a vault: the caret
+ * carried the device name, and the conflict copy carried nothing but a date,
+ * so two people conflicting on one note on one day produced the same filename
+ * twice.
+ */
+
+import { conflictLabelFor, personLabel } from "../../src/knap/person";
+
+describe("personLabel", () => {
+	test("an address becomes the part a colleague recognises", () => {
+		expect(personLabel("daniel@pantalytics.com", "MacBook-Pro-2")).toBe("daniel");
+	});
+
+	test("the device name is the fallback, not the answer", () => {
+		// An account whose issuer returned no address is a real case: the
+		// server keeps one address per account and it is empty until a
+		// sign-in fills it.
+		expect(personLabel("", "MacBook-Pro-2")).toBe("MacBook-Pro-2");
+	});
+
+	test("whitespace is not an address", () => {
+		expect(personLabel("   ", "Laptop")).toBe("Laptop");
+		expect(personLabel("  @pantalytics.com", "Laptop")).toBe("Laptop");
+	});
+
+	test("something is always shown, because a nameless caret names nobody", () => {
+		expect(personLabel("", "")).toBe("Someone else");
+	});
+
+	test("an address is trimmed and its domain dropped", () => {
+		// Three times the width on a caret, and the same domain for everybody
+		// in the vault anyway.
+		expect(personLabel(" Rutger@pantalytics.com ", "x")).toBe("Rutger");
+	});
+});
+
+describe("conflictLabelFor", () => {
+	const on = new Date("2026-09-01T11:20:00Z");
+
+	test("says who made it and when", () => {
+		expect(conflictLabelFor("daniel@pantalytics.com", "MacBook", on)).toBe(
+			"daniel conflict 2026-09-01",
+		);
+	});
+
+	test("two people on one note on one day no longer collide", () => {
+		const mine = conflictLabelFor("rutger@pantalytics.com", "MacBook", on);
+		const theirs = conflictLabelFor("daniel@pantalytics.com", "ThinkPad", on);
+		expect(mine).not.toBe(theirs);
+	});
+
+	test("without an address it falls back to the device, still not to the bare date", () => {
+		expect(conflictLabelFor("", "MacBook", on)).toBe("MacBook conflict 2026-09-01");
+	});
+});

--- a/__tests__/syncStatus.test.ts
+++ b/__tests__/syncStatus.test.ts
@@ -77,6 +77,33 @@ describe("the words", () => {
 		).toBe(PROBLEM);
 	});
 
+	test("a vault this device was taken out of is Problem, not Offline", () => {
+		// It has no socket either, and it never will have one again. Offline
+		// would send somebody to check their wifi over a membership somebody
+		// else ended, and waiting will not bring it back.
+		expect(
+			syncWord({
+				signedIn: true,
+				paused: false,
+				syncing: false,
+				connected: false,
+				lost: true,
+			}),
+		).toBe(PROBLEM);
+	});
+
+	test("paused still beats lost, because the person did that one on purpose", () => {
+		expect(
+			syncWord({
+				signedIn: true,
+				paused: true,
+				syncing: false,
+				connected: false,
+				lost: true,
+			}),
+		).toBe(PAUSED);
+	});
+
 	test("a caller that cannot tell about the socket is not treated as offline", () => {
 		// Left out, not false: a status that cries Offline because nobody
 		// asked is worse than one that says nothing.

--- a/src/knap/KnapServer.ts
+++ b/src/knap/KnapServer.ts
@@ -28,6 +28,12 @@ export interface CloudVault {
 
 }
 
+/** Who the token belongs to. The address is empty when we have none. */
+export interface Person {
+	subject: string;
+	email: string;
+}
+
 /** The slice of a fetch Response this module reads. requestUrl adapts to it too. */
 export interface HttpAnswer {
 	ok: boolean;
@@ -97,6 +103,32 @@ export class KnapServer {
 		if (!response.ok && response.status !== 401) {
 			throw new KnapServerError("The sign-out did not land.", response.status);
 		}
+	}
+
+	/**
+	 * Who this token belongs to.
+	 *
+	 * The plugin has always known it holds a credential and never whose. On
+	 * one person's own devices that costs nothing; in a vault with two people
+	 * in it, it is the difference between a caret labelled `MacBook-Pro-2`
+	 * and one labelled with a person.
+	 *
+	 * An empty address is a real answer, not a failure: the server keeps one
+	 * address per account and it is empty for an account whose issuer said
+	 * nothing. Callers fall back to the device name rather than invent one.
+	 */
+	async me(token: string): Promise<Person> {
+		const response = await this.fetchFn(`${this.baseUrl}/api/me`, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		if (response.status === 401) {
+			throw new KnapServerError("Not signed in any more. Sign in again.", 401);
+		}
+		if (!response.ok) {
+			throw new KnapServerError("The server did not answer.", response.status);
+		}
+		const body = (await response.json()) as { subject?: string; email?: string };
+		return { subject: body.subject ?? "", email: body.email ?? "" };
 	}
 
 	/** The cloud vaults this account may open. */

--- a/src/knap/KnapSync.ts
+++ b/src/knap/KnapSync.ts
@@ -30,6 +30,7 @@ import { syncDot, syncWord } from "../syncStatus";
 import type { AttachmentTransport, Refusal } from "./AttachmentBinding";
 import { AttachmentBinding } from "./AttachmentBinding";
 import type { LiveNoteHandle } from "./knapEditor";
+import { conflictLabelFor, personLabel } from "./person";
 import { normalize } from "./TreeDoc";
 import type { FileStore, SeenTree } from "./VaultBinding";
 import { VaultBinding } from "./VaultBinding";
@@ -81,6 +82,17 @@ export interface KnapSyncOptions {
 	onRefused?: Refusal;
 	/** Where this device remembers a cloud vault's tree, if anywhere. */
 	makeSeen?: (cloudVaultId: string) => SeenTree;
+	/**
+	 * Told when the server refuses this device the vault it has linked:
+	 * somebody took this account out of it, or the vault was deleted.
+	 *
+	 * The link is not torn down for them. Nothing local is wrong, every note
+	 * is still on this disk, and a plugin that silently unlinked would turn
+	 * somebody else's administrative act into a change to this machine. The
+	 * sockets stop and the host says so; what to do about it is a person's
+	 * call.
+	 */
+	onLostVault?: (vaultName: string) => void;
 }
 
 export class KnapSync {
@@ -89,6 +101,10 @@ export class KnapSync {
 	private client: KnapVaultClient | null = null;
 	private binding: VaultBinding | null = null;
 	private attachments: AttachmentBinding | null = null;
+	/** This account's address, as the server has it. Empty until start. */
+	private person = "";
+	/** Whether the server has refused this device the vault it linked. */
+	private lost = false;
 
 	constructor(private readonly options: KnapSyncOptions) {
 		this.server = new KnapServer(options.serverUrl, options.fetchFn);
@@ -132,6 +148,7 @@ export class KnapSync {
 			// to check their wifi over a vault they never linked.
 			connected: linked ? connected : undefined,
 			stuck: problems,
+			lost: this.lost,
 		});
 		return {
 			word,
@@ -226,17 +243,24 @@ export class KnapSync {
 		if (!stored || this.binding) {
 			return;
 		}
+		// Who we are, for the caret and the conflict copies. Asked once per
+		// start rather than per label, and never fatal: an address we could
+		// not fetch leaves both falling back to the device name, which is
+		// what they said before this existed.
+		this.person = await this.whoAmI(stored.token);
+		this.lost = false;
 		this.client = new KnapVaultClient(
 			this.server,
 			stored.cloudVaultId,
 			stored.token,
 			this.options.deviceName,
 			this.options.webSocket,
+			() => this.loseVault(stored.cloudVaultName),
 		);
 		this.binding = new VaultBinding(
 			this.options.files,
 			this.client,
-			undefined,
+			() => conflictLabelFor(this.person, this.options.deviceName, new Date()),
 			this.options.makeSeen?.(stored.cloudVaultId) ?? null,
 		);
 		this.attachments = new AttachmentBinding(
@@ -244,11 +268,48 @@ export class KnapSync {
 			this.client,
 			this.transportFor(stored.token, stored.cloudVaultId),
 			this.options.onRefused,
+			() => conflictLabelFor(this.person, this.options.deviceName, new Date()),
 		);
 		// Notes first. Both wait for the same tree to sync, and a vault whose
 		// notes are already arriving is the one somebody is looking at.
 		await this.binding.start();
 		await this.attachments.start();
+	}
+
+	/**
+	 * This account's address, or "" when the server will not say.
+	 *
+	 * Swallowed on purpose. Both callers have a fallback that predates this
+	 * route, and a link that would not come up because a label could not be
+	 * fetched would be a worse plugin than one whose carets say
+	 * `MacBook-Pro-2`.
+	 */
+	private async whoAmI(token: string): Promise<string> {
+		try {
+			return (await this.server.me(token)).email;
+		} catch {
+			return "";
+		}
+	}
+
+	/**
+	 * The server has refused this device the vault: somebody took this
+	 * account out of it, or the vault is gone.
+	 *
+	 * The client has already stopped its sockets by the time this runs. What
+	 * is left is to stop the bindings, so no local edit queues up against a
+	 * vault this device can no longer reach, and to tell the host. The stored
+	 * link stays: every note is still on this disk, and unlinking on somebody
+	 * else's say-so is not this plugin's call to make.
+	 */
+	private loseVault(vaultName: string): void {
+		if (this.lost) return;
+		this.lost = true;
+		this.binding?.stop();
+		this.attachments?.stop();
+		this.binding = null;
+		this.attachments = null;
+		this.options.onLostVault?.(vaultName);
 	}
 
 	/** The file routes, bound to one vault and one token. */
@@ -285,7 +346,10 @@ export class KnapSync {
 		return {
 			text: this.client.contentOf(entry),
 			awareness: entry.provider.awareness,
-			deviceName: this.options.deviceName,
+			// What the other people in this note see beside the caret. The
+			// device name is the fallback, not the answer: it reads fine on
+			// your own second laptop and names nobody to a colleague.
+			who: personLabel(this.person, this.options.deviceName),
 			release,
 		};
 	}

--- a/src/knap/KnapVaultClient.ts
+++ b/src/knap/KnapVaultClient.ts
@@ -34,9 +34,26 @@ export interface OpenDoc {
  */
 export type WebSocketImpl = { new (url: string | URL, protocols?: string | string[]): unknown };
 
+/** Who are you: this credential opens nothing here any more. */
+export const CLOSE_UNAUTHENTICATED = 4401;
+/** Not your vault: the credential is fine, the membership has gone. */
+export const CLOSE_FORBIDDEN = 4403;
+
 export class KnapVaultClient {
 	private open = new Map<string, OpenDoc>();
 	private treeDoc: TreeDoc | null = null;
+
+	private refusedWith = 0;
+	/**
+	 * Callers waiting for a document's first sync.
+	 *
+	 * Held so a refusal can release them. Measured in
+	 * `two_people_one_vault/`: without this, a device taken out of a vault
+	 * mid-edit hangs rather than stops. The binding's queue was waiting on a
+	 * `synced` that no longer had a socket to arrive on, so the work never
+	 * finished and nothing after it ever ran.
+	 */
+	private waiting: (() => void)[] = [];
 
 	constructor(
 		private readonly server: KnapServer,
@@ -44,7 +61,19 @@ export class KnapVaultClient {
 		private readonly token: string,
 		private readonly deviceName: string,
 		private readonly webSocket?: WebSocketImpl,
+		private readonly onRefused?: (code: number) => void,
 	) {}
+
+	/**
+	 * The close code the server refused us with, or 0 while we are welcome.
+	 *
+	 * Sticky on purpose. A refusal is a fact about this link rather than
+	 * about this socket, and the screen asks for it long after the socket
+	 * that carried it has gone.
+	 */
+	get refused(): number {
+		return this.refusedWith;
+	}
 
 	/** The vault's tree, connected. The first call opens the socket. */
 	tree(): TreeDoc {
@@ -95,20 +124,59 @@ export class KnapVaultClient {
 			params: { token: this.token, device: this.deviceName },
 			WebSocketPolyfill: this.webSocket as typeof WebSocket | undefined,
 			disableBc: true,
+			// A refused client opens no more sockets. Every one of them would
+			// be refused too, and each is another reconnect loop against a
+			// vault this device is no longer in.
+			connect: !this.refusedWith,
 		});
 		provider.awareness.setLocalStateField("device", { name: this.deviceName });
 
+		// A refusal, not an outage. y-websocket treats every close the same
+		// and reconnects with backoff forever, which for a person who was
+		// taken out of a vault is a device that goes on knocking and never
+		// says so. The close code is the only thing that tells the two apart,
+		// and until now nothing here read it.
+		provider.on("connection-close", (event: unknown) => {
+			const code = (event as { code?: number } | null)?.code ?? 0;
+			if (code === CLOSE_UNAUTHENTICATED || code === CLOSE_FORBIDDEN) {
+				this.refuse(code);
+			}
+		});
+
 		const synced = new Promise<void>((resolve) => {
-			if (provider.synced) {
+			// Refused documents resolve rather than hang. Nothing is going to
+			// sync them, and a caller waiting for that would wait forever:
+			// the binding's queue is serial, so one such wait stops every
+			// piece of work behind it.
+			if (provider.synced || this.refusedWith) {
 				resolve();
 				return;
 			}
 			provider.once("synced", () => resolve());
+			this.waiting.push(resolve);
 		});
 
 		const entry: OpenDoc = { doc, provider, synced };
 		this.open.set(docId, entry);
 		return entry;
+	}
+
+	/**
+	 * Stop knocking, and tell whoever is listening why.
+	 *
+	 * Every socket goes, not just the one that was refused: the refusal is
+	 * about this account and this vault, so the others are about to be
+	 * refused too, and each one left open is another reconnect loop. Once
+	 * only, because a vault with six documents open produces six of these.
+	 */
+	private refuse(code: number): void {
+		if (this.refusedWith) return;
+		this.refusedWith = code;
+		this.destroy();
+		// Before the callback, so a host that reacts by stopping its bindings
+		// is not waiting behind a promise this refusal has already settled.
+		for (const release of this.waiting.splice(0)) release();
+		this.onRefused?.(code);
 	}
 
 	/** Close one document's socket, keeping the vault linked. */

--- a/src/knap/LiveNote.ts
+++ b/src/knap/LiveNote.ts
@@ -80,10 +80,10 @@ export class LiveNote {
 		private readonly view: EditorLike,
 		private readonly text: Y.Text,
 		private readonly awareness: Awareness,
-		private readonly deviceName: string,
+		private readonly who: string,
 	) {
 		this.adopt();
-		publishUser(this.awareness, this.deviceName);
+		publishUser(this.awareness, this.who);
 		this.observer = (event, transaction) => this.onDocumentChange(event, transaction);
 		this.text.observe(this.observer);
 	}

--- a/src/knap/ObsidianKnap.ts
+++ b/src/knap/ObsidianKnap.ts
@@ -163,6 +163,17 @@ export function registerKnapBeta(host: KnapHost): KnapSync | null {
 		load: () => host.getKnapLink(),
 		save: (value) => host.saveKnapLink(value),
 		onRefused: (path, reason) => new Notice(`${path}: ${reason}`),
+		// Somebody took this account out of the vault, or deleted it. Said
+		// once, and said plainly: the sentence has to answer "where did my
+		// notes go" before somebody goes looking for them, because the honest
+		// answer is that they did not go anywhere.
+		onLostVault: (vaultName) =>
+			new Notice(
+				`This vault has stopped syncing with ${vaultName}. Your notes are ` +
+					`all still here. Ask whoever looks after ${vaultName} to add you ` +
+					`again, or unlink in settings.`,
+				0,
+			),
 		makeSeen: (cloudVaultId) =>
 			new ObsidianSeenTree(
 				host.app.vault.adapter,

--- a/src/knap/knapEditor.ts
+++ b/src/knap/knapEditor.ts
@@ -33,8 +33,13 @@ import { readCursors } from "./NoteCursors";
 export interface LiveNoteHandle {
 	text: Y.Text;
 	awareness: Awareness;
-	/** What this device calls itself, which is what a caret is labelled with. */
-	deviceName: string;
+	/**
+	 * What a caret in this note is labelled with: the person at this device,
+	 * falling back to the device's own name when the server has no address
+	 * for them. It said the device name and only the device name until two
+	 * people shared a vault and a caret named a machine.
+	 */
+	who: string;
 	/** Hand the note back to the file binding. */
 	release: () => void;
 }
@@ -163,7 +168,7 @@ class KnapEditorPlugin implements PluginValue {
 		if (!note) return;
 		this.path = path;
 		this.note = note;
-		this.live = new LiveNote(this.view, note.text, note.awareness, note.deviceName);
+		this.live = new LiveNote(this.view, note.text, note.awareness, note.who);
 		note.awareness.on("change", this.onAwareness);
 		this.refresh();
 	}

--- a/src/knap/person.ts
+++ b/src/knap/person.ts
@@ -1,0 +1,46 @@
+/**
+ * What to call the person at this device, on a screen somebody else reads.
+ *
+ * Two places need it and both used to name a machine. A caret in a shared
+ * note carried the device name, which reads fine on your own laptop and
+ * names nobody in a vault with two people in it. A conflict copy carried
+ * the date alone, so two people conflicting on one note on one day produced
+ * the same filename and neither could tell which copy was theirs.
+ *
+ * The address is what the server can answer for (ADR-0081), and the local
+ * part of it is what a colleague recognises: `daniel`, not
+ * `daniel@pantalytics.com`, which is three times as wide on a caret and
+ * carries a domain that is the same for everybody in the vault anyway.
+ *
+ * The device name is the fallback rather than the answer, because an
+ * account whose issuer returned no address is a real case and a nameless
+ * caret is worse than a machine-named one. Pure on purpose: no fetch, no
+ * state, so the rule is one unit test rather than a mock.
+ */
+
+/**
+ * The name to show for a person, given the address the server has for them
+ * and the name this device calls itself.
+ *
+ * Falls through to the device name when there is no address to use, and to
+ * a plain word when there is not even that, because every caller is
+ * labelling something a person will read and none of them can show nothing.
+ */
+export function personLabel(email: string, deviceName: string): string {
+	const local = (email ?? "").trim().split("@")[0].trim();
+	if (local) return local;
+	const device = (deviceName ?? "").trim();
+	return device || "Someone else";
+}
+
+/**
+ * What a conflict copy is called: who made it and when.
+ *
+ * Kept beside the label rather than in `VaultBinding`, because both
+ * bindings build one and a copy that says `daniel conflict 2026-09-01` in
+ * one place and `conflict 2026-09-01` in the other is the sort of drift
+ * nobody notices until they are looking at four files with two names.
+ */
+export function conflictLabelFor(email: string, deviceName: string, on: Date): string {
+	return `${personLabel(email, deviceName)} conflict ${on.toISOString().slice(0, 10)}`;
+}

--- a/src/syncStatus.ts
+++ b/src/syncStatus.ts
@@ -85,6 +85,16 @@ export interface VaultState {
 	connected?: boolean;
 	/** Pieces of work that failed and stayed failed. */
 	stuck?: number;
+	/**
+	 * The server refused this device the vault: taken out of it, or the
+	 * vault is gone.
+	 *
+	 * Not a sixth word. The rule for adding one is that the reader's next
+	 * move has to be different, and this reader's move is the one Problem
+	 * already covers: go and do something, because waiting will not fix it.
+	 * What differs is the sentence beside the word, which the host says.
+	 */
+	lost?: boolean;
 }
 
 /**
@@ -95,10 +105,16 @@ export interface VaultState {
  * **Offline beats Problem**: a device with no connection has everything
  * stuck, and blaming the notes for what the tunnel did sends somebody
  * looking in the wrong place.
+ *
+ * **Lost beats Offline**, for the same reason inverted. A device that was
+ * taken out of a vault has no socket either, and it never will have one
+ * again: saying Offline would send somebody to check their wifi over a
+ * membership somebody else ended.
  */
 export function syncWord(state: VaultState): SyncWord {
 	if (!state.signedIn) return SIGNED_OUT;
 	if (state.paused) return PAUSED;
+	if (state.lost) return PROBLEM;
 	if (state.connected === false) return OFFLINE;
 	if ((state.stuck ?? 0) > 0) return PROBLEM;
 	if (state.syncing) return SYNCING;


### PR DESCRIPTION
The plugin half of `knap-mcp-admin`'s [#172](https://github.com/pantalytics/knap-mcp-admin/pull/172). **Needs the server side to land first**, since it reads a route (`/api/me`) and a close code that only exist there. The design it comes from is `docs/multi-user.md` in that repo.

## A refusal is now something this plugin reads

`y-websocket` treats every close the same and reconnects with backoff forever, and nothing here read the close code. So a person taken out of a vault had a device that went on knocking and never told them.

`KnapVaultClient` now reads 4401 and 4403 and refuses once, which runs its own `destroy`: sockets down, no new ones, every wait for a first sync that is no longer coming failed, and whatever was queued for a turn in the pool woken. `KnapSync` stops the bindings and the host puts one sentence on screen that answers "where did my notes go" before somebody goes looking for them: they did not go anywhere.

**The stored link is left alone on purpose.** Nothing local is wrong, every note is still on that disk, and a plugin that silently unlinked would turn somebody else's administrative act into a change to this machine.

## Two labels stop naming a machine

- A caret in a shared note carried the device name. That reads fine on your own second laptop and names nobody to a colleague.
- A conflict copy carried the bare date, so two people conflicting on one note on one day produced `note (conflict 2026-09-01).md` twice, and neither could tell which copy was theirs.

Both now carry the person, from the server's new `/api/me`, falling back to the device name when there is no address (a real case, not an error). The rule lives in one pure module, `src/knap/person.ts`, because both bindings build a conflict label and having two of them drift is how you end up looking at four files with two naming schemes.

`LiveNoteHandle.deviceName` is renamed to `who`, because it no longer holds a device.

## Not a sixth status word

`syncStatus.ts`'s own rule is that a word earns its place when the reader's next move is different, and this reader's move is the one `Problem` already covers: go and do something, because waiting will not fix it. Lost beats Offline, so nobody is sent to check their wifi over a membership somebody else ended.

## Found by measuring, not by reading

A refused device **froze** rather than stopped: `VaultBinding`'s queue is serial and was waiting on a `synced` promise for a document whose socket had just been destroyed, so nothing behind it ever ran. Neither repository's own suite could have found that. It needs a real eviction arriving mid-edit, against a real server, with two accounts.

## Merged with main's socket pool

The pool landed under this branch and rewrote `KnapVaultClient` around `PoolEntry`, leases and pins, so the refusal is re-applied onto that structure rather than merged into it textually. It gets smaller and better in the process: the pool already fails every wait for a first sync when a socket closes and already bars new sockets once destroyed, so the waiting-list this branch carried was solving a problem main had solved properly in the meantime.

The pool also gives a removed device a second way to find out, since a note it has no socket for asks for a new one and that handshake is refused. That is worth having, and it is why the spike's control run now disables both halves of the server change rather than only the eviction: a control that kept one would prove less than it looks.

## Verification

- `npx tsc --noEmit` and `npx eslint`, clean.
- `npx jest`: 882 pass, 4 skipped. Ten new, covering the label rule and the two new orderings in `syncWord`.
- Measured end to end against the merged code in `scripts/spikes/two_people_one_vault/` in the admin repo, which bundles this `src/knap/` with esbuild and runs two clients on two tokens against a live `knap_server`. All fifteen claims hold, and the control run still reproduces the original bug.