### PR TITLE
The corner counts two directions, and never counts an edit

### DIFF
--- a/__tests__/knap/backlog.test.ts
+++ b/__tests__/knap/backlog.test.ts
@@ -1,0 +1,163 @@
+/**
+ * What the gauge behind the corner of the window counts, and what it refuses
+ * to count.
+ *
+ * Three things move notes and the two that can be counted are the ones that
+ * are worth a number: notes still to reach the cloud vault, and notes still to
+ * reach this device. An edit to a note both sides already have is the third,
+ * and it never touches the gauge, because a number that goes 1, 0, 1, 0 while
+ * somebody types is what made the old corner unreadable (ADR-0086).
+ */
+
+import * as Y from "yjs";
+
+import { TreeDoc } from "../../src/knap/TreeDoc";
+import type { FileEvent, FileStore, VaultDocs } from "../../src/knap/VaultBinding";
+import { VaultBinding } from "../../src/knap/VaultBinding";
+
+class MemoryFiles implements FileStore {
+	map = new Map<string, string>();
+	listeners: ((event: FileEvent) => void)[] = [];
+	/** Called on every read, which is where a fill spends its time. */
+	onRead: (path: string) => void = () => undefined;
+
+	async read(path: string): Promise<string | null> {
+		this.onRead(path);
+		return this.map.has(path) ? (this.map.get(path) as string) : null;
+	}
+	async write(path: string, text: string): Promise<void> {
+		const existed = this.map.has(path);
+		this.map.set(path, text);
+		this.emit({ type: existed ? "modify" : "create", path });
+	}
+	async remove(path: string): Promise<void> {
+		this.map.delete(path);
+		this.emit({ type: "delete", path });
+	}
+	async rename(from: string, to: string): Promise<void> {
+		const text = this.map.get(from) ?? "";
+		this.map.delete(from);
+		this.map.set(to, text);
+		this.emit({ type: "rename", path: to, oldPath: from });
+	}
+	async readBinary(): Promise<ArrayBuffer | null> {
+		return null;
+	}
+	async writeBinary(): Promise<void> {
+		throw new Error("This store holds notes.");
+	}
+	async listNotes(): Promise<string[]> {
+		return [...this.map.keys()].filter((p) => p.endsWith(".md"));
+	}
+	async listAttachments(): Promise<string[]> {
+		return [];
+	}
+	onChange(callback: (event: FileEvent) => void): () => void {
+		this.listeners.push(callback);
+		return () => {
+			this.listeners = this.listeners.filter((l) => l !== callback);
+		};
+	}
+	emit(event: FileEvent): void {
+		for (const listener of [...this.listeners]) listener(event);
+	}
+}
+
+/** One device's documents, all local: this file is about counting, not sync. */
+function docs(seed: Record<string, string> = {}): VaultDocs {
+	const open = new Map<string, Y.Doc>();
+	const treeDoc = new Y.Doc();
+	const tree = new TreeDoc(treeDoc);
+	for (const [path, text] of Object.entries(seed)) {
+		const docId = tree.ensureNote(path);
+		const doc = new Y.Doc();
+		doc.getText("content").insert(0, text);
+		open.set(docId, doc);
+	}
+	return {
+		tree: () => tree,
+		treeSynced: () => Promise.resolve(),
+		withNote: async <T,>(docId: string, use: (note: { doc: Y.Doc }) => Promise<T>) => {
+			let doc = open.get(docId);
+			if (!doc) open.set(docId, (doc = new Y.Doc()));
+			return use({ doc });
+		},
+		onNoteClosed: () => () => undefined,
+	};
+}
+
+const settle = async (binding: VaultBinding) => {
+	for (let round = 0; round < 3; round++) {
+		await binding.flush();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+};
+
+describe("the two gauges", () => {
+	it("counts every note of a first upload before it starts sending them", async () => {
+		const files = new MemoryFiles();
+		for (let i = 0; i < 20; i++) files.map.set(`note-${i}.md`, `body ${i}`);
+		const binding = new VaultBinding(files, docs());
+		// The fill works eight notes at a time, so a gauge that went up as
+		// each one started would say eight over a vault of twenty.
+		const seen: number[] = [];
+		files.onRead = () => seen.push(binding.backlog.up);
+
+		await binding.start();
+		await settle(binding);
+
+		expect(Math.max(...seen)).toBe(20);
+		expect(seen.every((n) => n > 0)).toBe(true);
+		// And it is empty again once the last one has landed.
+		expect(binding.backlog).toEqual({ up: 0, down: 0 });
+	});
+
+	it("counts notes the cloud vault has and this device has not", async () => {
+		const files = new MemoryFiles();
+		const binding = new VaultBinding(files, docs({ "a.md": "A", "b.md": "B" }));
+		const seen: number[] = [];
+		files.onRead = () => seen.push(binding.backlog.down);
+
+		await binding.start();
+		await settle(binding);
+
+		expect(Math.max(...seen)).toBe(2);
+		expect(files.map.get("a.md")).toBe("A");
+		expect(binding.backlog).toEqual({ up: 0, down: 0 });
+	});
+
+	it("never counts a note the tree already knows, which is every edit", async () => {
+		const files = new MemoryFiles();
+		files.map.set("plan.md", "# Plan\n");
+		const binding = new VaultBinding(files, docs());
+		await binding.start();
+		await settle(binding);
+		expect(binding.backlog).toEqual({ up: 0, down: 0 });
+
+		// Typing in it: the same path, a document that already exists.
+		const seen: number[] = [];
+		files.onRead = () => seen.push(binding.backlog.up);
+		files.map.set("plan.md", "# Plan\nand a line\n");
+		files.emit({ type: "modify", path: "plan.md" });
+		await settle(binding);
+
+		expect(seen.length).toBeGreaterThan(0);
+		expect(Math.max(...seen)).toBe(0);
+	});
+
+	it("counts a note that is genuinely new here, which is not an edit", async () => {
+		const files = new MemoryFiles();
+		const binding = new VaultBinding(files, docs());
+		await binding.start();
+		await settle(binding);
+
+		const seen: number[] = [];
+		files.onRead = () => seen.push(binding.backlog.up);
+		files.map.set("new.md", "fresh");
+		files.emit({ type: "create", path: "new.md" });
+		await settle(binding);
+
+		expect(Math.max(...seen)).toBe(1);
+		expect(binding.backlog).toEqual({ up: 0, down: 0 });
+	});
+});

--- a/__tests__/knap/backlog.test.ts
+++ b/__tests__/knap/backlog.test.ts
@@ -6,7 +6,7 @@
  * are worth a number: notes still to reach the cloud vault, and notes still to
  * reach this device. An edit to a note both sides already have is the third,
  * and it never touches the gauge, because a number that goes 1, 0, 1, 0 while
- * somebody types is what made the old corner unreadable (ADR-0086).
+ * somebody types is what made the old corner unreadable (ADR-0088).
  */
 
 import * as Y from "yjs";

--- a/__tests__/knap/settingsTab.test.ts
+++ b/__tests__/knap/settingsTab.test.ts
@@ -377,7 +377,7 @@ describe("the sign-out notice", () => {
 
 describe("the breakdown behind the fold", () => {
 	// The corner has room for two numbers and adds notes and attachments
-	// together to get them. This screen keeps them apart (ADR-0086).
+	// together to get them. This screen keeps them apart (ADR-0088).
 	it("names both directions and both kinds of file", () => {
 		expect(
 			statusFacts({

--- a/__tests__/knap/settingsTab.test.ts
+++ b/__tests__/knap/settingsTab.test.ts
@@ -134,6 +134,9 @@ function baseStatus() {
 		vaultName: "",
 		notes: 0,
 		problems: 0,
+		up: 0,
+		down: 0,
+		files: { up: 0, down: 0 },
 	};
 }
 
@@ -369,5 +372,37 @@ describe("the sign-out notice", () => {
 
 	it("admits the token may still be live when it did not", () => {
 		expect(signOutNotice(false)).toContain("may still count this device");
+	});
+});
+
+describe("the breakdown behind the fold", () => {
+	// The corner has room for two numbers and adds notes and attachments
+	// together to get them. This screen keeps them apart (ADR-0086).
+	it("names both directions and both kinds of file", () => {
+		expect(
+			statusFacts({
+				...baseStatus(),
+				word: SYNCING,
+				up: 412,
+				down: 2567,
+				files: { up: 3, down: 0 },
+			} as never),
+		).toEqual([
+			["To the cloud vault", "412 notes, 3 attachments"],
+			["To this device", "2,567 notes"],
+		]);
+	});
+
+	it("says only the direction that has something in it", () => {
+		expect(
+			statusFacts({ ...baseStatus(), word: SYNCING, files: { up: 1, down: 0 } } as never),
+		).toEqual([["To the cloud vault", "1 attachment"]]);
+	});
+
+	it("a vault with nothing moving keeps both rows off the screen", () => {
+		expect(statusFacts({ ...baseStatus(), notes: 12, vaultName: "Work" } as never)).toEqual([
+			["Cloud vault", "Work"],
+			["Notes", "12"],
+		]);
 	});
 });

--- a/__tests__/quiet.test.ts
+++ b/__tests__/quiet.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The two seconds at each end of the corner of the window.
+ *
+ * The bug this is here for is not a wrong number, it is a mark that moves all
+ * day: saving a note pushed its document, which put the vault into Syncing,
+ * which grew a count and a bar, all inside a second, every time (ADR-0086).
+ */
+
+import {
+	QUIET_MS,
+	RUNNING,
+	STILL,
+	backlogLabel,
+	backlogText,
+	burstProgress,
+	settle,
+} from "../src/quiet";
+
+describe("what the corner waits for", () => {
+	test("an ordinary save never reaches the screen", () => {
+		let burst = STILL;
+		// A note is saved: the vault is moving, and stops well inside the wait.
+		burst = settle(burst, true, 1, 1_000);
+		expect(burst.moving).toBe(false);
+		burst = settle(burst, true, 1, 1_400);
+		expect(burst.moving).toBe(false);
+		burst = settle(burst, false, 0, 1_800);
+		expect(burst.moving).toBe(false);
+		// And the pending flip is dropped rather than remembered, so the next
+		// save starts its own two seconds instead of inheriting these.
+		expect(burst.since).toBeNull();
+	});
+
+	test("a real sync gets said, two seconds in", () => {
+		let burst = settle(STILL, true, 2567, 0);
+		expect(burst.moving).toBe(false);
+		burst = settle(burst, true, 2567, QUIET_MS - 1);
+		expect(burst.moving).toBe(false);
+		burst = settle(burst, true, 2500, QUIET_MS);
+		expect(burst.moving).toBe(true);
+	});
+
+	test("up to date is held for two seconds after the last note lands", () => {
+		let burst = { moving: true, since: null, peak: 2567 };
+		burst = settle(burst, false, 0, 10_000);
+		expect(burst.moving).toBe(true);
+		burst = settle(burst, false, 0, 10_000 + QUIET_MS);
+		expect(burst.moving).toBe(false);
+		expect(burst.peak).toBe(0);
+	});
+
+	test("the bar fills against what the burst started with, not what is left", () => {
+		// The vault only ever knows how many notes are still to come, and a
+		// bar drawn against a shrinking total never moves.
+		let burst = settle(STILL, true, 1000, 0);
+		burst = settle(burst, true, 1000, QUIET_MS);
+		expect(burst.peak).toBe(1000);
+		expect(burstProgress(burst, 750)).toBeCloseTo(0.25);
+		// A vault that grows mid-burst raises the mark rather than overflowing.
+		burst = settle(burst, true, 1500, QUIET_MS + 1);
+		expect(burst.peak).toBe(1500);
+		expect(burstProgress(burst, 1500)).toBe(0);
+	});
+
+	test("nothing is drawn against a burst that is not running", () => {
+		expect(burstProgress(STILL, 0)).toBeUndefined();
+		expect(burstProgress(RUNNING, 12)).toBeUndefined();
+	});
+});
+
+describe("the two numbers", () => {
+	test("both directions, either alone, or neither", () => {
+		expect(backlogText(412, 2567)).toBe("↑ 412 ↓ 2,567");
+		expect(backlogText(412, 0)).toBe("↑ 412");
+		expect(backlogText(0, 2567)).toBe("↓ 2,567");
+		expect(backlogText(0, 0)).toBe("");
+	});
+
+	test("said out loud in the words that already exist", () => {
+		// vault, cloud vault and device are on the list a screen may use;
+		// upload, download and sync direction are not.
+		expect(backlogLabel(412, 2567)).toBe("412 to the cloud vault, 2,567 to this device");
+		expect(backlogLabel(0, 3)).toBe("3 to this device");
+		expect(backlogLabel(0, 0)).toBe("");
+	});
+});

--- a/__tests__/quiet.test.ts
+++ b/__tests__/quiet.test.ts
@@ -3,7 +3,7 @@
  *
  * The bug this is here for is not a wrong number, it is a mark that moves all
  * day: saving a note pushed its document, which put the vault into Syncing,
- * which grew a count and a bar, all inside a second, every time (ADR-0086).
+ * which grew a count and a bar, all inside a second, every time (ADR-0088).
  */
 
 import {

--- a/__tests__/vaultStatus.test.ts
+++ b/__tests__/vaultStatus.test.ts
@@ -14,7 +14,15 @@
  * date. So the assertions below are mostly about what must NOT read green.
  */
 
-import { PAUSED, SIGNED_OUT, SYNCING, UP_TO_DATE } from "../src/syncStatus";
+import {
+	OFFLINE,
+	PAUSED,
+	PROBLEM,
+	SIGNED_OUT,
+	SYNCING,
+	UP_TO_DATE,
+	syncDot,
+} from "../src/syncStatus";
 import {
 	SYNC_DOT_NAMES,
 	folderCaughtUp,
@@ -24,6 +32,7 @@ import {
 	vaultSyncWord,
 	type FolderStatus,
 } from "../src/vaultStatus";
+import { RUNNING, STILL } from "../src/quiet";
 
 /** A folder with nothing outstanding: the only shape that may read green. */
 const synced: FolderStatus = {
@@ -325,6 +334,7 @@ describe("the corner of the window", () => {
 	test("a first sync draws the bar, the count and the word", () => {
 		const paint = statusBarPaint(
 			vaultReading(true, [{ ...synced, total: 1202, completed: 412 }]),
+			RUNNING,
 		);
 		expect(paint.dot).toBe("working");
 		expect(paint.count).toBe("412 of 1,202");
@@ -333,13 +343,13 @@ describe("the corner of the window", () => {
 	});
 
 	test("a device downloading a vault it just joined draws one too", () => {
-		const paint = statusBarPaint(vaultReading(true, [justJoined]));
+		const paint = statusBarPaint(vaultReading(true, [justJoined]), RUNNING);
 		expect(paint.percent).toBe(0);
 		expect(paint.count).toBe("0 of 2,567");
 	});
 
 	test("a caught up vault has no bar and nothing to count", () => {
-		const paint = statusBarPaint(vaultReading(true, [synced]));
+		const paint = statusBarPaint(vaultReading(true, [synced]), RUNNING);
 		expect(paint.percent).toBeUndefined();
 		expect(paint.count).toBe("");
 		expect(paint.label).toBe("Knap: up to date");
@@ -348,6 +358,7 @@ describe("the corner of the window", () => {
 	test("signed out has no bar, whatever the folders were carrying", () => {
 		const paint = statusBarPaint(
 			vaultReading(false, [{ ...synced, total: 1202, completed: 412 }]),
+			RUNNING,
 		);
 		expect(paint.percent).toBeUndefined();
 		expect(paint.label).toBe("Knap: signed out");
@@ -358,7 +369,53 @@ describe("the corner of the window", () => {
 		// and a fill wider than its track is what it would draw.
 		const paint = statusBarPaint(
 			vaultReading(true, [{ ...synced, total: 10, completed: 40, missing: 1 }]),
+			RUNNING,
 		);
 		expect(paint.percent).toBe(100);
+	});
+});
+
+describe("the corner, split by direction", () => {
+	const syncing = {
+		word: SYNCING,
+		dot: "working" as const,
+		done: 0,
+		total: 0,
+		counts: "",
+		progress: undefined,
+		up: 412,
+		down: 2567,
+	};
+
+	test("both numbers, and the tooltip says which is which", () => {
+		const paint = statusBarPaint(syncing, { moving: true, since: null, peak: 3000 });
+		expect(paint.count).toBe("\u2191 412 \u2193 2,567");
+		expect(paint.label).toBe("Knap: syncing, 412 to the cloud vault, 2,567 to this device");
+		// 3,000 to start with, 2,979 still to go.
+		expect(paint.percent).toBe(1);
+	});
+
+	test("a vault that is only sending says only that", () => {
+		const paint = statusBarPaint(
+			{ ...syncing, down: 0 },
+			{ moving: true, since: null, peak: 412 },
+		);
+		expect(paint.count).toBe("\u2191 412");
+	});
+
+	test("the corner says nothing until the delay is up", () => {
+		const paint = statusBarPaint(syncing, STILL);
+		expect(paint.dot).toBe("ok");
+		expect(paint.count).toBe("");
+		expect(paint.label).toBe("Knap: up to date");
+		expect(paint.percent).toBeUndefined();
+	});
+
+	test("the delay never holds back a word somebody has to act on", () => {
+		for (const word of [PROBLEM, OFFLINE, SIGNED_OUT] as const) {
+			const paint = statusBarPaint({ ...syncing, word, dot: syncDot(word) }, STILL);
+			expect(paint.dot).not.toBe("ok");
+			expect(paint.count).toBe("\u2191 412 \u2193 2,567");
+		}
 	});
 });

--- a/docs/ui-ux.md
+++ b/docs/ui-ux.md
@@ -10,7 +10,7 @@ The decisions live as ADRs in the admin repository, `knap-mcp-admin/docs/adr/`:
 **0030** sign-in, **0031** one control surface, **0033** one server, **0034**
 permissions, **0038** the words, **0043** a vault is one unit, **0045** the
 plugin is Knap, **0066** one local vault to one cloud vault, **0071** what a
-failure may say. Where this page and an ADR disagree, the ADR wins.
+failure may say, **0086** what the corner counts. Where this page and an ADR disagree, the ADR wins.
 
 ## The rule
 
@@ -106,6 +106,7 @@ asks:
 |---|---|
 | The instruction for this word | Whenever the word carries one |
 | Cloud vault, Notes | When there is a link, and when notes have arrived |
+| To the cloud vault, To this device | While either direction has something in it, naming notes and attachments separately |
 | Could not sync, *N* changes | When something failed and stayed failed |
 | **Try again** | Only under *Problem* and *Offline*, the two words a person can act on |
 
@@ -155,6 +156,21 @@ and a two pixel bar follows while there is a denominator to draw it against. The
 word itself is in the tooltip rather than on screen, because the corner is read
 out of the side of the eye during a first sync and what is wanted there is how
 far along, not a sentence.
+
+**Two numbers, not one, and never a third.** Three things move notes: notes
+going up to the cloud vault, notes coming down to this device, and edits to a
+note both sides already have. The first two are countable and answer different
+questions, so they are counted apart, `↑ 412 ↓ 2,567`, either alone when the
+other is zero. Attachments travel the same two roads and are added into the same
+two numbers here; the settings screen behind this is where they are named
+separately. Edits are not counted at all, in either place.
+
+**And the corner is two seconds behind the vault, deliberately.** Saving a note
+pushes its document, which used to flip the icon, grow a count and draw a bar,
+all inside a second, every time anybody typed. So nothing is said until the
+vault has been moving for two seconds, and Up to date is held for two seconds
+after it stops. **Problem, Offline and Signed out are never held back**: the
+delay is for the state a person waits out, not the ones they act on. ADR-0086.
 
 It reads `readVaultStatus()` in `main.ts`, which returns the Knap client's own
 `status()` whenever there is one. **The corner and the settings screen cannot

--- a/docs/ui-ux.md
+++ b/docs/ui-ux.md
@@ -10,7 +10,8 @@ The decisions live as ADRs in the admin repository, `knap-mcp-admin/docs/adr/`:
 **0030** sign-in, **0031** one control surface, **0033** one server, **0034**
 permissions, **0038** the words, **0043** a vault is one unit, **0045** the
 plugin is Knap, **0066** one local vault to one cloud vault, **0071** what a
-failure may say, **0086** what the corner counts. Where this page and an ADR disagree, the ADR wins.
+failure may say, **0088** what the corner counts. Where this page and an ADR
+disagree, the ADR wins.
 
 ## The rule
 
@@ -170,7 +171,7 @@ pushes its document, which used to flip the icon, grow a count and draw a bar,
 all inside a second, every time anybody typed. So nothing is said until the
 vault has been moving for two seconds, and Up to date is held for two seconds
 after it stops. **Problem, Offline and Signed out are never held back**: the
-delay is for the state a person waits out, not the ones they act on. ADR-0086.
+delay is for the state a person waits out, not the ones they act on. ADR-0088.
 
 It reads `readVaultStatus()` in `main.ts`, which returns the Knap client's own
 `status()` whenever there is one. **The corner and the settings screen cannot

--- a/src/knap/AttachmentBinding.ts
+++ b/src/knap/AttachmentBinding.ts
@@ -31,7 +31,7 @@ import { buildConflictCopyPath } from "../conflictCopyPath";
 import { generateHash } from "../hashing";
 import type { AttachmentEntry, TreeDoc } from "./TreeDoc";
 import { isHidden, isNote, normalize } from "./TreeDoc";
-import type { FileEvent, FileStore } from "./VaultBinding";
+import type { Backlog, FileEvent, FileStore } from "./VaultBinding";
 
 /** What the binding needs from the file routes. KnapServer satisfies it. */
 export interface AttachmentTransport {
@@ -79,6 +79,8 @@ export class AttachmentBinding {
 	private stopTreeEvents: (() => void) | null = null;
 	private queue: Promise<void> = Promise.resolve();
 	private limits: AttachmentLimits = FALLBACK_LIMITS;
+	/** Files still to move, by direction. The note half keeps the same two. */
+	private outstanding = { up: 0, down: 0 };
 
 	constructor(
 		private readonly files: FileStore,
@@ -109,7 +111,11 @@ export class AttachmentBinding {
 		this.stopTreeEvents = this.docs.tree().onAttachmentChange((change) => {
 			void this.enqueue(async () => {
 				for (const [path, entry] of change.added) {
-					await this.pull(path, entry);
+					// An attachment this device already has is the echo of its
+					// own upload arriving back through the tree.
+					const here = (await this.files.readBinary(path)) !== null;
+					if (here) await this.pull(path, entry);
+					else await this.carry("down", () => this.pull(path, entry));
 				}
 				for (const [path] of change.removed) {
 					// A path in both halves is an attachment whose bytes
@@ -142,6 +148,29 @@ export class AttachmentBinding {
 
 	// -- link time -----------------------------------------------------------
 
+	/**
+	 * Attachments still to move, by direction.
+	 *
+	 * Kept apart from the notes rather than added to them because the two
+	 * behave differently on a slow line: one photo is a hundred notes' worth
+	 * of bytes, so a single number would sit still for a minute and then jump.
+	 * The corner adds them anyway; the screen behind it is where the four
+	 * numbers are worth having separately (ADR-0086).
+	 */
+	get backlog(): Backlog {
+		return { ...this.outstanding };
+	}
+
+	/** Run `work`, with this file on the gauge for as long as it takes. */
+	private async carry<T>(kind: "up" | "down", work: () => Promise<T>): Promise<T> {
+		this.outstanding[kind] += 1;
+		try {
+			return await work();
+		} finally {
+			this.outstanding[kind] -= 1;
+		}
+	}
+
 	private async reconcileAll(): Promise<void> {
 		// The same wait the note half makes, and for the same reason: a
 		// device that reconciled against an empty tree would decide every
@@ -154,13 +183,31 @@ export class AttachmentBinding {
 		);
 		const tree = this.docs.tree();
 		const recorded = tree.attachments();
-		for (const path of (await this.files.listAttachments()).map(normalize)) {
-			if (!recorded.has(path) && !isHidden(path)) {
+		const local = new Set((await this.files.listAttachments()).map(normalize));
+		// Sorted before any of it runs, so the gauge says how many files are
+		// still to come rather than how many are in flight right now.
+		const up = [...local].filter((path) => !recorded.has(path) && !isHidden(path));
+		// A recorded attachment already on the disk is checked, not fetched.
+		// Whether the bytes match is `pull`'s business and costs a hash; what
+		// the gauge needs is the file that is plainly not here.
+		const arriving = new Set(
+			[...recorded].filter(([path]) => !local.has(path)).map(([path]) => path),
+		);
+		this.outstanding.up += up.length;
+		this.outstanding.down += arriving.size;
+		for (const path of up) {
+			try {
 				await this.push(path);
+			} finally {
+				this.outstanding.up -= 1;
 			}
 		}
 		for (const [path, entry] of recorded) {
-			await this.pull(path, entry);
+			try {
+				await this.pull(path, entry);
+			} finally {
+				if (arriving.has(path)) this.outstanding.down -= 1;
+			}
 		}
 	}
 
@@ -175,7 +222,11 @@ export class AttachmentBinding {
 			await this.forget(normalize(event.path));
 			return;
 		}
-		await this.push(event.path);
+		// New bytes or replaced bytes, both going up, and unlike a note there
+		// is no cheap way to tell an edit from a first upload: an attachment is
+		// replaced whole. Both are counted, which is honest, because both take
+		// as long as the file is big.
+		await this.carry("up", () => this.push(event.path));
 	}
 
 	/**

--- a/src/knap/AttachmentBinding.ts
+++ b/src/knap/AttachmentBinding.ts
@@ -155,7 +155,7 @@ export class AttachmentBinding {
 	 * behave differently on a slow line: one photo is a hundred notes' worth
 	 * of bytes, so a single number would sit still for a minute and then jump.
 	 * The corner adds them anyway; the screen behind it is where the four
-	 * numbers are worth having separately (ADR-0086).
+	 * numbers are worth having separately (ADR-0088).
 	 */
 	get backlog(): Backlog {
 		return { ...this.outstanding };

--- a/src/knap/KnapSettingsTab.ts
+++ b/src/knap/KnapSettingsTab.ts
@@ -61,6 +61,16 @@ export function statusFacts(status: KnapStatus): Array<[string, string]> {
 	if (status.notes > 0) {
 		facts.push(["Notes", status.notes.toLocaleString("en-US")]);
 	}
+	// The corner has room for two numbers and adds the two kinds of file
+	// together to get them. This is the screen with room to keep them apart,
+	// and attachments are worth keeping apart: one photo is a hundred notes'
+	// worth of bytes, so a single number sits still and then jumps (ADR-0086).
+	// The rows are named the way the tooltip says it, because somebody moves
+	// between the two in one sitting.
+	const going = pieces(status.up, status.files.up);
+	if (going) facts.push(["To the cloud vault", going]);
+	const coming = pieces(status.down, status.files.down);
+	if (coming) facts.push(["To this device", coming]);
 	if (status.problems > 0) {
 		facts.push([
 			"Could not sync",
@@ -68,6 +78,18 @@ export function statusFacts(status: KnapStatus): Array<[string, string]> {
 		]);
 	}
 	return facts;
+}
+
+/** "412 notes, 3 attachments", or as much of it as is above zero. */
+function pieces(notes: number, files: number): string {
+	const parts: string[] = [];
+	if (notes > 0) parts.push(`${count(notes)} note${notes === 1 ? "" : "s"}`);
+	if (files > 0) parts.push(`${count(files)} attachment${files === 1 ? "" : "s"}`);
+	return parts.join(", ");
+}
+
+function count(n: number): string {
+	return n.toLocaleString("en-US");
 }
 
 /** Only the two words a person can do something about get a button here. */
@@ -248,7 +270,7 @@ function detailLine(status: KnapStatus): string {
 	const parts: string[] = [];
 	if (status.vaultName) parts.push(status.vaultName);
 	if (status.notes > 0) {
-		parts.push(`${status.notes.toLocaleString("en-US")} note${status.notes === 1 ? "" : "s"}`);
+		parts.push(`${count(status.notes)} note${status.notes === 1 ? "" : "s"}`);
 	}
 	return parts.join(" · ");
 }

--- a/src/knap/KnapSettingsTab.ts
+++ b/src/knap/KnapSettingsTab.ts
@@ -64,7 +64,7 @@ export function statusFacts(status: KnapStatus): Array<[string, string]> {
 	// The corner has room for two numbers and adds the two kinds of file
 	// together to get them. This is the screen with room to keep them apart,
 	// and attachments are worth keeping apart: one photo is a hundred notes'
-	// worth of bytes, so a single number sits still and then jumps (ADR-0086).
+	// worth of bytes, so a single number sits still and then jumps (ADR-0088).
 	// The rows are named the way the tooltip says it, because somebody moves
 	// between the two in one sitting.
 	const going = pieces(status.up, status.files.up);

--- a/src/knap/KnapSync.ts
+++ b/src/knap/KnapSync.ts
@@ -62,6 +62,12 @@ export interface KnapStatus {
 	notes: number;
 	/** Pieces of work that failed and stayed failed. */
 	problems: number;
+	/** Notes this device still has to send to the cloud vault. */
+	up: number;
+	/** Notes the cloud vault lists that are not on this device yet. */
+	down: number;
+	/** Attachments still to go up, and still to come down. */
+	files: { up: number; down: number };
 }
 
 export interface KnapSyncOptions {
@@ -127,6 +133,8 @@ export class KnapSync {
 		const linked = this.linked;
 		const connected = this.client?.connected ?? false;
 		const problems = this.binding?.problems ?? 0;
+		const backlog = this.binding?.backlog ?? { up: 0, down: 0 };
+		const files = this.attachments?.backlog ?? { up: 0, down: 0 };
 		const word = syncWord({
 			signedIn: this.signedIn,
 			// Signed in with nowhere to sync to is not up to date, it is
@@ -137,7 +145,13 @@ export class KnapSync {
 			// to. The screen says Not linked in full; the corner of the
 			// window has one word to do it in.
 			paused: !linked,
-			syncing: Boolean(this.client) && !this.client?.settled,
+			// The tree settling is the socket's half of it. The backlog is the
+			// notes' half, and it is the half that lasts: a tree settles in
+			// seconds over a vault whose bodies are hours away, and green over
+			// that is exactly the lie #40 was about.
+			syncing:
+				(Boolean(this.client) && !this.client?.settled) ||
+				backlog.up + backlog.down + files.up + files.down > 0,
 			// Not linked is not offline: there is no socket because there is
 			// nothing to open one to, and saying Offline would send somebody
 			// to check their wifi over a vault they never linked.
@@ -150,6 +164,9 @@ export class KnapSync {
 			vaultName: linked?.cloudVaultName ?? "",
 			notes: this.client ? this.client.tree().entries().size : 0,
 			problems,
+			up: backlog.up,
+			down: backlog.down,
+			files,
 		};
 	}
 

--- a/src/knap/VaultBinding.ts
+++ b/src/knap/VaultBinding.ts
@@ -121,6 +121,25 @@ export interface SeenTree {
 	forget(): Promise<void>;
 }
 
+/**
+ * Notes still to move, by direction, with edits deliberately absent.
+ *
+ * Three things move notes and only two of them can be counted (ADR-0086).
+ * `up` is notes this device holds that the cloud vault has not got yet, `down`
+ * is notes the cloud vault lists that have no file here. They are disjoint
+ * sets, which is what makes them addable: a note is missing from one side or
+ * the other, never both.
+ *
+ * An edit to a note both sides already have is the third thing, and it is not
+ * in here. It has no denominator, it is over in under a second, and a number
+ * beside the icon that goes 1, 0, 1, 0 while somebody types is what makes the
+ * corner of the window unreadable.
+ */
+export interface Backlog {
+	up: number;
+	down: number;
+}
+
 const CONTENT = "content";
 
 /** How long to wait for the tree's first sync before giving up on a link. */
@@ -167,6 +186,8 @@ export class VaultBinding {
 	private noteObservers = new Map<string, () => void>();
 	private queue: Promise<void> = Promise.resolve();
 	private failures = 0;
+	/** Work taken on and not finished, by direction. Never edits. */
+	private outstanding = { up: 0, down: 0 };
 	/** Paths an open editor is holding, which this binding leaves alone. */
 	private held = new Set<string>();
 	/** Set whenever this device changed the tree, cleared when it is saved. */
@@ -204,7 +225,15 @@ export class VaultBinding {
 			void this.enqueue(async () => {
 				this.seenDirty = true;
 				for (const [path, docId] of change.added) {
-					await this.bindNote(path, docId);
+					// A document this binding already watches is the echo of
+					// its own push coming back through the tree, not a note
+					// arriving from somewhere else, and putting it on the
+					// down gauge would count every upload twice.
+					if (this.noteObservers.has(docId)) {
+						await this.bindNote(path, docId);
+					} else {
+						await this.carry("down", () => this.bindNote(path, docId));
+					}
 				}
 				for (const [path, docId] of change.removed) {
 					// A move announces itself as removed+added under one id, and
@@ -252,6 +281,29 @@ export class VaultBinding {
 	 */
 	get problems(): number {
 		return this.failures;
+	}
+
+	/**
+	 * Notes still to move, by direction.
+	 *
+	 * Counted where the work is decided rather than where it runs: a fill
+	 * works eight notes at a time, so a gauge that went up as each one started
+	 * would say eight over a vault of three thousand. What is wanted is how
+	 * many are still to come, so the whole set is counted the moment it is
+	 * known and each note takes itself off as it lands.
+	 */
+	get backlog(): Backlog {
+		return { ...this.outstanding };
+	}
+
+	/** Run `work`, with this note on the gauge for as long as it takes. */
+	private async carry<T>(kind: "up" | "down", work: () => Promise<T>): Promise<T> {
+		this.outstanding[kind] += 1;
+		try {
+			return await work();
+		} finally {
+			this.outstanding[kind] -= 1;
+		}
 	}
 
 	/**
@@ -359,21 +411,20 @@ export class VaultBinding {
 		// cost of being wrong here is every note in the cloud vault.
 		const emptied = local.size === 0 && seen.size > 0;
 
-		// Both halves run several notes deep. The tree above is read first and
-		// in full, so what each note does is its own business and the width
-		// only decides how many are waiting for a socket at once.
-		await this.inWaves([...local], async (path) => {
-			if (remote.has(path)) return;
-			if (seen.has(path)) {
-				// It was in the tree when this device last looked and it is
-				// not now: it was deleted in the cloud vault while this
-				// device was away. A delete is a delete, in both directions.
-				await this.files.remove(path);
-			} else {
-				await this.pushNote(path);
-			}
-		});
-		await this.inWaves([...remote], async ([path, docId]) => {
+		// The work is sorted before any of it runs, because the gauge the
+		// corner of the window reads is how many notes are still to move, and
+		// the waves below only ever know about eight at a time.
+		const gone: string[] = [];
+		const up: string[] = [];
+		for (const path of local) {
+			if (remote.has(path)) continue;
+			// In the tree when this device last looked and not now: deleted in
+			// the cloud vault while this device was away. A delete is a delete,
+			// in both directions.
+			(seen.has(path) ? gone : up).push(path);
+		}
+		const bind: [string, string][] = [];
+		for (const [path, docId] of remote) {
 			if (!local.has(path) && !emptied && seen.get(path) === docId) {
 				// The same note, at the same path, as this device last had
 				// it on disk, and the file is gone. Somebody deleted it here
@@ -381,9 +432,34 @@ export class VaultBinding {
 				// downloaded the note back, every time, on every device.
 				tree.remove(path);
 				this.seenDirty = true;
-				return;
+				continue;
 			}
-			await this.bindNote(path, docId);
+			bind.push([path, docId]);
+		}
+		// A note the tree lists that is already on the disk is a bind, not a
+		// download: it opens the document and writes nothing. Counting those
+		// would put the whole vault on the gauge at every start.
+		const down = new Set(bind.filter(([path]) => !local.has(path)).map(([path]) => path));
+		this.outstanding.up += up.length;
+		this.outstanding.down += down.size;
+
+		// Each half runs several notes deep. The tree above is read first and
+		// in full, so what each note does is its own business and the width
+		// only decides how many are waiting for a socket at once.
+		await this.inWaves(gone, (path) => this.files.remove(path));
+		await this.inWaves(up, async (path) => {
+			try {
+				await this.pushNote(path);
+			} finally {
+				this.outstanding.up -= 1;
+			}
+		});
+		await this.inWaves(bind, async ([path, docId]) => {
+			try {
+				await this.bindNote(path, docId);
+			} finally {
+				if (down.has(path)) this.outstanding.down -= 1;
+			}
 		});
 	}
 
@@ -424,7 +500,7 @@ export class VaultBinding {
 				this.seenDirty = true;
 				return;
 			}
-			await this.pushNote(event.path);
+			await this.pushCounted(event.path);
 			return;
 		}
 		if (event.type === "delete") {
@@ -448,7 +524,19 @@ export class VaultBinding {
 		// the save event that arrives a second later says nothing newer.
 		if (this.held.has(normalize(event.path))) return;
 		// create and modify converge: bring the document to the file's text.
-		await this.pushNote(event.path);
+		await this.pushCounted(event.path);
+	}
+
+	/**
+	 * Push, and put it on the gauge only when it is a note going up for the
+	 * first time. A path the tree already knows is an edit, and an edit is
+	 * never counted (ADR-0086).
+	 */
+	private async pushCounted(path: string): Promise<void> {
+		if (this.docs.tree().docIdFor(normalize(path)) !== undefined) {
+			return this.pushNote(path);
+		}
+		return this.carry("up", () => this.pushNote(path));
 	}
 
 	private async pushNote(path: string): Promise<void> {

--- a/src/knap/VaultBinding.ts
+++ b/src/knap/VaultBinding.ts
@@ -124,7 +124,7 @@ export interface SeenTree {
 /**
  * Notes still to move, by direction, with edits deliberately absent.
  *
- * Three things move notes and only two of them can be counted (ADR-0086).
+ * Three things move notes and only two of them can be counted (ADR-0088).
  * `up` is notes this device holds that the cloud vault has not got yet, `down`
  * is notes the cloud vault lists that have no file here. They are disjoint
  * sets, which is what makes them addable: a note is missing from one side or
@@ -530,7 +530,7 @@ export class VaultBinding {
 	/**
 	 * Push, and put it on the gauge only when it is a note going up for the
 	 * first time. A path the tree already knows is an edit, and an edit is
-	 * never counted (ADR-0086).
+	 * never counted (ADR-0088).
 	 */
 	private async pushCounted(path: string): Promise<void> {
 		if (this.docs.tree().docIdFor(normalize(path)) !== undefined) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -132,6 +132,7 @@ import {
 	vaultReading,
 	type VaultReading,
 } from "./vaultStatus";
+import { STILL, settle, type Burst } from "./quiet";
 import {
 	planVaultSync,
 	vaultSyncResult,
@@ -1416,6 +1417,9 @@ export default class Live extends Plugin {
 	 * the bar says how far at a glance, which is the one a person reads while
 	 * they are doing something else.
 	 */
+	/** What the corner is saying, which lags what the vault is doing. */
+	private corner: Burst = STILL;
+
 	private addRelayStatusBarItem() {
 		const statusBarItem = this.addStatusBarItem();
 		statusBarItem.addClass("relay-onprem-statusbar");
@@ -1621,6 +1625,9 @@ export default class Live extends Plugin {
 		// the window and the Knap screen from wording one vault two ways.
 		if (this.knapSync) {
 			const status = this.knapSync.status();
+			// The corner adds the two kinds of file together, because it has
+			// room for two numbers and not four; the settings screen behind
+			// it keeps notes and attachments apart (ADR-0086).
 			return {
 				word: status.word,
 				dot: status.dot,
@@ -1628,6 +1635,8 @@ export default class Live extends Plugin {
 				total: 0,
 				counts: status.problems > 0 ? String(status.problems) : "",
 				progress: undefined,
+				up: status.up + status.files.up,
+				down: status.down + status.files.down,
 			};
 		}
 		const signedIn = this.loginManager?.isLoggedInToServer?.(KNAP_SERVER_ID) ?? false;
@@ -1670,7 +1679,17 @@ export default class Live extends Plugin {
 		trackEl: HTMLElement,
 		fillEl: HTMLElement,
 	) {
-		const corner = statusBarPaint(this.readVaultStatus());
+		const reading = this.readVaultStatus();
+		// The corner lags the vault by two seconds at each end, so an ordinary
+		// save never reaches it. Everything a person has to act on goes up at
+		// once; only Syncing waits (ADR-0086).
+		this.corner = settle(
+			this.corner,
+			reading.word === SYNCING,
+			reading.up + reading.down,
+			Date.now(),
+		);
+		const corner = statusBarPaint(reading, this.corner);
 		for (const dot of SYNC_DOT_NAMES) {
 			iconEl.toggleClass(`relay-status-${dot}`, dot === corner.dot);
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1627,7 +1627,7 @@ export default class Live extends Plugin {
 			const status = this.knapSync.status();
 			// The corner adds the two kinds of file together, because it has
 			// room for two numbers and not four; the settings screen behind
-			// it keeps notes and attachments apart (ADR-0086).
+			// it keeps notes and attachments apart (ADR-0088).
 			return {
 				word: status.word,
 				dot: status.dot,
@@ -1682,7 +1682,7 @@ export default class Live extends Plugin {
 		const reading = this.readVaultStatus();
 		// The corner lags the vault by two seconds at each end, so an ordinary
 		// save never reaches it. Everything a person has to act on goes up at
-		// once; only Syncing waits (ADR-0086).
+		// once; only Syncing waits (ADR-0088).
 		this.corner = settle(
 			this.corner,
 			reading.word === SYNCING,

--- a/src/quiet.ts
+++ b/src/quiet.ts
@@ -1,0 +1,121 @@
+"use strict";
+
+/**
+ * How long the corner of the window waits before it says anything.
+ *
+ * Three things move notes and only one of them is worth a mark on screen for
+ * as long as it lasts (ADR-0086). A first sync runs for minutes and somebody
+ * is watching it. An edit to a note both sides already have is over in under a
+ * second, and it used to flip the icon, grow a count and draw a bar every time
+ * a note was saved. A mark that moves all day is a mark the eye stops reading,
+ * which costs the two moments it is there for.
+ *
+ * So the corner lags the vault, deliberately, at both ends: two seconds before
+ * it admits that notes are moving, two seconds of Up to date after they stop.
+ * Everyday typing never gets past the first of those. A real sync loses two
+ * seconds off the front of something that takes minutes.
+ *
+ * **Only the moving state is held back.** Problem, Offline and Signed out go up
+ * the instant they are true, because those are the ones somebody has to do
+ * something about.
+ */
+
+/** Two seconds at each end. Long enough for a save, short enough to trust. */
+export const QUIET_MS = 2000;
+
+/** What the corner is saying, and what it needs to keep saying it. */
+export interface Burst {
+	/** What is on screen, which is not always what the vault is doing. */
+	moving: boolean;
+	/** When the vault started disagreeing with the screen, or null. */
+	since: number | null;
+	/**
+	 * The largest backlog seen since this burst began, which is what the bar
+	 * is drawn against. It cannot come from the vault, because the vault only
+	 * knows what is left: a bar against a shrinking denominator never moves.
+	 */
+	peak: number;
+}
+
+/** Nothing on screen, nothing pending. Where every corner starts. */
+export const STILL: Burst = { moving: false, since: null, peak: 0 };
+
+/**
+ * The corner already saying it is moving. Nothing produces this state on its
+ * own; it is what a caller passes when the delay is not what is under test.
+ */
+export const RUNNING: Burst = { moving: true, since: null, peak: 0 };
+
+/**
+ * Fold one reading into the burst.
+ *
+ * `moving` is the vault's own answer, `backlog` is how many notes are behind
+ * it, and `now` is a clock the caller owns so a test does not have to wait two
+ * seconds to find out what happens after two seconds.
+ */
+export function settle(
+	prev: Burst,
+	moving: boolean,
+	backlog: number,
+	now: number,
+): Burst {
+	if (moving === prev.moving) {
+		// Screen and vault agree. Nothing is pending, and a burst that is
+		// running keeps its high-water mark.
+		return {
+			moving,
+			since: null,
+			peak: moving ? Math.max(prev.peak, backlog) : 0,
+		};
+	}
+	// Null rather than zero, because a clock that reads zero is a clock a
+	// test set, and a sentinel that a legitimate reading can equal is a
+	// sentinel that stops working exactly where it is being checked.
+	const since = prev.since ?? now;
+	if (now - since < QUIET_MS) {
+		return { moving: prev.moving, since, peak: prev.peak };
+	}
+	// Held long enough to be worth saying.
+	return { moving, since: null, peak: moving ? backlog : 0 };
+}
+
+/**
+ * The count beside the icon: two directions, or one, or nothing.
+ *
+ * The arrows do the labelling because the corner has room for a number and
+ * not for a sentence. The tooltip says it in words, and the words are the ones
+ * that already exist (ADR-0038): cloud vault, and device.
+ */
+export function backlogText(up: number, down: number): string {
+	const parts: string[] = [];
+	if (up > 0) parts.push(`↑ ${group(up)}`);
+	if (down > 0) parts.push(`↓ ${group(down)}`);
+	return parts.join(" ");
+}
+
+/** The same two numbers, said out loud. */
+export function backlogLabel(up: number, down: number): string {
+	const parts: string[] = [];
+	if (up > 0) parts.push(`${group(up)} to the cloud vault`);
+	if (down > 0) parts.push(`${group(down)} to this device`);
+	return parts.join(", ");
+}
+
+/**
+ * How full the bar is, 0 to 1, or undefined when there is nothing to draw it
+ * against. What has landed over what this burst started with, which is the
+ * only pair of numbers here that both exist.
+ */
+export function burstProgress(
+	burst: Burst,
+	backlog: number,
+): number | undefined {
+	if (!burst.moving || burst.peak <= 0) return undefined;
+	const done = burst.peak - Math.min(backlog, burst.peak);
+	return Math.min(1, done / burst.peak);
+}
+
+/** Thousands separators, the way the rest of the status says them. */
+function group(n: number): string {
+	return n.toLocaleString("en-US");
+}

--- a/src/quiet.ts
+++ b/src/quiet.ts
@@ -4,7 +4,7 @@
  * How long the corner of the window waits before it says anything.
  *
  * Three things move notes and only one of them is worth a mark on screen for
- * as long as it lasts (ADR-0086). A first sync runs for minutes and somebody
+ * as long as it lasts (ADR-0088). A first sync runs for minutes and somebody
  * is watching it. An edit to a note both sides already have is over in under a
  * second, and it used to flip the icon, grow a count and draw a bar every time
  * a note was saved. A mark that moves all day is a mark the eye stops reading,

--- a/src/vaultStatus.ts
+++ b/src/vaultStatus.ts
@@ -16,6 +16,7 @@
 
 import {
 	SYNCING,
+	UP_TO_DATE,
 	syncCounts,
 	syncDot,
 	syncProgress,
@@ -23,6 +24,7 @@ import {
 	type SyncDot,
 	type SyncWord,
 } from "./syncStatus";
+import { backlogLabel, backlogText, burstProgress, type Burst } from "./quiet";
 
 /**
  * Every dot the status bar may be wearing. It is here rather than in
@@ -170,6 +172,10 @@ export interface VaultReading {
 	counts: string;
 	/** How full the bar is, 0 to 1, or undefined when there is no bar. */
 	progress: number | undefined;
+	/** Notes still to reach the cloud vault. Zero on the pre-rebuild path. */
+	up: number;
+	/** Notes still to reach this device. Zero on the pre-rebuild path. */
+	down: number;
 }
 
 /**
@@ -195,6 +201,11 @@ export function vaultReading(
 		total,
 		counts: moving ? syncCounts(done, total) : "",
 		progress: moving ? syncProgress(done, total) : undefined,
+		// The pre-rebuild path cannot split its number: its queue counts sends
+		// and fetches in one total, which is the reason `vaultCounts` above has
+		// to choose between two ways of counting rather than adding them.
+		up: 0,
+		down: 0,
 	};
 }
 
@@ -222,13 +233,27 @@ export interface StatusBarPaint {
  * phrasing that lives next to the elements it writes into is a phrasing no
  * test reaches.
  */
-export function statusBarPaint(reading: VaultReading): StatusBarPaint {
+export function statusBarPaint(reading: VaultReading, burst: Burst): StatusBarPaint {
+	// Held back: the vault says it is syncing and the corner has not been told
+	// to say so yet, which is where an ordinary save lives and dies. Only this
+	// one word waits; the three a person has to act on go straight past.
+	if (reading.word === SYNCING && !burst.moving) {
+		return {
+			dot: "ok",
+			count: "",
+			label: `Knap: ${UP_TO_DATE.toLowerCase()}`,
+			percent: undefined,
+		};
+	}
 	const word = reading.word.toLowerCase();
+	const backlog = reading.up + reading.down;
+	const count = backlog > 0 ? backlogText(reading.up, reading.down) : reading.counts;
+	const said = backlog > 0 ? backlogLabel(reading.up, reading.down) : reading.counts;
+	const progress = backlog > 0 ? burstProgress(burst, backlog) : reading.progress;
 	return {
 		dot: reading.dot,
-		count: reading.counts,
-		label: reading.counts ? `Knap: ${word}, ${reading.counts}` : `Knap: ${word}`,
-		percent:
-			reading.progress === undefined ? undefined : Math.round(reading.progress * 100),
+		count,
+		label: said ? `Knap: ${word}, ${said}` : `Knap: ${word}`,
+		percent: progress === undefined ? undefined : Math.round(progress * 100),
 	};
 }


### PR DESCRIPTION
## Summary

Three things move notes and the corner of the window said all three with one word and one number.

- **Up.** Notes and attachments this device holds that the cloud vault has not got.
- **Down.** Notes and attachments the cloud vault lists that have no file here.
- **Edits.** A keystroke into a note both sides already have. Over in under a second.

The third is where the irritation lives: saving a note pushed its document, so the icon flipped to Syncing, grew a count and drew a two pixel bar, all inside a second, every time anybody typed. A mark that moves constantly is one the eye stops reading, which costs the two moments it is there for.

**What changes**

- `VaultBinding` and `AttachmentBinding` each keep a gauge per direction. The sets are disjoint by definition, which is what makes them addable and what the old single count could never do (`vaultCounts` picks one of two ways of counting and drops the other, on purpose, for exactly this reason).
- **An edit is never counted.** It has no denominator and it is over before anybody looks. It surfaces only when it fails, as Problem, which already existed.
- **The corner is two seconds behind the vault at each end**, so an ordinary save never reaches it. Problem, Offline and Signed out are not delayed: the wait is for the state a person sits out, not the ones they act on.
- The corner draws `↑ 412 ↓ 2,567`, adding notes and attachments because it has room for two numbers and not four. The fold on the settings screen names them apart, which is what explains a sync that looks stalled on one large file.
- The backlog now counts toward Syncing, so a settled tree over a vault whose bodies are still hours away no longer reads green.

Reasoning and the prior art it borrows from are in **ADR-0088**, accepted: [pantalytics/knap-mcp-admin#174](https://github.com/pantalytics/knap-mcp-admin/pull/174). It was written as 0086 and renumbered after main took that number.

Merged main in twice while this was open. The second merge conflicted with #125, which took the vault and its note count out of the fold because the head already carries them. That removal stands; the two direction rows stay, since how many notes are still moving is a different fact and is nowhere else on the screen.

**Left undone on purpose:** a mark per note in the file explorer. That is the surface Dropbox and OneDrive get most of their value from, and it is the better answer to *is this one note safe*, but it is its own change and would have held up the fix for the thing that is actively annoying. Filed as [#130](https://github.com/pantalytics/knap-obsidian/issues/130).

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (6 pre-existing warnings, unchanged)
- [ ] Tested in Obsidian
- [x] Changes are minimal and focused

904 tests pass, including new coverage for the two gauges (`__tests__/knap/backlog.test.ts`), the delay at each end (`__tests__/quiet.test.ts`) and what the corner and the fold draw.