### PR TITLE
Every socket says how many notes this device counts

### DIFF
--- a/__tests__/knap/socketPool.test.ts
+++ b/__tests__/knap/socketPool.test.ts
@@ -390,4 +390,37 @@ describe("the note socket pool", () => {
 
 		client.destroy();
 	});
+
+	it("says on every socket what the device counts, and says nothing when it has not counted", async () => {
+		// The fill of 2026-09-01: Mac at 2611 notes, server at 1773, phone at
+		// 1420, and a card reading "Up to date". The server can only put the
+		// gap on a screen if the device tells it the local total.
+		const network = new FakeNetwork();
+		const urls: string[] = [];
+		const Base = network.socket as { new (url: string | URL): object };
+		const recording = class extends Base {
+			constructor(url: string | URL) {
+				super(url);
+				urls.push(String(url));
+			}
+		};
+		const server = new KnapServer("https://knap.test", async () => new Response("{}"));
+
+		const counting = new KnapVaultClient(server, "v1", "knap_token", "Laptop", recording, undefined, () => ({
+			notes: 2611,
+			attachments: 349,
+		}));
+		counting.tree();
+		await counting.treeSynced();
+		expect(urls.pop()).toContain("notes=2611&attachments=349");
+		counting.destroy();
+
+		// No supplier, or a supplier with nothing yet: the parameters stay off
+		// the wire entirely rather than sending a zero nobody counted.
+		const silent = new KnapVaultClient(server, "v2", "knap_token", "Laptop", recording, undefined, () => null);
+		silent.tree();
+		await silent.treeSynced();
+		expect(urls.pop()).not.toContain("notes=");
+		silent.destroy();
+	});
 });

--- a/src/knap/KnapSync.ts
+++ b/src/knap/KnapSync.ts
@@ -105,6 +105,8 @@ export class KnapSync {
 	private person = "";
 	/** Whether the server has refused this device the vault it linked. */
 	private lost = false;
+	/** What this vault holds on this disk, taken once per start. */
+	private counts: { notes: number; attachments: number } | null = null;
 
 	constructor(private readonly options: KnapSyncOptions) {
 		this.server = new KnapServer(options.serverUrl, options.fetchFn);
@@ -260,6 +262,15 @@ export class KnapSync {
 		// what they said before this existed.
 		this.person = await this.whoAmI(stored.token);
 		this.lost = false;
+		// What this vault holds on this disk, counted once per start. The
+		// number rides along on every socket so the server can say "1773 of
+		// 2611 notes" while a fill is behind, instead of a bare count that
+		// reads as complete. Stale within a session is fine: the local total
+		// barely moves, and every restart takes it fresh.
+		this.counts = {
+			notes: (await this.options.files.listNotes()).length,
+			attachments: (await this.options.files.listAttachments()).length,
+		};
 		this.client = new KnapVaultClient(
 			this.server,
 			stored.cloudVaultId,
@@ -267,6 +278,7 @@ export class KnapSync {
 			this.options.deviceName,
 			this.options.webSocket,
 			() => this.loseVault(stored.cloudVaultName),
+			() => this.counts,
 		);
 		this.binding = new VaultBinding(
 			this.options.files,

--- a/src/knap/KnapVaultClient.ts
+++ b/src/knap/KnapVaultClient.ts
@@ -131,6 +131,13 @@ export class KnapVaultClient {
 		private readonly deviceName: string,
 		private readonly webSocket?: WebSocketImpl,
 		private readonly onRefused?: (code: number) => void,
+		/**
+		 * What this device counts in its local vault, so the server can put
+		 * "1773 of 2611 notes" on a screen instead of a done-state nobody
+		 * verified. Two integers and nothing else leaves this device. Null
+		 * while the count has not been taken; sockets opened then say nothing.
+		 */
+		private readonly localCounts?: () => { notes: number; attachments: number } | null,
 	) {}
 
 	/**
@@ -395,8 +402,14 @@ export class KnapVaultClient {
 		}
 
 		const doc = new Y.Doc();
+		const params: Record<string, string> = { token: this.token, device: this.deviceName };
+		const counts = this.localCounts?.();
+		if (counts) {
+			params.notes = String(counts.notes);
+			params.attachments = String(counts.attachments);
+		}
 		const provider = new WebsocketProvider(this.server.syncUrl(this.vaultId), docId, doc, {
-			params: { token: this.token, device: this.deviceName },
+			params,
 			WebSocketPolyfill: this.webSocket as typeof WebSocket | undefined,
 			disableBc: true,
 		});


### PR DESCRIPTION
De vulling van 2026-09-01 stokte met de Mac op 2611 notities, de server op 1773 en de telefoon op 1420, terwijl de kaart hier *Up to date* zei.

- De lokale totalen reizen nu op elke sync-socket mee als twee integers, `notes=` en `attachments=`, één keer geteld per start. Geen paden, geen namen.
- De serverkant (knap-mcp-admin#175) vergelijkt ze met wat hij heeft en zet **"1773 of 2611 notes"** op de vaultpagina zolang een vulling achterloopt.
- Een client die nog niet geteld heeft stuurt niets, geen nul die niemand telde.

Sluit de tellerhelft van #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)