### PR TITLE
Uploading and Downloading are words the screen may use

### DIFF
--- a/__tests__/syncStatus.test.ts
+++ b/__tests__/syncStatus.test.ts
@@ -17,6 +17,9 @@ import {
 	UP_TO_DATE,
 	hasSignInButton,
 	syncCounts,
+	DOWNLOADING,
+	UPLOADING,
+	isMoving,
 	syncDot,
 	syncInstruction,
 	syncProgress,
@@ -27,6 +30,8 @@ describe("the words", () => {
 	test("these are they, in this order", () => {
 		expect(SYNC_WORDS).toEqual([
 			"Syncing",
+			"Uploading",
+			"Downloading",
 			"Up to date",
 			"Paused",
 			"Offline",
@@ -43,8 +48,34 @@ describe("the words", () => {
 		expect(syncWord({ signedIn: true, paused: true, syncing: true })).toBe(PAUSED);
 	});
 
-	test("notes on the move are Syncing", () => {
+	test("notes on the move with no direction to go on are Syncing", () => {
 		expect(syncWord({ signedIn: true, paused: false, syncing: true })).toBe(SYNCING);
+	});
+
+	test("one direction on its own gets its own word", () => {
+		// Which is the whole point of having them: Uploading over the notes
+		// somebody wrote this morning says their own work is what is moving.
+		const moving = { signedIn: true, paused: false, syncing: true };
+		expect(syncWord({ ...moving, up: 412, down: 0 })).toBe(UPLOADING);
+		expect(syncWord({ ...moving, up: 0, down: 2567 })).toBe(DOWNLOADING);
+		expect(syncWord({ ...moving, up: 412, down: 2567 })).toBe(SYNCING);
+		// A queue that cannot say which way it is going says the general one
+		// rather than guessing.
+		expect(syncWord({ ...moving, up: 0, down: 0 })).toBe(SYNCING);
+	});
+
+	test("the two new words wear the working dot, like the one they came from", () => {
+		expect(syncDot(UPLOADING)).toBe("working");
+		expect(syncDot(DOWNLOADING)).toBe("working");
+	});
+
+	test("all three moving words say so, and nothing else does", () => {
+		expect(SYNC_WORDS.filter(isMoving)).toEqual([SYNCING, UPLOADING, DOWNLOADING]);
+	});
+
+	test("and all three carry the same instruction, because the wait is the same", () => {
+		expect(syncInstruction(UPLOADING)).toBe(syncInstruction(SYNCING));
+		expect(syncInstruction(DOWNLOADING)).toBe(syncInstruction(SYNCING));
 	});
 
 	test("nothing left to carry is Up to date", () => {

--- a/__tests__/vaultStatus.test.ts
+++ b/__tests__/vaultStatus.test.ts
@@ -15,11 +15,13 @@
  */
 
 import {
+	DOWNLOADING,
 	OFFLINE,
 	PAUSED,
 	PROBLEM,
 	SIGNED_OUT,
 	SYNCING,
+	UPLOADING,
 	UP_TO_DATE,
 	syncDot,
 } from "../src/syncStatus";
@@ -416,6 +418,41 @@ describe("the corner, split by direction", () => {
 			const paint = statusBarPaint({ ...syncing, word, dot: syncDot(word) }, STILL);
 			expect(paint.dot).not.toBe("ok");
 			expect(paint.count).toBe("\u2191 412 \u2193 2,567");
+		}
+	});
+});
+
+describe("the word the corner says out loud", () => {
+	// ADR-0089: the direction is in the word now, not only in the arrows.
+	const moving = {
+		dot: "working" as const,
+		done: 0,
+		total: 0,
+		counts: "",
+		progress: undefined,
+	};
+	const running = { moving: true, since: null, peak: 3000 };
+
+	test("one direction names itself in the tooltip", () => {
+		expect(
+			statusBarPaint({ ...moving, word: UPLOADING, up: 412, down: 0 }, running).label,
+		).toBe("Knap: uploading, 412 to the cloud vault");
+		expect(
+			statusBarPaint({ ...moving, word: DOWNLOADING, up: 0, down: 2567 }, running).label,
+		).toBe("Knap: downloading, 2,567 to this device");
+	});
+
+	test("both directions keep the word they had", () => {
+		expect(
+			statusBarPaint({ ...moving, word: SYNCING, up: 412, down: 2567 }, running).label,
+		).toBe("Knap: syncing, 412 to the cloud vault, 2,567 to this device");
+	});
+
+	test("the delay holds all three back, not only the one it was written for", () => {
+		for (const word of [SYNCING, UPLOADING, DOWNLOADING] as const) {
+			const paint = statusBarPaint({ ...moving, word, up: 412, down: 0 }, STILL);
+			expect(paint.dot).toBe("ok");
+			expect(paint.label).toBe("Knap: up to date");
 		}
 	});
 });

--- a/docs/ui-ux.md
+++ b/docs/ui-ux.md
@@ -10,7 +10,8 @@ The decisions live as ADRs in the admin repository, `knap-mcp-admin/docs/adr/`:
 **0030** sign-in, **0031** one control surface, **0033** one server, **0034**
 permissions, **0038** the words, **0043** a vault is one unit, **0045** the
 plugin is Knap, **0066** one local vault to one cloud vault, **0071** what a
-failure may say, **0088** what the corner counts. Where this page and an ADR
+failure may say, **0088** what the corner counts, **0089** which way it says
+they are going. Where this page and an ADR
 disagree, the ADR wins.
 
 ## The rule
@@ -155,7 +156,7 @@ other than a release does, but that is the frame it is read in.
 
 ## The words
 
-Six, from `src/syncStatus.ts`, and no screen invents a seventh. That file is the
+Eight, from `src/syncStatus.ts`, and no screen invents a ninth. That file is the
 list. It used to mirror a `status.py` in the admin repository, and that file went
 with the rebuild, so there is nothing on the other side to keep in step with
 today.
@@ -163,6 +164,8 @@ today.
 | Word | Dot | The instruction under it |
 |---|---|---|
 | **Syncing** | accent | Leave Obsidian open until it finishes. It picks up where it left off if you close it. |
+| **Uploading** | accent | the same sentence |
+| **Downloading** | accent | the same sentence |
 | **Up to date** | green | none |
 | **Paused** | yellow | Nothing is moving while this device is paused. |
 | **Offline** | yellow | Your changes are saved here and go up when the connection is back. |
@@ -182,8 +185,15 @@ doing anything. Red is act: Signed out and Problem both need a person.
 Offline and Problem were added on 2026-09-01, because four words could not say
 that something was wrong and Signed out held the only error dot, so a refused
 upload had to present itself as a missing account. **The rule for adding a
-seventh is that a word earns its place when the reader's next move is
-different.**
+seventh was that a word earns its place when the reader's next move is
+different**, and Uploading and Downloading broke it on 2026-09-01 (ADR-0089,
+which supersedes ADR-0088 on this one point). They mean the same move as
+Syncing, which is wait. What they add is whose work is in flight: your own
+notes going up, or somebody else's arriving. Somebody watching a first sync for
+an hour wants to know which of the two it is, and the three moving words are
+chosen off the same two gauges the numbers come from. A vault moving both ways
+at once is Syncing, and so is one whose queue cannot say which way it is going,
+because a word that guesses is worse than the general one.
 
 Counts are one phrasing: *412 of 1,202* once something has counted the far side,
 *412 notes so far* while the first pass is still discovering how much there is.
@@ -197,7 +207,7 @@ word itself is in the tooltip rather than on screen, because the corner is read
 out of the side of the eye during a first sync and what is wanted there is how
 far along, not a sentence.
 
-**Two numbers, not one, and never a third.** Three things move notes: notes
+**The word carries the direction, and so do two numbers.** Three things move notes: notes
 going up to the cloud vault, notes coming down to this device, and edits to a
 note both sides already have. The first two are countable and answer different
 questions, so they are counted apart, `↑ 412 ↓ 2,567`, either alone when the

--- a/src/knap/KnapSync.ts
+++ b/src/knap/KnapSync.ts
@@ -170,6 +170,12 @@ export class KnapSync {
 			syncing:
 				(Boolean(this.client) && !this.client?.settled) ||
 				backlog.up + backlog.down + files.up + files.down > 0,
+			// Which way the notes are going, so the word can say Uploading or
+			// Downloading rather than the general Syncing (ADR-0089). Notes
+			// and attachments together, because the word is about direction
+			// and both kinds travel the same road.
+			up: backlog.up + files.up,
+			down: backlog.down + files.down,
 			// Not linked is not offline: there is no socket because there is
 			// nothing to open one to, and saying Offline would send somebody
 			// to check their wifi over a vault they never linked.

--- a/src/main.ts
+++ b/src/main.ts
@@ -143,8 +143,11 @@ import {
 	PAUSED,
 	PROBLEM,
 	SIGNED_OUT,
+	DOWNLOADING,
 	SYNCING,
+	UPLOADING,
 	UP_TO_DATE,
+	isMoving,
 	syncInstruction,
 	type SyncWord,
 } from "./syncStatus";
@@ -1087,6 +1090,11 @@ export default class Live extends Plugin {
 			const reading = this.readVaultStatus();
 			const lines: Record<SyncWord, string> = {
 				[SYNCING]: "Your vault is syncing.",
+				// One sentence each, because the after-update notice is the
+				// one place the word is read as a whole sentence rather than
+				// as a label beside a number.
+				[UPLOADING]: "Your vault is uploading.",
+				[DOWNLOADING]: "Your vault is downloading.",
 				[UP_TO_DATE]: "Your vault is up to date.",
 				[PAUSED]: "Sync is paused on this device.",
 				[OFFLINE]: "Knap is out of reach. Your notes are safe here.",
@@ -1685,7 +1693,7 @@ export default class Live extends Plugin {
 		// once; only Syncing waits (ADR-0088).
 		this.corner = settle(
 			this.corner,
-			reading.word === SYNCING,
+			isMoving(reading.word),
 			reading.up + reading.down,
 			Date.now(),
 		);

--- a/src/syncStatus.ts
+++ b/src/syncStatus.ts
@@ -13,9 +13,18 @@
  *
  * **Offline and Problem were added on 2026-09-01**, because four words could
  * not say that something is wrong. Signed out held the only error dot, so a
- * refused upload had to present itself as a missing account. The rule for
- * adding one is that a word earns its place when the reader's next move is
+ * refused upload had to present itself as a missing account. The test for
+ * adding one was that a word earns its place when the reader's next move is
  * different: Offline is wait, Problem is act.
+ *
+ * **Uploading and Downloading came the same day, and they fail that test**
+ * (ADR-0089, which supersedes ADR-0088 on this one point). Both mean wait,
+ * exactly as Syncing does. They are here because the reader's next move is not
+ * the only thing a word is for: *Uploading* over the notes somebody wrote this
+ * morning tells them their own work is the thing in flight, and *Downloading*
+ * over a vault they have just joined tells them the wait is somebody else's
+ * notes arriving. Syncing said neither, and a person watching a first sync for
+ * an hour wants to know which of the two it is.
  *
  * The header used to say this list mirrored `status.py` in the admin
  * repository. That file went with the 2026-08-18 rebuild and the panel now
@@ -24,6 +33,8 @@
  */
 
 export const SYNCING = "Syncing";
+export const UPLOADING = "Uploading";
+export const DOWNLOADING = "Downloading";
 export const UP_TO_DATE = "Up to date";
 export const PAUSED = "Paused";
 export const OFFLINE = "Offline";
@@ -33,6 +44,8 @@ export const PROBLEM = "Problem";
 /** In the order a vault moves through them, trouble last. */
 export const SYNC_WORDS = [
 	SYNCING,
+	UPLOADING,
+	DOWNLOADING,
 	UP_TO_DATE,
 	PAUSED,
 	OFFLINE,
@@ -53,6 +66,8 @@ export type SyncDot = "ok" | "working" | "wait" | "error";
 
 const DOTS: Record<SyncWord, SyncDot> = {
 	[SYNCING]: "working",
+	[UPLOADING]: "working",
+	[DOWNLOADING]: "working",
 	[UP_TO_DATE]: "ok",
 	[PAUSED]: "wait",
 	[OFFLINE]: "wait",
@@ -77,6 +92,14 @@ export interface VaultState {
 	paused: boolean;
 	/** A share exists and its documents are still going up or coming down. */
 	syncing: boolean;
+	/**
+	 * Notes and attachments still to reach the cloud vault, and still to
+	 * reach this device. They pick which of the three moving words is said
+	 * (ADR-0089). Left out by callers that cannot split their queue, which
+	 * read as both and get Syncing.
+	 */
+	up?: number;
+	down?: number;
 	/**
 	 * A socket is up. Left out by callers that cannot tell, which read as
 	 * connected: a status that cries Offline because nobody asked is worse
@@ -117,8 +140,28 @@ export function syncWord(state: VaultState): SyncWord {
 	if (state.lost) return PROBLEM;
 	if (state.connected === false) return OFFLINE;
 	if ((state.stuck ?? 0) > 0) return PROBLEM;
-	if (state.syncing) return SYNCING;
+	if (state.syncing) return movingWord(state.up, state.down);
 	return UP_TO_DATE;
+}
+
+/**
+ * Which of the three moving words this vault is doing.
+ *
+ * One direction gets its own word, because that is the one a person can
+ * check against what they just did: *Uploading* over the notes they wrote
+ * this morning, *Downloading* over a vault they have just joined. Both at
+ * once is Syncing, and so is a vault whose queue cannot say which way it is
+ * going, because a word that guesses is worse than the general one.
+ */
+export function movingWord(up = 0, down = 0): SyncWord {
+	if (up > 0 && down <= 0) return UPLOADING;
+	if (down > 0 && up <= 0) return DOWNLOADING;
+	return SYNCING;
+}
+
+/** Whether this word is one of the three that mean notes are on the move. */
+export function isMoving(word: SyncWord): boolean {
+	return word === SYNCING || word === UPLOADING || word === DOWNLOADING;
 }
 
 /**
@@ -169,6 +212,8 @@ export function syncInstruction(word: SyncWord): string {
 		case PROBLEM:
 			return "Everything else is up to date, and nothing was lost.";
 		case SYNCING:
+		case UPLOADING:
+		case DOWNLOADING:
 			return "Leave Obsidian open until it finishes. It picks up where it left off if you close it.";
 		default:
 			return "";

--- a/src/vaultStatus.ts
+++ b/src/vaultStatus.ts
@@ -15,8 +15,8 @@
  */
 
 import {
-	SYNCING,
 	UP_TO_DATE,
+	isMoving,
 	syncCounts,
 	syncDot,
 	syncProgress,
@@ -193,7 +193,7 @@ export function vaultReading(
 ): VaultReading {
 	const word = vaultSyncWord(signedIn, folders, held);
 	const { done, total } = vaultCounts(folders);
-	const moving = word === SYNCING && total > 0;
+	const moving = isMoving(word) && total > 0;
 	return {
 		word,
 		dot: syncDot(word),
@@ -237,7 +237,7 @@ export function statusBarPaint(reading: VaultReading, burst: Burst): StatusBarPa
 	// Held back: the vault says it is syncing and the corner has not been told
 	// to say so yet, which is where an ordinary save lives and dies. Only this
 	// one word waits; the three a person has to act on go straight past.
-	if (reading.word === SYNCING && !burst.moving) {
+	if (isMoving(reading.word) && !burst.moving) {
 		return {
 			dot: "ok",
 			count: "",


### PR DESCRIPTION
## Summary

[#129](https://github.com/pantalytics/knap-obsidian/pull/129) split the corner's number by direction and kept six words, turning down *Uploading* and *Downloading* on the rule that a word earns its place when the reader's next move is different. This overturns that half.

The rule holds; the conclusion did not. Somebody who wrote five notes this morning wants to know their own work is what is in flight. Somebody who just linked a phone to an existing vault wants to know the wait is somebody else's notes arriving. Syncing said neither, and the arrows that do say it exist in one of the four places the state is shown.

**What changes**

- `SYNC_WORDS` gains **Uploading** and **Downloading**, both on the working dot, both carrying Syncing's instruction, because what a person does about it is the same.
- The word is chosen by the gauges [#129](https://github.com/pantalytics/knap-obsidian/pull/129) already added, not by new state: one direction with work in it and the other empty gets that direction's word.
- **Syncing stays** and covers two cases: both directions at once, and a queue that cannot say which way it is going. The pre-rebuild path is the second, since its queue counts sends and fetches in one total. A word that guesses is worse than the general one.
- The two seconds of quiet in the corner now cover all three moving words rather than the one they were written for.
- The after-update notice gets a sentence each, which is where the type checker caught the branch that would have been forgotten.

Nothing else from [#129](https://github.com/pantalytics/knap-obsidian/pull/129) moves: an edit is still never counted, attachments are still counted apart and shown together, and the per-note mark in the file explorer is still [#130](https://github.com/pantalytics/knap-obsidian/issues/130).

**The cost, stated in the ADR:** eight words instead of six, and the test for adding one is weaker than it was. It was "the reader's next move is different"; it is now that, or the word says whose work is in flight.

Decision: **ADR-0089** in [pantalytics/knap-mcp-admin](https://github.com/pantalytics/knap-mcp-admin), which supersedes ADR-0088 on this one point.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (6 pre-existing warnings, unchanged)
- [ ] Tested in Obsidian
- [x] Changes are minimal and focused

912 tests pass, including new coverage for which word each direction picks, that all three wear the working dot and share one instruction, and that the corner's delay holds all three back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAujPw18TXGadYRdwhdgqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAujPw18TXGadYRdwhdgqv)_