### PR TITLE
A restart skips the notes the server says are unchanged

### DIFF
--- a/__tests__/knap/TreeDoc.test.ts
+++ b/__tests__/knap/TreeDoc.test.ts
@@ -145,4 +145,15 @@ describe("TreeDoc", () => {
 			/never leaves/,
 		);
 	});
+
+	it("reads the hash the server wrote for a note, and nothing for one it has not", () => {
+		const server = new Y.Doc();
+		const device = new TreeDoc(new Y.Doc());
+		const id = device.ensureNote("Notes/plan.md");
+		expect(device.hashFor(id)).toBeUndefined();
+
+		server.getMap<string>("hashes").set(id, "abc123");
+		Y.applyUpdate(device.doc, Y.encodeStateAsUpdate(server));
+		expect(device.hashFor(id)).toBe("abc123");
+	});
 });

--- a/__tests__/knap/VaultBinding.test.ts
+++ b/__tests__/knap/VaultBinding.test.ts
@@ -10,6 +10,7 @@
 
 import * as Y from "yjs";
 
+import { generateHash } from "../../src/hashing";
 import { TreeDoc } from "../../src/knap/TreeDoc";
 import {
 	FileEvent,
@@ -96,6 +97,25 @@ class Hub {
 	 */
 	treeDelay = 0;
 
+	/** Which documents any device borrowed, by id. */
+	borrowed = new Set<string>();
+
+	/**
+	 * What the server's markdown mirror does after every flush: a sha256 per
+	 * note, in the tree's third map, keyed by document id.
+	 */
+	async mirror(): Promise<void> {
+		const tree = this.byId.get("tree")?.[0];
+		if (!tree) return;
+		const hashes = tree.getMap<string>("hashes");
+		for (const docId of tree.getMap<string>("files").values()) {
+			const doc = this.byId.get(docId)?.[0];
+			if (!doc) continue;
+			const text = doc.getText("content").toString();
+			hashes.set(docId, await generateHash(new TextEncoder().encode(text)));
+		}
+	}
+
 	/** The tree as the server holds it. */
 	treeOf(): Y.Map<string> {
 		const peers = this.byId.get("tree") ?? [];
@@ -170,6 +190,7 @@ class Hub {
 			tree: () => (tree ??= new TreeDoc(open("tree").doc)),
 			treeSynced: () => open("tree").synced,
 			withNote: async <T,>(docId: string, use: (note: { doc: Y.Doc }) => Promise<T>) => {
+				this.borrowed.add(docId);
 				const entry = open(docId);
 				await entry.synced;
 				return use({ doc: entry.doc });
@@ -410,6 +431,70 @@ describe("VaultBinding", () => {
 
 		expect(a.files.map.get("nieuw.md")).toBe("van B");
 		expect(a.files.map.get("eigen.md")).toBe("x");
+	});
+
+	it("a restart opens no note whose file is what the server last mirrored", async () => {
+		const hub = new Hub();
+		const seen = new MemorySeen();
+		const a = await device(hub, { "een.md": "1", "twee.md": "2" }, seen);
+		await settle(a.binding);
+		await hub.mirror();
+
+		hub.borrowed.clear();
+		const again = await restart(hub, a.files, seen);
+		await settle(again);
+		expect(hub.borrowed.size).toBe(0);
+		// The pass still counts them: the screen says the check is done.
+		expect(again.checked).toEqual({ done: 2, total: 2 });
+	});
+
+	it("a restart opens the one note that changed in the cloud while the device was away", async () => {
+		const hub = new Hub();
+		const seen = new MemorySeen();
+		const a = await device(hub, { "stil.md": "blijft", "druk.md": "oud" }, seen);
+		const b = await device(hub);
+		await settle(a.binding, b.binding);
+		await hub.mirror();
+		a.binding.stop();
+
+		await b.files.write("druk.md", "nieuw");
+		await settle(b.binding);
+		await hub.mirror();
+
+		hub.borrowed.clear();
+		const again = await restart(hub, a.files, seen);
+		await settle(again);
+		expect(hub.borrowed.has(hub.treeOf().get("stil.md") as string)).toBe(false);
+		expect(hub.borrowed.has(hub.treeOf().get("druk.md") as string)).toBe(true);
+		expect(a.files.map.get("druk.md")).toBe("nieuw");
+	});
+
+	it("a restart opens the one note edited here while the plugin was not running", async () => {
+		const hub = new Hub();
+		const seen = new MemorySeen();
+		const a = await device(hub, { "stil.md": "blijft", "druk.md": "oud" }, seen);
+		await settle(a.binding);
+		await hub.mirror();
+		a.binding.stop();
+		a.files.map.set("druk.md", "hier veranderd"); // no event: the plugin was off
+
+		hub.borrowed.clear();
+		const again = await restart(hub, a.files, seen);
+		await settle(again);
+		expect(hub.borrowed.has(hub.treeOf().get("stil.md") as string)).toBe(false);
+		expect(hub.borrowed.has(hub.treeOf().get("druk.md") as string)).toBe(true);
+	});
+
+	it("a note the server has not hashed yet is opened, as before", async () => {
+		const hub = new Hub();
+		const seen = new MemorySeen();
+		const a = await device(hub, { "een.md": "1" }, seen);
+		await settle(a.binding);
+
+		hub.borrowed.clear();
+		const again = await restart(hub, a.files, seen);
+		await settle(again);
+		expect(hub.borrowed.has(hub.treeOf().get("een.md") as string)).toBe(true);
 	});
 
 	it("a vault whose files have not loaded deletes nothing", async () => {

--- a/src/knap/TreeDoc.ts
+++ b/src/knap/TreeDoc.ts
@@ -18,7 +18,13 @@
  * map with a kind field would put a device's attachment bookkeeping in a
  * position to name a note's path and delete another device's note.
  *
- * This module wraps both maps for the plugin. It never talks to the network:
+ * `hashes` is the third map, and the server's: document id to the sha256 of
+ * the note's text, put there by the markdown mirror every time it writes the
+ * note. This plugin only reads it, at start, to tell a note it already has
+ * from one that changed while it was away without opening a socket per note.
+ * Keyed by document id, so a move costs it nothing.
+ *
+ * This module wraps all three maps for the plugin. It never talks to the network:
  * the caller binds the underlying Y.Doc to a socket, and this class stays
  * honest whether the doc is live, offline, or in a test.
  */
@@ -28,6 +34,7 @@ import * as Y from "yjs";
 export const TREE_DOC_ID = "tree";
 const FILES = "files";
 const ATTACHMENTS = "attachments";
+const HASHES = "hashes";
 
 export interface TreeChange {
 	added: Map<string, string>;
@@ -50,10 +57,21 @@ export interface AttachmentChange {
 export class TreeDoc {
 	private readonly files: Y.Map<string>;
 	private readonly attachmentMap: Y.Map<AttachmentEntry>;
+	private readonly hashes: Y.Map<string>;
 
 	constructor(readonly doc: Y.Doc) {
 		this.files = doc.getMap<string>(FILES);
 		this.attachmentMap = doc.getMap<AttachmentEntry>(ATTACHMENTS);
+		this.hashes = doc.getMap<string>(HASHES);
+	}
+
+	/**
+	 * The sha256 of a note's text as the server last mirrored it, or
+	 * undefined for a note the server has not written yet. Compare it with
+	 * the file on disk: equal means nothing to fetch and nothing to push.
+	 */
+	hashFor(docId: string): string | undefined {
+		return this.hashes.get(docId);
 	}
 
 	/** path -> document id, a plain snapshot. */

--- a/src/knap/VaultBinding.ts
+++ b/src/knap/VaultBinding.ts
@@ -38,6 +38,7 @@
 import * as Y from "yjs";
 
 import { buildConflictCopyPath } from "../conflictCopyPath";
+import { generateHash } from "../hashing";
 import { TREE_SYNC_FAILED, TREE_SYNC_TIMEOUT_MS, withTimeout } from "./deadline";
 import { TreeDoc, isNote, normalize } from "./TreeDoc";
 
@@ -467,11 +468,33 @@ export class VaultBinding {
 		});
 		await this.inWaves(bind, async ([path, docId]) => {
 			try {
+				if (await this.sameAsCloud(path, docId)) return;
 				await this.bindNote(path, docId);
 			} finally {
 				if (down.has(path)) this.outstanding.down -= 1;
 			}
 		});
+	}
+
+	/**
+	 * Whether the file on disk is the note as the server last mirrored it.
+	 *
+	 * The tree carries a hash per note, written by the server's mirror, and a
+	 * file that hashes to the same thing needs no socket: nothing to fetch,
+	 * nothing to push, and nothing to compare. This is what turns a restart
+	 * over a vault that is already here from minutes of opening every note
+	 * into seconds of reading every file. Measured before it: 2,505 notes,
+	 * eight sockets at a time, about five minutes with nothing moving.
+	 *
+	 * Only ever answers yes on a match. A note the server has not hashed yet
+	 * takes the long road, and so does one whose file cannot be read.
+	 */
+	private async sameAsCloud(path: string, docId: string): Promise<boolean> {
+		const cloud = this.docs.tree().hashFor(docId);
+		if (cloud === undefined) return false;
+		const text = await this.files.read(path);
+		if (text === null) return false;
+		return (await generateHash(new TextEncoder().encode(text))) === cloud;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Every start of the plugin opened every note that was both in the tree and on disk, eight at a time, to compare its text with the file. On 2,505 notes that was about five minutes of "Checked 104 of 2,505" with nothing moving. Closes #140.

The tree now carries a third map, `hashes`, from document id to the sha256 of the note's text. The server's mirror writes it ([pantalytics/knap-mcp-admin#186](https://github.com/pantalytics/knap-mcp-admin/pull/186), ADR-0092 there); this plugin only reads it. At start, `VaultBinding.sameAsCloud` hashes the file and skips the note when the numbers match. Anything else takes the road it took before: a note the server has not hashed yet, a file edited here while the plugin was off, a note that changed in the cloud while the device was away. The Checked gauge still counts every note.

Either half ships alone: against a server without the map, every note takes the old road.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [ ] Tested in Obsidian
- [x] Changes are minimal and focused

Also checked: `npm test` (941 passed), and the server repo's `plugin_against_knap_server` spike re-run against the real server, which asserts the plugin's sha256 of the file is the server's number in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9WbE1Pe4K22KURiEoZ8sc

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9WbE1Pe4K22KURiEoZ8sc)_