### PR TITLE
An empty file is not a copy worth keeping

### DIFF
--- a/__tests__/knap/AttachmentBinding.test.ts
+++ b/__tests__/knap/AttachmentBinding.test.ts
@@ -347,6 +347,32 @@ describe("nothing is lost", () => {
 		alice.binding.stop();
 		bob.binding.stop();
 	});
+
+	it("does not keep a copy of nought bytes beside the real file", async () => {
+		// A download that was cut off leaves an empty file at the path, and
+		// the hash of nothing differs from every real hash, so the rule above
+		// used to file it as a second copy worth keeping. It is not a copy of
+		// anything, and the note side proved what that costs: 57 empty notes
+		// in one evening, 2026-09-05.
+		const hub = new Hub();
+		const transport = new MemoryTransport();
+		const alice = await device(hub, transport);
+
+		const bob = await device(hub, transport);
+		bob.binding.stop();
+		bob.files.blobs.set("foto.png", new ArrayBuffer(0));
+
+		await alice.files.writeBinary("foto.png", bytes("alice's photo"));
+		await settle(alice);
+		await bob.binding.start();
+		await settle(alice, bob);
+
+		expect(textOf(bob.files.blobs.get("foto.png") as ArrayBuffer)).toBe("alice's photo");
+		expect([...bob.files.blobs.keys()].filter((p) => p.includes("conflict"))).toHaveLength(0);
+		expect([...transport.stored.keys()].filter((p) => p.includes("conflict"))).toHaveLength(0);
+		alice.binding.stop();
+		bob.binding.stop();
+	});
 });
 
 describe("the ceilings", () => {

--- a/__tests__/knap/VaultBinding.test.ts
+++ b/__tests__/knap/VaultBinding.test.ts
@@ -570,6 +570,22 @@ describe("VaultBinding", () => {
 		expect(a.files.map.get("nota (conflict).md")).toBe("lokale versie");
 	});
 
+	it("an empty local file is filled, not copied beside itself", async () => {
+		// What a fill killed halfway leaves at a path. Measured on 2026-09-05:
+		// a phone made 57 of these, every copy nought bytes, and every one of
+		// them became a note in the cloud vault and on every other device.
+		const hub = new Hub();
+		const a = await device(hub, { "nota.md": "cloudversie" });
+		await settle(a.binding);
+
+		const b = await device(hub, { "nota.md": "" });
+		await settle(a.binding, b.binding);
+
+		expect(b.files.map.get("nota.md")).toBe("cloudversie");
+		expect([...b.files.map].filter(([path]) => path.includes("conflict"))).toHaveLength(0);
+		expect([...a.files.map].filter(([path]) => path.includes("conflict"))).toHaveLength(0);
+	});
+
 	it("its own writes do not echo", async () => {
 		const hub = new Hub();
 		const a = await device(hub, { "stil.md": "rust" });

--- a/src/knap/AttachmentBinding.ts
+++ b/src/knap/AttachmentBinding.ts
@@ -343,12 +343,18 @@ export class AttachmentBinding {
 	 */
 	private async pull(path: string, entry: AttachmentEntry): Promise<void> {
 		const local = await this.files.readBinary(path);
-		if (local !== null) {
+		if (local !== null && local.byteLength > 0) {
 			if ((await generateHash(local)) === entry.hash) return; // already here
 			// Both sides have bytes, and they differ. There is no merge for a
 			// binary and no text to rebuild it from, so nothing is thrown
 			// away: the cloud copy takes the path and this device's copy
 			// survives beside it, named for what happened.
+			//
+			// Zero bytes is not a copy of anything. It is what a download that
+			// was cut off leaves at the path, and keeping it beside the real
+			// file would add an empty attachment to the vault for every one
+			// that failed. The note side hit exactly that on 2026-09-05, 57
+			// times over.
 			const copy = buildConflictCopyPath(path, this.conflictLabel());
 			await this.files.writeBinary(copy, local);
 			await this.push(copy);

--- a/src/knap/VaultBinding.ts
+++ b/src/knap/VaultBinding.ts
@@ -616,8 +616,16 @@ export class VaultBinding {
 			const fileText = await this.files.read(path);
 			let conflict: string | null = null;
 
-			if (fileText === null) {
-				await this.files.write(path, docText);
+			if (fileText === null || fileText === "") {
+				// No file, or a file with nothing in it. An empty file is what
+				// a fill that was killed halfway leaves behind, and a copy of
+				// nothing preserves nothing: on 2026-09-05 a phone whose fill
+				// kept dying turned 57 of them into 57 empty notes, first in
+				// the cloud vault and then on every device. So an empty file
+				// takes the same route as no file at all, and the branch below
+				// keeps the case it was written for, which is two sides that
+				// both actually wrote something.
+				if (docText !== fileText) await this.files.write(path, docText);
 			} else if (fileText !== docText) {
 				if (docText === "") {
 					// A minted note nobody typed in yet: the local text is the


### PR DESCRIPTION
Closes #149.

## What happened

A note arriving where a nought-byte file sits took the branch written for two sides that both wrote something: it named the empty file a conflict copy, wrote it beside the real note, and pushed it as a note of its own.

Measured 2026-09-05 on `260812_RH_Obsidian_vault`. A phone whose first fill kept dying made 57 of these in ninety seconds, 16:53:58 to 16:54:44 UTC. Every copy is nought bytes. All 57 are now notes in the cloud vault and on every device; the vault went from 2511 notes to 2568.

## The change

`VaultBinding.bindNote`: an empty file takes the same route as no file at all. The cloud text is written over it and nothing is kept beside it, because there is nothing to keep. The conflict branch still does what it was written for.

`AttachmentBinding.pull`: the same shape, with worse odds. A download cut off halfway leaves nought bytes at the path, the hash of nothing matches no entry, so every failed download would have added an empty attachment to the vault.

Two tests, one per binding, both failing before the change.

## What this does not do

It does not stop the nought-byte files appearing. A fill killed mid-write still leaves one, and that is issue #115's ground. This stops one of them turning into a note in everybody's vault.

It also does not remove the 57 already there. They are identifiable: nought bytes, and the exact label `(rutger conflict 2026-09-05)`.