### PR TITLE
What this device agreed with means what is on its disk

### DIFF
--- a/__tests__/knap/VaultBinding.test.ts
+++ b/__tests__/knap/VaultBinding.test.ts
@@ -101,6 +101,12 @@ class Hub {
 	borrowed = new Set<string>();
 
 	/**
+	 * Documents whose socket refuses to come up, by id. A fill that dies
+	 * halfway is the ordinary case on a phone, and this is how a test says so.
+	 */
+	broken = new Set<string>();
+
+	/**
 	 * What the server's markdown mirror does after every flush: a sha256 per
 	 * note, in the tree's third map, keyed by document id.
 	 */
@@ -190,6 +196,7 @@ class Hub {
 			tree: () => (tree ??= new TreeDoc(open("tree").doc)),
 			treeSynced: () => open("tree").synced,
 			withNote: async <T,>(docId: string, use: (note: { doc: Y.Doc }) => Promise<T>) => {
+				if (this.broken.has(docId)) throw new Error("This note did not sync in time.");
 				this.borrowed.add(docId);
 				const entry = open(docId);
 				await entry.synced;
@@ -584,6 +591,40 @@ describe("VaultBinding", () => {
 		expect(b.files.map.get("nota.md")).toBe("cloudversie");
 		expect([...b.files.map].filter(([path]) => path.includes("conflict"))).toHaveLength(0);
 		expect([...a.files.map].filter(([path]) => path.includes("conflict"))).toHaveLength(0);
+	});
+
+	it("a fill that did not finish deletes nothing it never downloaded", async () => {
+		// Measured 2026-09-05: a phone whose fill kept dying wrote down the
+		// whole tree as notes it agreed with, and on the next start read its
+		// own missing files as deletions. Four notes went off every device.
+		const hub = new Hub();
+		const a = await device(hub, { "komt.md": "aangekomen", "komt-niet.md": "kostbaar" });
+		await settle(a.binding);
+
+		// One note's socket never comes up, so the fill gets part of the way.
+		hub.broken.add(hub.treeOf().get("komt-niet.md") as string);
+		const seen = new MemorySeen();
+		const b = await device(hub, {}, seen);
+		await settle(a.binding, b.binding);
+		expect(b.files.map.get("komt.md")).toBe("aangekomen");
+		expect(b.files.map.has("komt-niet.md")).toBe(false);
+
+		// Anything at all happening in the tree writes the record, which is
+		// how a fill that is still limping along commits what it has not done.
+		await a.files.write("later.md", "iets anders");
+		await settle(a.binding, b.binding);
+
+		// The record may not claim a note this device has not got.
+		expect(seen.entries?.has("komt-niet.md") ?? false).toBe(false);
+
+		// And the restart downloads it rather than deleting it everywhere.
+		hub.broken.clear();
+		const again = await restart(hub, b.files, seen);
+		await settle(a.binding, again);
+
+		expect(a.files.map.get("komt-niet.md")).toBe("kostbaar");
+		expect(b.files.map.get("komt-niet.md")).toBe("kostbaar");
+		expect(hub.treeOf().has("komt-niet.md")).toBe(true);
 	});
 
 	it("its own writes do not echo", async () => {

--- a/src/knap/VaultBinding.ts
+++ b/src/knap/VaultBinding.ts
@@ -377,12 +377,33 @@ export class VaultBinding {
 		return this.queue;
 	}
 
-	/** Write down the tree this device now agrees with. Failing is survivable. */
+	/**
+	 * Write down the tree this device now agrees with. Failing is survivable.
+	 *
+	 * Agreed with means on this disk, and the two are not the same thing. This
+	 * used to save the tree whole, so a device whose fill did not finish wrote
+	 * down every path in it, the notes it had not managed to download
+	 * included. `reconcileAll` reads that back as "the file is gone and the
+	 * record says I had it", which is its sentence for a note somebody deleted
+	 * while the plugin was off, and deletes it in the cloud vault and on every
+	 * other device. Measured 2026-09-05: a phone whose first fill kept dying
+	 * deleted the four newest notes in the vault, the ones made after it last
+	 * got anywhere, off every device. They came back off an hourly backup.
+	 *
+	 * So the record is the tree narrowed to what is actually here. A path this
+	 * device never fetched is simply not in it, and the next pass downloads it
+	 * rather than deleting it, which is the safe direction and the true one.
+	 */
 	private async rememberTree(): Promise<void> {
 		if (!this.seenDirty || !this.seen) return;
 		this.seenDirty = false;
 		try {
-			await this.seen.save(this.docs.tree().entries());
+			const onDisk = new Set((await this.files.listNotes()).map(normalize));
+			const agreed = new Map<string, string>();
+			for (const [path, docId] of this.docs.tree().entries()) {
+				if (onDisk.has(path)) agreed.set(path, docId);
+			}
+			await this.seen.save(agreed);
 		} catch {
 			// A record that could not be written is a record that stays
 			// older than it is, and older is the safe direction: every


### PR DESCRIPTION
Closes #151.

Measured 2026-09-05 on `260812_RH_Obsidian_vault`: a phone whose first fill kept dying deleted the four newest notes in the vault, off every device and out of the cloud. Two of them were Excalidraw drawings of 29 KB and 150 KB. They came back off the 19:01 restic snapshot; without an hourly backup they were gone.

## Why

`rememberTree` saved the tree whole:

    await this.seen.save(this.docs.tree().entries());

A device whose fill did not finish therefore wrote down every path in the tree as one it had agreed with, the notes it never managed to download included. Any tree change at all sets `seenDirty`, so a fill that is still limping along commits what it has not done.

On the next start `reconcileAll` reads that record back, finds no file at a path it claims, and takes its branch for a note somebody deleted while the plugin was off:

    if (!local.has(path) && !emptied && seen.get(path) === docId) tree.remove(path);

The `emptied` guard covers a whole vault that failed to load. It does not cover a fill that got part of the way, which is the ordinary case on a phone (#115, and the socket ceiling that has been killing this vault's fills for days).

## The change

The record is the tree narrowed to what is actually on this disk. A path this device never fetched is simply not in it, so the next pass downloads it rather than deleting it everywhere. That is both the safe direction and the true one.

One test: a fill where one note's socket never comes up, a tree change to force the record out, then a restart. On main it fails by deleting the note off the other device.