### PR TITLE
An error travels in both directions (ADR-0095)

### DIFF
--- a/__tests__/faults.test.ts
+++ b/__tests__/faults.test.ts
@@ -145,3 +145,93 @@ describe("faults", () => {
 		expect(requestUrlMock).toHaveBeenCalledTimes(1);
 	});
 });
+
+/**
+ * ADR-0095 raised the ceiling for a device that can prove who it is. The
+ * anonymous half above is unchanged and stays the load-bearing promise; this
+ * half asserts that the message travels only when a credential does.
+ */
+describe("faults, signed in", () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+		requestUrlMock.mockReset();
+		requestUrlMock.mockResolvedValue({ status: 200 });
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	async function sendOne(
+		token: string,
+		error: unknown = PATHY,
+		after: (reporter: FaultReporter) => void = () => undefined,
+	) {
+		const reporter = new FaultReporter();
+		reporter.setCredential(token);
+		reporter.report("sync", error);
+		after(reporter);
+		await jest.advanceTimersByTimeAsync(SEND_EVERY_MS);
+		return requestUrlMock.mock.calls[0]?.[0];
+	}
+
+	it("carries the message and the top frame, with the token", async () => {
+		const params = await sendOne("knap_abc");
+		expect(params.headers.Authorization).toBe("Bearer knap_abc");
+		const fault = JSON.parse(params.body as string).faults[0];
+		expect(fault.message).toBe(PATHY.message);
+		expect(fault.where).toMatch(/^at /);
+	});
+
+	it("sends no Authorization header and no message without one", async () => {
+		const params = await sendOne("");
+		expect(params.headers.Authorization).toBeUndefined();
+		const fault = JSON.parse(params.body as string).faults[0];
+		expect(fault.message).toBeUndefined();
+		expect(params.body).not.toContain("Acme");
+	});
+
+	it("strips the message from a fault queued before signing out", async () => {
+		const params = await sendOne("knap_abc", PATHY, (reporter) =>
+			reporter.setCredential(""),
+		);
+		expect(params.headers.Authorization).toBeUndefined();
+		expect(params.body).not.toContain("Acme");
+	});
+
+	it("keeps a message to one line, so it cannot forge a second log line", async () => {
+		const params = await sendOne(
+			"knap_abc",
+			new Error("first\nWARNING forged second line"),
+		);
+		const fault = JSON.parse(params.body as string).faults[0];
+		expect(fault.message).toBe("first WARNING forged second line");
+	});
+
+	it("does not fold two failures that said different things", async () => {
+		const reporter = new FaultReporter();
+		reporter.setCredential("knap_abc");
+		reporter.report("sync", new Error("Acme.md is locked"));
+		reporter.report("sync", new Error("Beta.md is locked"));
+		await jest.advanceTimersByTimeAsync(SEND_EVERY_MS);
+		expect(JSON.parse(sentBodies()[0]).faults).toHaveLength(2);
+	});
+
+	it("says nothing at all when reporting is off, credential or not", async () => {
+		const reporter = new FaultReporter();
+		reporter.setCredential("knap_abc");
+		reporter.setEnabled(false);
+		reporter.report("sync", PATHY);
+		await jest.advanceTimersByTimeAsync(SEND_EVERY_MS * 3);
+		expect(requestUrlMock).not.toHaveBeenCalled();
+	});
+
+	it("scrubs to the four facts when asked without a credential", () => {
+		expect(Object.keys(scrubFault("sync", PATHY)).sort()).toEqual([
+			"component",
+			"platform",
+			"type",
+			"version",
+		]);
+	});
+});

--- a/__tests__/knap/notices.test.ts
+++ b/__tests__/knap/notices.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The frame the server sends when something went wrong on its side
+ * (ADR-0095), read here the way the plugin reads it.
+ *
+ * The bytes in `FROM_THE_SERVER` were produced by the server's own encoder
+ * (`knap_server/sockets.py`, `encode_notice`) and pasted in. That is the
+ * point of them: a format written down in two repositories that ship
+ * separately is the one thing neither repository's own tests can see going
+ * wrong, so this side asserts against the other side's actual output rather
+ * than against its own idea of it.
+ */
+
+import * as decoding from "lib0/decoding";
+
+import { NOTICE_MESSAGE, listenForNotices, readNotice } from "../../src/knap/notices";
+import type { ServerNotice } from "../../src/knap/notices";
+
+/**
+ * One real notice off knap_server: a warn about a name the search copy will
+ * not hold. 182 bytes, and its length needs two varint bytes, which is the
+ * case a one-byte reader gets wrong on every notice that matters.
+ */
+const FROM_THE_SERVER = new Uint8Array([
+	42, 179, 1, 123, 34, 108, 101, 118, 101, 108, 34, 58, 34, 119, 97, 114, 110, 34, 44, 34,
+	99, 111, 100, 101, 34, 58, 34, 110, 111, 116, 101, 45, 110, 111, 116, 45, 105, 110, 45,
+	115, 101, 97, 114, 99, 104, 45, 99, 111, 112, 121, 34, 44, 34, 116, 101, 120, 116, 34, 58,
+	34, 66, 111, 111, 100, 115, 99, 104, 97, 112, 112, 101, 110, 46, 116, 120, 116, 32, 115,
+	121, 110, 99, 115, 32, 98, 101, 116, 119, 101, 101, 110, 32, 121, 111, 117, 114, 32, 100,
+	101, 118, 105, 99, 101, 115, 44, 32, 98, 117, 116, 32, 105, 116, 115, 32, 110, 97, 109,
+	101, 32, 105, 115, 32, 111, 110, 101, 32, 116, 104, 101, 32, 115, 101, 97, 114, 99, 104,
+	32, 99, 111, 112, 121, 32, 119, 105, 108, 108, 32, 110, 111, 116, 32, 104, 111, 108, 100,
+	44, 32, 115, 111, 32, 97, 110, 32, 65, 73, 32, 99, 97, 110, 110, 111, 116, 32, 102, 105,
+	110, 100, 32, 105, 116, 46, 34, 125,
+]);
+
+/** Enough of a y-websocket provider for the handler table. */
+function fakeProvider() {
+	return { messageHandlers: [] as unknown[] } as never;
+}
+
+/** Feed one whole frame to whatever the provider registered for it. */
+function deliver(provider: { messageHandlers: unknown[] }, frame: Uint8Array): void {
+	const decoder = decoding.createDecoder(frame);
+	const type = decoding.readVarUint(decoder);
+	const handler = provider.messageHandlers[type] as
+		| ((...args: unknown[]) => void)
+		| undefined;
+	handler?.(null, decoder, provider, false, type);
+}
+
+describe("server notices", () => {
+	it("reads a frame the server actually produced", () => {
+		const provider = fakeProvider() as unknown as { messageHandlers: unknown[] };
+		const heard: ServerNotice[] = [];
+		listenForNotices(provider as never, (notice) => heard.push(notice));
+
+		expect(FROM_THE_SERVER[0]).toBe(NOTICE_MESSAGE);
+		deliver(provider, FROM_THE_SERVER);
+
+		expect(heard).toHaveLength(1);
+		expect(heard[0].level).toBe("warn");
+		expect(heard[0].code).toBe("note-not-in-search-copy");
+		expect(heard[0].text).toContain("Boodschappen.txt");
+	});
+
+	it("takes an unknown level as a warning rather than dropping the notice", () => {
+		expect(readNotice('{"level":"catastrophe","code":"x","text":"Something."}')).toEqual({
+			level: "warn",
+			code: "x",
+			text: "Something.",
+		});
+	});
+
+	it("refuses anything that is not a notice", () => {
+		expect(readNotice("not json")).toBeNull();
+		expect(readNotice("[]")).toBeNull();
+		expect(readNotice("null")).toBeNull();
+		expect(readNotice('{"code":"x"}')).toBeNull();
+		expect(readNotice('{"code":"x","text":""}')).toBeNull();
+		expect(readNotice('{"code":7,"text":"Something."}')).toBeNull();
+	});
+
+	it("a frame it cannot read does not reach the caller and does not throw", () => {
+		const provider = fakeProvider() as unknown as { messageHandlers: unknown[] };
+		const heard: ServerNotice[] = [];
+		listenForNotices(provider as never, (notice) => heard.push(notice));
+
+		// The type byte, and then nothing behind it.
+		expect(() => deliver(provider, new Uint8Array([NOTICE_MESSAGE]))).not.toThrow();
+		expect(heard).toEqual([]);
+	});
+
+	it("claims only its own message type", () => {
+		const provider = fakeProvider() as unknown as { messageHandlers: unknown[] };
+		listenForNotices(provider as never, () => undefined);
+		const claimed = provider.messageHandlers
+			.map((handler, type) => (handler ? type : -1))
+			.filter((type) => type >= 0);
+		expect(claimed).toEqual([NOTICE_MESSAGE]);
+	});
+});

--- a/src/components/SignIn.svelte
+++ b/src/components/SignIn.svelte
@@ -853,11 +853,13 @@
 	     row, one honest sentence: exactly what is sent, and what never is. -->
 	<div class="setting-item mod-toggle">
 		<div class="setting-item-info">
-			<div class="setting-item-name">Send anonymous error reports</div>
+			<div class="setting-item-name">Send error reports</div>
 			<div class="setting-item-description">
 				When something breaks, Knap sends the kind of error, where in the
-				plugin it happened, the plugin version and your platform, and never a
-				note, a file name or anything that identifies you.
+				plugin it happened, the plugin version and your platform. While you
+				are signed in it also sends what the error said, which can name a
+				note. It goes to the server your vault is already on, and nowhere
+				else.
 			</div>
 		</div>
 		<div class="setting-item-control">
@@ -866,7 +868,7 @@
 				class:is-enabled={faultReporting}
 				role="checkbox"
 				aria-checked={faultReporting}
-				aria-label="Send anonymous error reports"
+				aria-label="Send error reports"
 				tabindex="0"
 				on:click={toggleFaultReporting}
 				on:keypress={(e) => {

--- a/src/faults.ts
+++ b/src/faults.ts
@@ -17,6 +17,15 @@
  * retry: a fault reporter that hammers a struggling server is a second bug on
  * top of the first.
  *
+ * **Signed in, a fault says more (ADR-0095).** A device holding a Knap token
+ * is a member of a vault whose notes are already sitting on that server, so
+ * the error's own message and one line of where it happened go with it, and
+ * the server writes them into the log for that vault. Without a token
+ * nothing changes: four facts, no message, because an anonymous device is an
+ * unknown person's vault. The credential is the switch and it is checked at
+ * the moment of sending, so a fault queued while signed in and sent after
+ * signing out loses its message on the way out.
+ *
  * On by default, with the off switch in settings (main.ts wires the setting to
  * `setFaultReporting`). Off means no queueing and no network at all.
  */
@@ -38,6 +47,11 @@ export const FAULT_COMPONENTS = [
 	"settings",
 	"startup",
 	"attachments",
+	// The rebuilt sync layer (src/knap). It had no call sites at all until
+	// ADR-0095, which is to say the code that actually runs reported nothing.
+	"tree",
+	"link",
+	"mirror",
 ] as const;
 
 export type FaultComponent = (typeof FAULT_COMPONENTS)[number];
@@ -50,13 +64,24 @@ export type FaultPlatform =
 	| "mobile-android"
 	| "unknown";
 
-/** The whole of what one fault says. Four keys, and nothing else ever. */
+/**
+ * The whole of what one fault says. Four keys always, and two more only when
+ * a credential went with it.
+ */
 export interface Fault {
 	type: string;
 	component: FaultComponent;
 	version: string;
 	platform: FaultPlatform;
+	/** The error's own message. Only ever set on a signed-in report. */
+	message?: string;
+	/** One frame of where it happened. Same condition. */
+	where?: string;
 }
+
+/** How long each of the two extra fields may be. The server has its own. */
+const MAX_MESSAGE = 400;
+const MAX_WHERE = 200;
 
 /** One entry on the wire: a fault, folded with how often it happened. */
 export interface QueuedFault extends Fault {
@@ -104,17 +129,55 @@ function faultType(error: unknown): string {
 }
 
 /**
- * Reduce an error to the four facts that may leave the device. This is the
- * one gate: `report` calls it and nothing else builds a fault, so a message
- * cannot reach the wire through any call site.
+ * One line of the error's own message, or "". Newlines go: a fault becomes a
+ * log line on the server, and a message that can carry a newline can carry a
+ * whole fake log line after it.
  */
-export function scrubFault(component: FaultComponent, error: unknown): Fault {
-	return {
+function faultMessage(error: unknown): string {
+	const raw = error instanceof Error ? error.message : "";
+	return raw.split(/\s+/).join(" ").trim().slice(0, MAX_MESSAGE);
+}
+
+/**
+ * The top frame of the stack, as one short string.
+ *
+ * Where in *the plugin*, never where in the vault: a stack frame names a
+ * bundled module and a line number, which is exactly what is worth having and
+ * carries nothing about anybody's notes. Missing on a thrown non-Error and on
+ * platforms that do not fill `stack` in, and missing is fine.
+ */
+function faultWhere(error: unknown): string {
+	const stack = error instanceof Error ? error.stack : "";
+	if (!stack) return "";
+	const frame = stack.split("\n").find((line) => /^\s*at\s/.test(line));
+	return frame ? frame.trim().slice(0, MAX_WHERE) : "";
+}
+
+/**
+ * Reduce an error to the facts that may leave the device. This is the one
+ * gate: `report` calls it and nothing else builds a fault, so a message
+ * cannot reach the wire through any call site.
+ *
+ * `credentialed` is the whole of the difference ADR-0095 made. False is
+ * ADR-0071 unchanged.
+ */
+export function scrubFault(
+	component: FaultComponent,
+	error: unknown,
+	credentialed = false,
+): Fault {
+	const fault: Fault = {
 		type: faultType(error),
 		component,
 		version: GIT_TAG,
 		platform: faultPlatform(),
 	};
+	if (!credentialed) return fault;
+	const message = faultMessage(error);
+	const where = faultWhere(error);
+	if (message) fault.message = message;
+	if (where) fault.where = where;
+	return fault;
 }
 
 /**
@@ -126,8 +189,25 @@ export class FaultReporter {
 	private enabled = true;
 	private queue = new Map<string, QueuedFault>();
 	private timer: number | null = null;
+	/**
+	 * This device's Knap token, while it has one. Held so a report can prove
+	 * who is making it; never read for anything else, and never logged.
+	 */
+	private credential = "";
 
 	constructor(private readonly endpoint: string = faultsEndpoint()) {}
+
+	/**
+	 * Whose reports these are. Called on sign-in with the token and on sign
+	 * out with "".
+	 *
+	 * Signing out does not drop the queue the way turning reporting off does:
+	 * the faults are still worth having, they just stop saying more than an
+	 * anonymous one may.
+	 */
+	setCredential(token: string): void {
+		this.credential = token;
+	}
 
 	/**
 	 * The off switch. Off drops the queue and the pending send as well:
@@ -156,8 +236,17 @@ export class FaultReporter {
 	report(component: FaultComponent, error: unknown): void {
 		if (!this.enabled) return;
 		try {
-			const fault = scrubFault(component, error);
-			const key = `${fault.type}|${fault.component}|${fault.version}|${fault.platform}`;
+			const fault = scrubFault(component, error, this.credential !== "");
+			// The message is part of the key. Two failures with the same type
+			// and different messages are two failures, and folding them would
+			// throw away the half that says which.
+			const key = [
+				fault.type,
+				fault.component,
+				fault.version,
+				fault.platform,
+				fault.message ?? "",
+			].join("|");
 			const existing = this.queue.get(key);
 			if (existing) {
 				existing.count += 1;
@@ -182,13 +271,23 @@ export class FaultReporter {
 	 */
 	private async flush(): Promise<void> {
 		if (!this.enabled || this.queue.size === 0) return;
-		const faults = [...this.queue.values()];
+		const token = this.credential;
+		// Checked here rather than at report time: a fault queued while
+		// signed in and sent after signing out has nothing to prove itself
+		// with, so it goes out as an anonymous one instead of carrying a
+		// message the server would drop anyway.
+		const faults = [...this.queue.values()].map((fault) =>
+			token ? fault : { ...fault, message: undefined, where: undefined },
+		);
 		this.queue.clear();
 		try {
 			await requestUrl({
 				url: this.endpoint,
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: {
+					"Content-Type": "application/json",
+					...(token ? { Authorization: `Bearer ${token}` } : {}),
+				},
 				body: JSON.stringify({ faults }),
 				throw: false,
 			});
@@ -208,4 +307,12 @@ export function reportFault(component: FaultComponent, error: unknown): void {
 /** Wire the settings toggle through. Off means no queueing and no network. */
 export function setFaultReporting(enabled: boolean): void {
 	reporter.setEnabled(enabled);
+}
+
+/**
+ * Tell the reporter which device it is reporting for: the Knap token on sign
+ * in, "" on sign out. With one, a fault may carry its message (ADR-0095).
+ */
+export function setFaultCredential(token: string): void {
+	reporter.setCredential(token);
 }

--- a/src/knap/AttachmentBinding.ts
+++ b/src/knap/AttachmentBinding.ts
@@ -29,6 +29,7 @@
 
 import { buildConflictCopyPath } from "../conflictCopyPath";
 import { generateHash } from "../hashing";
+import { knapFault } from "./faultSink";
 import { TREE_SYNC_FAILED, TREE_SYNC_TIMEOUT_MS, withTimeout } from "./deadline";
 import type { AttachmentEntry, TreeDoc } from "./TreeDoc";
 import { isHidden, isNote, normalize } from "./TreeDoc";
@@ -93,7 +94,8 @@ export class AttachmentBinding {
 	async start(): Promise<void> {
 		try {
 			this.limits = await this.transport.limits();
-		} catch {
+		} catch (error) {
+			knapFault("attachments", error);
 			// A link that cannot read the ceilings is still a link. The
 			// server enforces them regardless, so the cost of guessing here
 			// is one wasted upload, not a wrong outcome.
@@ -281,7 +283,7 @@ export class AttachmentBinding {
 		try {
 			await this.transport.upload(clean, content);
 		} catch (error) {
-			this.refused(clean, messageOf(error));
+			this.failed(clean, error);
 			return;
 		}
 		// Only now, because this entry is what sends every other device
@@ -309,7 +311,7 @@ export class AttachmentBinding {
 		try {
 			await this.transport.upload(to, content);
 		} catch (error) {
-			this.refused(to, messageOf(error));
+			this.failed(to, error);
 			return;
 		}
 		tree.moveAttachment(from, to);
@@ -363,7 +365,7 @@ export class AttachmentBinding {
 		try {
 			content = await this.transport.download(path);
 		} catch (error) {
-			this.refused(path, messageOf(error));
+			this.failed(path, error);
 			return;
 		}
 		await this.files.writeBinary(path, content);
@@ -378,8 +380,21 @@ export class AttachmentBinding {
 		try {
 			await this.transport.remove(path);
 		} catch (error) {
-			this.refused(path, messageOf(error));
+			this.failed(path, error);
 		}
+	}
+
+	/**
+	 * An attachment that would not travel: said on screen, and filed with
+	 * the server (ADR-0095).
+	 *
+	 * The sentence is for the person whose photo is missing from their
+	 * phone. The fault is so that somebody can find out why without asking
+	 * them to open a console, which until now was the only way.
+	 */
+	private failed(path: string, error: unknown): void {
+		this.refused(path, messageOf(error));
+		knapFault("attachments", error);
 	}
 }
 

--- a/src/knap/KnapSync.ts
+++ b/src/knap/KnapSync.ts
@@ -44,6 +44,8 @@ import type { CloudVault, Fetch } from "./KnapServer";
 import { KnapServer } from "./KnapServer";
 import { KnapVaultClient } from "./KnapVaultClient";
 import type { WebSocketImpl } from "./KnapVaultClient";
+import { knapCredential, knapFault } from "./faultSink";
+import type { ServerNotice } from "./notices";
 import { SignInFlow } from "./SignInFlow";
 
 export interface KnapLink {
@@ -161,6 +163,14 @@ export interface KnapSyncOptions {
 	 * call.
 	 */
 	onLostVault?: (vaultName: string) => void;
+	/**
+	 * Told when the server says something went wrong on its side (ADR-0095):
+	 * a note whose name its search copy will not hold, an attachment it does
+	 * not have. Nothing local is broken when one of these arrives; what it
+	 * costs is that an AI cannot see that note, which is the whole reason
+	 * somebody put the vault on a server.
+	 */
+	onNotice?: (notice: ServerNotice) => void;
 }
 
 export class KnapSync {
@@ -394,6 +404,7 @@ export class KnapSync {
 			}
 		}
 		await this.options.save(null);
+		knapCredential("");
 		return { endedRemotely };
 	}
 
@@ -422,6 +433,9 @@ export class KnapSync {
 		// start rather than per label, and never fatal: an address we could
 		// not fetch leaves both falling back to the device name, which is
 		// what they said before this existed.
+		// Whose device this is, before anything can fail: a fault raised in
+		// this start may say more because of it (ADR-0095).
+		knapCredential(stored.token);
 		this.person = await this.whoAmI(stored.token);
 		this.lost = false;
 		// A link that has never finished a pass is still in its first one,
@@ -448,6 +462,7 @@ export class KnapSync {
 			this.options.webSocket,
 			() => this.loseVault(stored.cloudVaultName),
 			() => this.counts,
+			this.options.onNotice,
 		);
 		// The tree, before anything is counted against it. Both bindings make
 		// this same wait for the same reason, and making it here as well costs
@@ -464,6 +479,7 @@ export class KnapSync {
 			// out or a retry while the server was still away. None of those
 			// is a failure of this start, so none of them is reported as one.
 			if (this.client !== client) return;
+			knapFault("link", error);
 			throw error;
 		}
 		if (this.client !== client) return;
@@ -574,7 +590,8 @@ export class KnapSync {
 	private async whoAmI(token: string): Promise<string> {
 		try {
 			return (await this.server.me(token)).email;
-		} catch {
+		} catch (error) {
+			knapFault("auth", error);
 			return "";
 		}
 	}

--- a/src/knap/KnapVaultClient.ts
+++ b/src/knap/KnapVaultClient.ts
@@ -30,6 +30,7 @@ import { WebsocketProvider } from "y-websocket";
 
 import { withTimeout } from "./deadline";
 import type { KnapServer } from "./KnapServer";
+import { listenForNotices, type ServerNotice } from "./notices";
 import { TREE_DOC_ID, TreeDoc } from "./TreeDoc";
 
 /**
@@ -122,6 +123,14 @@ export class KnapVaultClient {
 		 * while the count has not been taken; sockets opened then say nothing.
 		 */
 		private readonly localCounts?: () => { notes: number; attachments: number } | null,
+		/**
+		 * Told when the server says something went wrong on its side
+		 * (ADR-0095). Only the tree socket carries these, so this is called
+		 * once per notice however many notes this vault has open. Last in the
+		 * list because everything before it was already being passed
+		 * positionally by callers that do not care about notices.
+		 */
+		private readonly onNotice?: (notice: ServerNotice) => void,
 	) {}
 
 	/**
@@ -398,6 +407,11 @@ export class KnapVaultClient {
 			disableBc: true,
 		});
 		provider.awareness.setLocalStateField("device", { name: this.deviceName });
+		// The server sends notices down the tree socket and nowhere else, so
+		// this is the one place that listens for them.
+		if (docId === TREE_DOC_ID && this.onNotice) {
+			listenForNotices(provider, this.onNotice);
+		}
 
 		// A refusal, not an outage. y-websocket treats every close the same and
 		// reconnects with backoff forever, which for somebody who was taken out

--- a/src/knap/ObsidianKnap.ts
+++ b/src/knap/ObsidianKnap.ts
@@ -15,8 +15,11 @@
 import { Notice, Platform, Plugin, SuggestModal, editorInfoField } from "obsidian";
 
 import { KNAP_PANEL_URL } from "../RelayOnPremConfig";
+import { reportFault, setFaultCredential } from "../faults";
+import { setFaultSink } from "./faultSink";
 
 import type { CloudVault } from "./KnapServer";
+import type { ServerNotice } from "./notices";
 import { knapLiveEditing } from "./knapEditor";
 import { KnapSync } from "./KnapSync";
 import type { KnapLink } from "./KnapSync";
@@ -156,6 +159,11 @@ export function registerKnapBeta(host: KnapHost): KnapSync | null {
 		return null;
 	}
 
+	// The sync layer files its faults through an injected sink so that nothing
+	// in src/knap has to import Obsidian (see faultSink.ts). This is the one
+	// place that connects the two, and it is set before anything can fail.
+	setFaultSink({ report: reportFault, credential: setFaultCredential });
+
 	const device = `${host.app.vault.getName()} on ${Platform.isMobileApp ? "phone" : "desktop"}`;
 	const sync = new KnapSync({
 		serverUrl,
@@ -165,6 +173,14 @@ export function registerKnapBeta(host: KnapHost): KnapSync | null {
 		load: () => host.getKnapLink(),
 		save: (value) => host.saveKnapLink(value),
 		onRefused: (path, reason) => new Notice(`${path}: ${reason}`),
+		// The server had a problem with something in this vault (ADR-0095).
+		// Nothing local is broken, so this is a sentence and not an alarm;
+		// info levels stay off screen, because a person opening Obsidian to
+		// write does not need this server's running commentary.
+		onNotice: (notice: ServerNotice) => {
+			if (notice.level === "info") return;
+			new Notice(notice.text, notice.level === "error" ? 0 : undefined);
+		},
 		// Somebody took this account out of the vault, or deleted it. Said
 		// once, and said plainly: the sentence has to answer "where did my
 		// notes go" before somebody goes looking for them, because the honest

--- a/src/knap/VaultBinding.ts
+++ b/src/knap/VaultBinding.ts
@@ -39,6 +39,7 @@ import * as Y from "yjs";
 
 import { buildConflictCopyPath } from "../conflictCopyPath";
 import { generateHash } from "../hashing";
+import { knapFault } from "./faultSink";
 import { TREE_SYNC_FAILED, TREE_SYNC_TIMEOUT_MS, withTimeout } from "./deadline";
 import { TreeDoc, isNote, normalize } from "./TreeDoc";
 
@@ -404,7 +405,8 @@ export class VaultBinding {
 				if (onDisk.has(path)) agreed.set(path, docId);
 			}
 			await this.seen.save(agreed);
-		} catch {
+		} catch (error) {
+			knapFault("tree", error);
 			// A record that could not be written is a record that stays
 			// older than it is, and older is the safe direction: every
 			// deletion below needs the record to positively say so.
@@ -535,8 +537,13 @@ export class VaultBinding {
 				const item = items[next++];
 				try {
 					await work(item);
-				} catch {
+				} catch (error) {
+					// The count is what the screen reads; the fault is what
+					// says which note and why, on a server somebody can look
+					// at. Before ADR-0095 a note that would not sync was a
+					// number on a card and nothing else, anywhere.
 					this.failures += 1;
+					knapFault("sync", error);
 				} finally {
 					// Done or failed, this piece is behind us either way.
 					this.pass.done += 1;

--- a/src/knap/faultSink.ts
+++ b/src/knap/faultSink.ts
@@ -1,0 +1,76 @@
+/**
+ * Where the sync layer files a fault, without knowing what a fault is.
+ *
+ * `src/faults.ts` talks to Obsidian (`Platform`, `requestUrl`) and to the
+ * network. Everything in this directory except the `Obsidian*` adapters is
+ * deliberately portable: it runs under jest against fake stores and a fake
+ * socket, and importing the reporter into it would drag Obsidian in with it.
+ *
+ * So the reporter is injected, exactly like the file store and the fetch are.
+ * `ObsidianKnap` sets the sink once at load; a test that does not set one
+ * gets the no-op, which is also what a build with fault reporting turned off
+ * behaves like.
+ *
+ * Every call here is swallowed. This is the module a piece of code reaches
+ * for when it has *already* failed, and a reporter that throws on top of that
+ * is a bug hidden behind a bug.
+ */
+
+/**
+ * Which part of the sync layer a fault happened in. A subset of
+ * `FAULT_COMPONENTS` in `src/faults.ts`, spelled again rather than imported
+ * so that nothing here has a path to Obsidian.
+ */
+export type KnapFaultComponent =
+	| "sync"
+	| "auth"
+	| "tokens"
+	| "settings"
+	| "startup"
+	| "attachments"
+	| "tree"
+	| "link"
+	| "mirror";
+
+/** What a host has to provide for faults to go anywhere. */
+export interface FaultSink {
+	report(component: KnapFaultComponent, error: unknown): void;
+	/** The device's token on sign-in, "" on sign-out. See ADR-0095. */
+	credential(token: string): void;
+}
+
+const NOWHERE: FaultSink = {
+	report: () => undefined,
+	credential: () => undefined,
+};
+
+let sink: FaultSink = NOWHERE;
+
+/** Point the sync layer's faults at a real reporter. Called once, at load. */
+export function setFaultSink(next: FaultSink): void {
+	sink = next;
+}
+
+/** Undo it, for a test that wants the silence back. */
+export function clearFaultSink(): void {
+	sink = NOWHERE;
+}
+
+/** File one fault. Never throws, whatever the sink does. */
+export function knapFault(component: KnapFaultComponent, error: unknown): void {
+	try {
+		sink.report(component, error);
+	} catch {
+		// See the module note: this is the one failure that cannot be
+		// allowed to have a failure of its own.
+	}
+}
+
+/** Say whose device this is now, so a fault may say more (ADR-0095). */
+export function knapCredential(token: string): void {
+	try {
+		sink.credential(token);
+	} catch {
+		// Same.
+	}
+}

--- a/src/knap/notices.ts
+++ b/src/knap/notices.ts
@@ -1,0 +1,97 @@
+/**
+ * What the server says down the socket when something went wrong there
+ * (ADR-0095).
+ *
+ * Until this existed the only sentence the server could say to a device was a
+ * close code, so everything short of "go away" was a warning in a log on a
+ * box and a silence in Obsidian. The case that made it worth building: a note
+ * whose name the server's search copy will not hold goes on syncing between
+ * somebody's machines exactly as it should, while every AI answers that the
+ * note does not exist, and nothing anywhere says so.
+ *
+ * One frame, one direction. The server sends message type 42 with a JSON
+ * varstring behind it; nothing here ever writes one. It arrives on the tree
+ * socket, which is the socket a linked vault always holds, so a notice comes
+ * in once rather than once per open note.
+ *
+ * A notice is a sentence for a person and not an error to switch on: `code`
+ * is the stable half and `text` is the English, which the server may reword
+ * any day without breaking this.
+ */
+
+import * as decoding from "lib0/decoding";
+import type { WebsocketProvider } from "y-websocket";
+
+/**
+ * Our type in the y-protocol stream. y-websocket dispatches on the leading
+ * varuint and reserves 0 (sync), 1 (awareness), 2 (auth) and 3 (query
+ * awareness). The same number is spelled in `knap_server/sockets.py`, and
+ * `tests/test_knap_server_faults.py` there asserts the bytes.
+ */
+export const NOTICE_MESSAGE = 42;
+
+/** How loudly to say it. Anything else is read as "warn". */
+export type NoticeLevel = "info" | "warn" | "error";
+
+/** One thing the server has to tell this device. */
+export interface ServerNotice {
+	level: NoticeLevel;
+	code: string;
+	text: string;
+}
+
+const LEVELS: readonly string[] = ["info", "warn", "error"];
+
+/**
+ * One notice off the wire, or null if what arrived was not one.
+ *
+ * Everything is checked because everything is somebody else's bytes, and a
+ * malformed frame must be a notice that does not arrive rather than a socket
+ * that falls over. A newer server sending a shape this build does not know is
+ * the normal state of the world, not an error.
+ */
+export function readNotice(payload: string): ServerNotice | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(payload);
+	} catch {
+		return null;
+	}
+	if (typeof parsed !== "object" || parsed === null) return null;
+	const { level, code, text } = parsed as Record<string, unknown>;
+	if (typeof code !== "string" || typeof text !== "string" || !text) return null;
+	return {
+		level: typeof level === "string" && LEVELS.includes(level) ? (level as NoticeLevel) : "warn",
+		code,
+		text,
+	};
+}
+
+/**
+ * Listen for notices on one provider's socket.
+ *
+ * y-websocket copies its handler table per instance and dispatches on the
+ * leading varuint, so this is a slot in a table rather than a patch: an
+ * unknown type without it logs "Unable to compute message" to the console and
+ * carries on, which is what an older build of this plugin does and is the
+ * right behaviour for it.
+ *
+ * The handler writes nothing back. y-websocket replies only when a handler
+ * put something in the encoder, and a notice is not a question.
+ */
+export function listenForNotices(
+	provider: WebsocketProvider,
+	onNotice: (notice: ServerNotice) => void,
+): void {
+	provider.messageHandlers[NOTICE_MESSAGE] = (_encoder, decoder) => {
+		let notice: ServerNotice | null = null;
+		try {
+			notice = readNotice(decoding.readVarString(decoder));
+		} catch {
+			// A frame we cannot read is a frame we drop. The socket carries
+			// notes, and it is not going down over a diagnostic message.
+			return;
+		}
+		if (notice) onNotice(notice);
+	};
+}


### PR DESCRIPTION
The plugin half of pantalytics/knap-mcp-admin#196. Merge both, or the notices arrive at a plugin that logs "Unable to compute message" and the richer faults never leave.

Measured 2026-09-05, before writing anything: `POST https://app.knap.pantalytics.com/faults` answers **404**, so every beacon ADR-0071 shipped on 2026-08-17 has gone nowhere. And `src/knap/` -- the rebuilt sync layer, the code that actually runs -- had **zero** `reportFault` call sites. What works reported nothing and what reported went to a 404.

## Faults say more when they can prove who they are

Signed in, a fault carries the error's own message and its top stack frame, with the token in an `Authorization` header. The message is one line with a ceiling, so a beacon cannot forge a second log line on the server. Signed out it carries neither, and the stripping happens at send time rather than at report time, so a fault queued while signed in and sent after signing out goes out anonymous.

Anonymous is ADR-0071 unchanged, and its nine tests are unchanged with it.

**The settings copy moves with it.** "never a note, a file name or anything that identifies you" stopped being true for a signed-in device, and copy that is no longer true is worse than no copy.

## The sync layer can now file one

`src/faults.ts` imports Obsidian; everything in `src/knap` except the `Obsidian*` adapters is portable on purpose and runs under jest against fake stores. So the reporter is injected, exactly like the file store and the fetch are (`knap/faultSink.ts`), and `ObsidianKnap` connects the two at load.

First call sites, all of them places a failure was previously swallowed whole: a note that would not sync inside a fill wave (the `failures` counter, which was a number on a card and nothing else anywhere), a seen-record that would not write, an attachment that would not travel, a `/api/me` that would not answer, a tree that never synced.

## And the server can talk back

Message type 42 in the y-protocol stream, a JSON varstring behind it, server to device only. `KnapVaultClient` listens on the tree socket and nowhere else, so a notice arrives once rather than once per open note, and `ObsidianKnap` puts warn and error on screen while info stays off it.

Everything is checked on the way in: a malformed frame is a notice that does not arrive, never a socket that falls over, and an unknown level reads as a warning rather than being dropped.

## Measured

- `npx jest`: 1001 pass, 12 of them new. `npm run build` clean, `npx eslint src/` no new warnings.
- `__tests__/knap/notices.test.ts` reads bytes the **server's own encoder** produced, pasted in. A 182-byte notice needs a two-byte varint length, which is the case a naive reader gets wrong on every notice that matters.
- The server repo's `plugin_against_knap_server` spike bundles this branch's `src/knap` and takes a real notice off a real socket: twenty claims hold.