### PR TITLE
A record says which rule wrote it, or it is not read

### DIFF
--- a/__tests__/knap/ObsidianSeenTree.test.ts
+++ b/__tests__/knap/ObsidianSeenTree.test.ts
@@ -51,6 +51,29 @@ describe("ObsidianSeenTree", () => {
 		expect(await treeFor(adapter, "cloud-2").load()).toEqual(new Map());
 	});
 
+	it("says nothing about a record written before the tree was narrowed", async () => {
+		// Pre-#152 shape: the tree saved whole, no `narrowed` flag. On a device
+		// whose fill never finished it claims paths that never reached the
+		// disk, and reconcileAll reads such a claim as a deletion.
+		const adapter = new FakeAdapter();
+		adapter.files.set(
+			PATH,
+			JSON.stringify({ cloudVaultId: "cloud-1", files: { "Notes/plan.md": "doc-1" } }),
+		);
+
+		expect(await treeFor(adapter).load()).toEqual(new Map());
+	});
+
+	it("reads its own record back across the upgrade it survives", async () => {
+		// The flag is written, so the very next start trusts the record again
+		// and the refill is paid once rather than every time.
+		const adapter = new FakeAdapter();
+		await treeFor(adapter).save(new Map([["Notes/plan.md", "doc-1"]]));
+
+		expect(JSON.parse(adapter.files.get(PATH) as string).narrowed).toBe(true);
+		expect(await treeFor(adapter).load()).toEqual(new Map([["Notes/plan.md", "doc-1"]]));
+	});
+
 	it("a record that is not there, or not readable, is an empty one", async () => {
 		const adapter = new FakeAdapter();
 		expect(await treeFor(adapter).load()).toEqual(new Map());

--- a/src/knap/ObsidianSeenTree.ts
+++ b/src/knap/ObsidianSeenTree.ts
@@ -16,6 +16,13 @@
  * back in. A record made against one cloud vault says nothing about another,
  * and reading it as though it did is how a link to a second vault would
  * start by deleting notes out of it.
+ *
+ * A `narrowed` flag is written beside it and checked the same way. Before
+ * #152 the record was the tree saved whole, so a device whose fill had not
+ * finished wrote down paths it had never fetched; the flag says the file in
+ * hand was written under the rule that only what is on this disk goes in it.
+ * A record without the flag was written under the old rule and cannot be
+ * told apart from an honest one by reading it, so it is not read at all.
  */
 
 import { normalizePath } from "obsidian";
@@ -25,6 +32,8 @@ import type { SeenTree } from "./VaultBinding";
 
 interface Stored {
 	cloudVaultId: string;
+	/** Written only by a version whose record is what is on this disk. */
+	narrowed?: boolean;
 	files: Record<string, string>;
 }
 
@@ -41,13 +50,18 @@ export class ObsidianSeenTree implements SeenTree {
 	 * Every failure lands on empty on purpose. An empty record is the state
 	 * a first link is in, and it deletes nothing on either side: the binding
 	 * only removes a note where the record positively says it used to be
-	 * there. A record that cannot be read is one this device does not have.
+	 * there. A record that cannot be read is one this device does not have,
+	 * and so is one this device cannot vouch for: a pre-#152 record claims
+	 * every path in the tree, which on an unfinished fill is a claim to have
+	 * had notes that never arrived. Upgrading costs a refill; believing it
+	 * costs those notes, on every device and in the cloud vault.
 	 */
 	async load(): Promise<Map<string, string>> {
 		try {
 			const raw = await this.adapter.read(normalizePath(this.path));
 			const stored = JSON.parse(raw) as Stored;
 			if (stored.cloudVaultId !== this.cloudVaultId) return new Map();
+			if (stored.narrowed !== true) return new Map();
 			return new Map(Object.entries(stored.files ?? {}));
 		} catch {
 			return new Map();
@@ -57,6 +71,7 @@ export class ObsidianSeenTree implements SeenTree {
 	async save(entries: Map<string, string>): Promise<void> {
 		const stored: Stored = {
 			cloudVaultId: this.cloudVaultId,
+			narrowed: true,
 			files: Object.fromEntries(entries),
 		};
 		await this.adapter.write(normalizePath(this.path), JSON.stringify(stored));


### PR DESCRIPTION
#152 narrowed `rememberTree` to what is on disk. It said nothing about the records already written, and every device that ran a version before 1.13.31 carries one: the tree saved whole, paths the device never fetched included.

The first `reconcileAll` on the new version reads that record, not a new one:

```ts
if (!local.has(path) && !emptied && seen.get(path) === docId) {
    tree.remove(path);
```

`docId` matches, because the old record came straight out of the tree. `local` does not have the file, because the fill never fetched it. `emptied` is false, because the device does have most of the vault. So the note is removed -- off every device and out of the cloud vault -- before `rememberTree` gets a turn to write an honest record.

Nothing in the file distinguishes an honest record from that one, so the file now says so itself: `narrowed: true` beside the cloud vault id, checked on the way in exactly as the id is. A record without it is read as no record at all. That is what this class already does everywhere else -- an empty record deletes nothing and downloads what is missing -- and it costs one refill, once.

Measured 2026-09-06 on `260812_RH_Obsidian_vault`: an iPad on 1.13.28 holding 2,850 files against the desktop's 2,861, with `03 Resources/templates/` empty there and three notes on disk. That gap is what the old record would have claimed to have had.

`ConfigBinding` and `AttachmentBinding` keep no such record, so `VaultBinding` is the whole of it.

Fixes #154. Relates to #151, #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)