### PR TITLE
The plugin refuses what the server refuses

### DIFF
--- a/__tests__/knap/configPaths.test.ts
+++ b/__tests__/knap/configPaths.test.ts
@@ -34,6 +34,20 @@ describe("what settings sync carries", () => {
 		// Which panes are open, on either kind of device.
 		[".obsidian/workspace.json", false],
 		[".obsidian/workspace-mobile.json", false],
+		// The rest of the family, seen on a real vault (#147): an older
+		// Obsidian's extensionless file, and a file syncer's duplicates.
+		[".obsidian/workspace", false],
+		[".obsidian/workspace 2.json", false],
+		[".obsidian/workspace 3.json", false],
+		// Dropped with them on purpose: the core plugin's saved layouts.
+		[".obsidian/workspaces.json", false],
+		// A plugin named after them lives a directory down and travels.
+		[".obsidian/plugins/workspaces-plus/main.js", true],
+		// What the operating system left lying around, at any depth.
+		[".obsidian/.DS_Store", false],
+		[".obsidian/plugins/.DS_Store", false],
+		[".obsidian/plugins/dataview/.ds_store", false],
+		[".obsidian/Thumbs.db", false],
 		// Hidden, and not settings.
 		[".trash/gone.md", false],
 		[".git/config", false],

--- a/src/knap/configPaths.ts
+++ b/src/knap/configPaths.ts
@@ -52,7 +52,7 @@ export const OUR_PLUGIN_ID = "synced-vaults";
 const REFUSED_PREFIXES = [`plugins/${OUR_PLUGIN_ID}`];
 
 /**
- * Files inside the config directory that stay on the device.
+ * The workspace family, matched on how the name starts rather than listed.
  *
  * Which panes are open, on each of the two kinds of device Obsidian runs on.
  * Obsidian keeps them apart itself, `workspace.json` on desktop and
@@ -60,8 +60,28 @@ const REFUSED_PREFIXES = [`plugins/${OUR_PLUGIN_ID}`];
  * at six writes in twenty-five idle seconds against zero for every other file
  * in the directory, so two devices syncing one would never settle. Obsidian
  * Sync does not carry them either.
+ *
+ * Listing the two names by hand held until one vault broke it: `workspace`
+ * with no extension from an older Obsidian, and `workspace 2.json` and
+ * `workspace 3.json` from a file syncer that had duplicated it (#147). Every
+ * one of those is one device's pane layout under a name nobody predicted, so
+ * the rule is the stem instead, and only at the top of the directory: the
+ * `workspaces-plus` plugin lives a directory down and travels like any other
+ * plugin. Dropped on purpose: `workspaces.json`, the core plugin's saved
+ * layouts, which is closer to a setting than to a pane -- worth carrying, not
+ * worth a second rule to separate it from the file it is named after.
  */
-const REFUSED_FILES = ["workspace.json", "workspace-mobile.json"];
+const WORKSPACE_STEM = "workspace";
+
+/**
+ * What the operating system left lying around, at any depth.
+ *
+ * `.DS_Store` under `plugins/` is a Finder artefact of looking at the folder,
+ * not a setting, and a device that offers one gets it refused rather than
+ * stored. Matched by basename, lowercased, because these names come from
+ * whichever machine wrote them.
+ */
+const REFUSED_NAMES = [".ds_store", "thumbs.db", "desktop.ini"];
 
 /**
  * Is this path one settings sync carries?
@@ -79,8 +99,12 @@ export function isSyncedConfig(vaultPath: string): boolean {
 	}
 	const parts = clean.split("/").filter(Boolean);
 	if (parts.length < 2 || parts[0] !== CONFIG_DIR) return false;
+	const name = parts[parts.length - 1].toLowerCase();
+	if (REFUSED_NAMES.includes(name)) return false;
+	if (parts.length === 2 && parts[1].toLowerCase().startsWith(WORKSPACE_STEM)) {
+		return false;
+	}
 	const inside = parts.slice(1).join("/");
-	if (REFUSED_FILES.includes(inside)) return false;
 	return !REFUSED_PREFIXES.some(
 		(prefix) => inside === prefix || inside.startsWith(prefix + "/"),
 	);


### PR DESCRIPTION
#147 fixed the carve-out on the server ([knap-mcp-admin#192](https://github.com/pantalytics/knap-mcp-admin/commit/9559ba7)) and left this half of it alone -- the exact failure `configPaths.ts`'s own docstring names: *"the two carve-out lists have to say the same thing, or a device offers a file the server answers 422 to."*

Server side became a stem match plus the OS leavings. Plugin side stayed `["workspace.json", "workspace-mobile.json"]`, spelled out. So the rest of the family walked through and reached the tree before the server stopped taking them:

- `.obsidian/workspace` -- extensionless, older Obsidian
- `.obsidian/workspace 2.json`, `.obsidian/workspace 3.json` -- a file syncer's duplicates
- `.obsidian/plugins/.DS_Store`

They are still in the tree. A device turning settings sync on reads them out of it, asks for bytes the server no longer serves, and gets a notice per file. Measured on an iPad 2026-09-06, four at once, none about a file anybody put anywhere:

> `.obsidian/workspace: No file at that path.`

`pull` catches each one and carries on, so nothing downstream broke -- it is noise, but it is noise every device gets on first enabling the feature, about files the product has already decided it does not want.

Now matched the way `is_synced_config` matches: stem `workspace` at the top of the config directory only (so `plugins/workspaces-plus/` still travels), and `.DS_Store` / `Thumbs.db` / `desktop.ini` by basename at any depth. `ConfigBinding.reconcileAll` filters the tree through this predicate, so the stale entries stop being *read* as well as stop being written, and the notices go with them without a tree migration.

`workspaces.json` is dropped along with them, deliberately and as on the server: the core plugin's saved layouts are closer to a setting than to a pane, but not worth a second rule to separate them from the file they are named after.

Tests: 1010 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)