### PR TITLE
Settings travel, and there is nothing to turn on

### DIFF
--- a/__tests__/knap/settingsTab.test.ts
+++ b/__tests__/knap/settingsTab.test.ts
@@ -194,10 +194,6 @@ interface FakeState {
 	signedIn: boolean;
 	linked: null | { id: string; name: string };
 	status?: Partial<ReturnType<typeof baseStatus>>;
-	/** Whether settings sync is already on for this link. */
-	settingsOn?: boolean;
-	/** Whether the cloud vault already carries settings. */
-	cloudHasSettings?: boolean;
 }
 
 function baseStatus() {
@@ -230,7 +226,6 @@ function fakeSync(state: FakeState) {
 	const retried: string[] = [];
 	let settle: (() => void) | null = null;
 	let breaks: ((error: Error) => void) | null = null;
-	let settingsOn = state.settingsOn === true;
 	return {
 		retried,
 		/** Move the vault on, the way a socket does behind the screen's back. */
@@ -277,16 +272,6 @@ function fakeSync(state: FakeState) {
 			signedIn = false;
 			linked = null;
 			return { endedRemotely: true };
-		},
-		// The settings switch. `settingsOn` is what the row reads back, and
-		// `asked` records whether the person was warned before it moved.
-		canSyncSettings: true,
-		get syncsSettings() {
-			return settingsOn;
-		},
-		cloudHasSettings: () => state.cloudHasSettings === true,
-		setSyncSettings: async (on: boolean) => {
-			settingsOn = on;
 		},
 	};
 }
@@ -385,9 +370,10 @@ describe("the screen, signed in", () => {
 			signedIn: true,
 			linked: { id: "v1", name: "Work notes" },
 		});
-		// Account, then the vault, then what travels with it. The order is
-		// what each row depends on: who, which vault, and how much of it.
-		expect(rows.map((r) => r.name)).toEqual(["Account", "Cloud vault", "Sync settings"]);
+		// Account, then the vault. The order is what each row depends on:
+		// who, then which vault. There is no third row, because there is no
+		// longer a question about how much of the vault travels.
+		expect(rows.map((r) => r.name)).toEqual(["Account", "Cloud vault"]);
 		// Inside the vault's own block rather than beside it: one border round
 		// both, so the strip cannot be read as a third subject.
 		const block = find(container, "knap-vault");
@@ -402,7 +388,7 @@ describe("the screen, signed in", () => {
 				linked: { id: "v1", name: "Work notes" },
 				status: { problems, word: problems ? PROBLEM : UP_TO_DATE, dot: "error" },
 			});
-			expect(rows.map((r) => r.name)).toEqual(["Account", "Cloud vault", "Sync settings"]);
+			expect(rows.map((r) => r.name)).toEqual(["Account", "Cloud vault"]);
 		}
 	});
 
@@ -426,45 +412,22 @@ describe("the screen, signed in", () => {
 	});
 });
 
-describe("the settings switch", () => {
-	it("is not on the screen until there is a cloud vault to be about", () => {
-		const { rows } = drawWith(fakeSync({ signedIn: true, linked: null }));
-		expect(rows.map((row) => row.name)).not.toContain("Sync settings");
+describe("the settings switch that is not there", () => {
+	// The switch is gone, and with it the two ways it could be wrong: off on
+	// one device and on on another, and a person having to know that settings
+	// are a thing you opt into. A vault is its notes and how it is set up.
+	it("has no row, linked or not", () => {
+		for (const linked of [null, { id: "v1", name: "Work notes" }]) {
+			const { rows } = drawWith(fakeSync({ signedIn: true, linked }));
+			expect(rows.map((row) => row.name)).not.toContain("Sync settings");
+		}
 	});
 
-	it("is a name, an info button and the switch, with nothing said under it", () => {
+	it("leaves no switch anywhere on the screen", () => {
 		const { rows } = drawWith(
 			fakeSync({ signedIn: true, linked: { id: "v1", name: "Work notes" } }),
 		);
-		const row = rows.find((candidate) => candidate.name === "Sync settings");
-		expect(row).toBeDefined();
-		// The description line is the thing this row deliberately does not
-		// have: what travels is most of a folder, and one line either lies by
-		// omission or runs to three lines on a phone (ADR-0094).
-		expect(row?.desc).toBe("");
-		expect(row?.extras).toEqual(["info"]);
-		expect(row?.toggle?.value).toBe(false);
-	});
-
-	it("reads back on, once it is on", () => {
-		const { rows } = drawWith(
-			fakeSync({
-				signedIn: true,
-				linked: { id: "v1", name: "Work notes" },
-				settingsOn: true,
-			}),
-		);
-		const row = rows.find((candidate) => candidate.name === "Sync settings");
-		expect(row?.toggle?.value).toBe(true);
-	});
-
-	it("turns on without a question where there is nothing to replace", async () => {
-		const sync = fakeSync({ signedIn: true, linked: { id: "v1", name: "Work notes" } });
-		const { rows } = drawWith(sync);
-		rows.find((row) => row.name === "Sync settings")?.toggle?.flip(true);
-		await Promise.resolve();
-		await Promise.resolve();
-		expect(sync.syncsSettings).toBe(true);
+		expect(rows.filter((row) => row.toggle !== undefined)).toEqual([]);
 	});
 });
 

--- a/src/knap/KnapSettingsTab.ts
+++ b/src/knap/KnapSettingsTab.ts
@@ -35,7 +35,7 @@
  * uninstalling the plugin, which leaves the token alive anyway.
  */
 
-import { type App, Modal, Notice, type Plugin, PluginSettingTab, Setting, setIcon } from "obsidian";
+import { Notice, type Plugin, PluginSettingTab, Setting, setIcon } from "obsidian";
 
 import {
 	DOWNLOADING,
@@ -320,7 +320,6 @@ export class KnapSettingsTab extends PluginSettingTab {
 			this.statusEl = block.createDiv({ cls: "knap-status-slot" });
 			this.paint();
 			this.startTick();
-			this.drawSettingsSync(block);
 			return;
 		}
 
@@ -335,58 +334,6 @@ export class KnapSettingsTab extends PluginSettingTab {
 						.catch((error: Error) => new Notice(error.message));
 				}),
 		);
-	}
-
-	/**
-	 * The settings switch, under the strip and inside the same block.
-	 *
-	 * A name, an info button and the switch, and no sentence under it. What
-	 * travels is most of a folder now (ADR-0094), and a description line
-	 * either lies by omission or runs to three lines on a phone. *Settings*
-	 * means plugins to the person reading it, so the honest answer is a list
-	 * rather than a summary, and a list belongs behind a button.
-	 *
-	 * It is inside the Cloud vault block because it is a fact about the link:
-	 * unlink, and there is nothing left for it to be about.
-	 */
-	private drawSettingsSync(block: HTMLElement): void {
-		if (!this.sync.canSyncSettings) return;
-		const row = new Setting(block).setName("Sync settings");
-		row.addExtraButton((button) =>
-			button
-				.setIcon("info")
-				.setTooltip("What travels")
-				.onClick(() => new WhatTravelsModal(this.app).open()),
-		);
-		row.addToggle((toggle) =>
-			toggle.setValue(this.sync.syncsSettings).onChange((on) => {
-				// Read back rather than trusted: the confirm below can be
-				// declined, and a toggle that already moved would then be
-				// showing something that is not true.
-				void this.changeSettingsSync(on).then(() => this.display());
-			}),
-		);
-	}
-
-	/**
-	 * Turn it on or off, asking first where turning it on costs something.
-	 *
-	 * The one moment in this feature where somebody loses work they did by
-	 * hand: a cloud vault that already carries settings replaces this
-	 * device's. Off is never asked about, because turning it off leaves both
-	 * sides exactly as they are.
-	 */
-	private async changeSettingsSync(on: boolean): Promise<void> {
-		if (on && this.sync.cloudHasSettings()) {
-			const vaultName = this.sync.linked?.cloudVaultName ?? "the cloud vault";
-			const go = await new ReplaceSettingsModal(this.app, vaultName).ask();
-			if (!go) return;
-		}
-		try {
-			await this.sync.setSyncSettings(on);
-		} catch (error) {
-			new Notice((error as Error).message);
-		}
 	}
 
 	/**
@@ -553,108 +500,3 @@ function hostOf(serverUrl: string): string {
 }
 
 
-/**
- * What settings sync carries, and the short list of what it does not.
- *
- * The second list is the interesting one and it is why this modal exists at
- * all: two items, and both of them are things a person would otherwise
- * discover by noticing something missing.
- */
-export class WhatTravelsModal extends Modal {
-	onOpen(): void {
-		const { contentEl } = this;
-		contentEl.empty();
-		contentEl.createEl("h3", { text: "What travels with this vault" });
-
-		const lists = contentEl.createDiv({ cls: "knap-travels" });
-		this.list(lists, "Travels", [
-			"Theme, snippets and appearance",
-			"Hotkeys",
-			"Plugins, and their settings",
-			"Editor and graph settings",
-		]);
-		this.list(lists, "Stays on this device", [
-			"Which panes are open",
-			"Your Knap account and this link",
-		]);
-
-		contentEl.createDiv({
-			cls: "knap-travels-foot",
-			text:
-				"Two devices changing the same setting while both are offline: the newer " +
-				"one wins. A theme or a hotkey applies straight away. A plugin that " +
-				"arrives starts the next time you open Obsidian.",
-		});
-	}
-
-	private list(parent: HTMLElement, head: string, items: string[]): void {
-		const column = parent.createDiv({ cls: "knap-travels-column" });
-		column.createDiv({ cls: "knap-travels-head", text: head });
-		const list = column.createEl("ul", { cls: "knap-travels-list" });
-		for (const item of items) list.createEl("li", { text: item });
-	}
-
-	onClose(): void {
-		this.contentEl.empty();
-	}
-}
-
-/**
- * The question turning the switch on asks when there is something to lose.
- *
- * Only when the cloud vault already carries settings, and it names the vault,
- * because somebody with two of them needs to know which one is about to win.
- * The sentence about notes is there because that is the fear the word
- * *replace* creates, and it is unfounded.
- */
-export class ReplaceSettingsModal extends Modal {
-	private answered = false;
-	private settle: ((go: boolean) => void) | null = null;
-
-	constructor(
-		app: App,
-		private readonly vaultName: string,
-	) {
-		super(app);
-	}
-
-	ask(): Promise<boolean> {
-		return new Promise<boolean>((resolve) => {
-			this.settle = resolve;
-			this.open();
-		});
-	}
-
-	onOpen(): void {
-		const { contentEl } = this;
-		contentEl.empty();
-		contentEl.createEl("h3", { text: "Use the cloud vault's settings?" });
-		contentEl.createEl("p", {
-			text:
-				`${this.vaultName} already carries a theme, hotkeys, snippets and plugins. ` +
-				"Turning this on replaces the ones on this device with those. Your notes " +
-				"are not touched.",
-		});
-		const buttons = contentEl.createDiv({ cls: "knap-modal-buttons" });
-		const cancel = buttons.createEl("button", { text: "Cancel" });
-		cancel.type = "button";
-		cancel.addEventListener("click", () => this.answer(false));
-		const go = buttons.createEl("button", { text: "Use the cloud vault's", cls: "mod-cta" });
-		go.type = "button";
-		go.addEventListener("click", () => this.answer(true));
-	}
-
-	private answer(go: boolean): void {
-		this.answered = true;
-		this.settle?.(go);
-		this.settle = null;
-		this.close();
-	}
-
-	/** Closing the dialog is an answer, and the answer is no. */
-	onClose(): void {
-		this.contentEl.empty();
-		if (!this.answered) this.settle?.(false);
-		this.settle = null;
-	}
-}

--- a/src/knap/KnapSync.ts
+++ b/src/knap/KnapSync.ts
@@ -34,7 +34,6 @@ import type { AttachmentTransport, Refusal } from "./AttachmentBinding";
 import { AttachmentBinding } from "./AttachmentBinding";
 import type { ConfigStore } from "./ConfigBinding";
 import { ConfigBinding } from "./ConfigBinding";
-import { isSyncedConfig } from "./configPaths";
 import type { LiveNoteHandle } from "./knapEditor";
 import { conflictLabelFor, personLabel } from "./person";
 import { normalize } from "./TreeDoc";
@@ -66,15 +65,6 @@ export interface KnapLink {
 	 * vault falls quiet.
 	 */
 	initialized?: boolean;
-	/**
-	 * Whether this vault's settings travel with the cloud vault.
-	 *
-	 * Off unless somebody turned it on, and stored beside the link rather
-	 * than in the plugin's own settings because it is a fact about this
-	 * link: unlinking ends it, and linking somewhere else starts the
-	 * question again (ADR-0094).
-	 */
-	syncSettings?: boolean;
 }
 
 /**
@@ -518,8 +508,11 @@ export class KnapSync {
 			this.options.onRefused,
 			() => conflictLabelFor(this.person, this.options.deviceName, new Date()),
 		);
+		// No condition beyond whether this host can carry settings at all.
+		// A vault is its notes and how it is set up, and a device that had
+		// one without the other was a device somebody had to be told about.
 		this.settings =
-			this.options.config && stored.syncSettings
+			this.options.config
 				? new ConfigBinding(
 						this.options.config,
 						this.client,
@@ -616,64 +609,6 @@ export class KnapSync {
 		this.attachments = null;
 		this.settings = null;
 		this.options.onLostVault?.(vaultName);
-	}
-
-	// -- settings sync -------------------------------------------------------
-
-	/** Whether this link carries Obsidian's own settings. Off by default. */
-	get syncsSettings(): boolean {
-		return this.options.load()?.syncSettings === true;
-	}
-
-	/** Whether this host can carry settings at all. False in a bare test. */
-	get canSyncSettings(): boolean {
-		return this.options.config !== undefined;
-	}
-
-	/**
-	 * Whether the cloud vault already holds settings.
-	 *
-	 * The screen asks before turning the switch on, because a cloud vault
-	 * that has them replaces this device's, and that is the one moment in
-	 * this feature where somebody can lose something they set up by hand.
-	 * False while there is no socket, which reads as nothing to replace: the
-	 * binding's own reconciliation is the thing that decides in the end, and
-	 * it compares hashes rather than trusting this.
-	 */
-	cloudHasSettings(): boolean {
-		if (!this.client) return false;
-		for (const path of this.client.tree().attachments().keys()) {
-			if (isSyncedConfig(path)) return true;
-		}
-		return false;
-	}
-
-	/**
-	 * Turn settings sync on or off for this link.
-	 *
-	 * Takes effect now rather than at the next start, because a switch that
-	 * needs Obsidian restarted to mean anything is a switch somebody presses
-	 * twice. Turning it off stops this device listening and leaves both sides
-	 * as they are: the files stay in the cloud vault, and the files here stay
-	 * here.
-	 */
-	async setSyncSettings(on: boolean): Promise<void> {
-		const stored = this.options.load();
-		if (!stored) return;
-		await this.options.save({ ...stored, syncSettings: on });
-		if (!on) {
-			this.settings?.stop();
-			this.settings = null;
-			return;
-		}
-		if (this.settings || !this.options.config || !this.client) return;
-		this.settings = new ConfigBinding(
-			this.options.config,
-			this.client,
-			this.transportFor(stored.token, stored.cloudVaultId),
-			this.options.onRefused,
-		);
-		await this.settings.start();
 	}
 
 	/** The file routes, bound to one vault and one token. */

--- a/styles.css
+++ b/styles.css
@@ -841,45 +841,6 @@
 	margin-bottom: var(--size-4-3);
 }
 
-/* The two lists behind the info button on the Sync settings row. Side by side
-   where there is room and stacked on a phone, because the second list is the
-   one worth reading and it must not fall off the bottom. */
-.knap-travels {
-	display: flex;
-	flex-wrap: wrap;
-	gap: var(--size-4-4);
-	margin-bottom: var(--size-4-4);
-}
-
-.knap-travels-column {
-	flex: 1 1 200px;
-	min-width: 0;
-}
-
-.knap-travels-head {
-	color: var(--text-faint);
-	font-size: var(--font-ui-smaller);
-	text-transform: uppercase;
-	letter-spacing: 0.06em;
-	margin-bottom: var(--size-4-2);
-}
-
-.knap-travels-list {
-	margin: 0;
-	padding-left: var(--size-4-4);
-}
-
-.knap-travels-list li {
-	margin-bottom: var(--size-4-1);
-}
-
-.knap-travels-foot {
-	border-top: 1px solid var(--background-modifier-border);
-	padding-top: var(--size-4-3);
-	color: var(--text-muted);
-	font-size: var(--font-ui-smaller);
-}
-
 .knap-modal-buttons {
 	display: flex;
 	gap: var(--size-4-2);


### PR DESCRIPTION
**320 lines out, 21 in.**

The switch was per device and off by default, so linking a second device gave you the notes and none of how the vault is set up, with nothing on screen to say why. An iPad measured 2026-09-06 wrote the day's daily note into the vault root with no template, because `daily-notes.json` had never reached it. Finding that took a session. The fix was one switch nobody knew to look for.

`KnapSync` named the one thing the switch protected:

> The screen asks before turning the switch on, because a cloud vault that has them replaces this device's, and that is the one moment in this feature where somebody can lose something they set up by hand.

One moment, at linking. A setting that lives forever is the wrong shape for a question asked once, and that shape is exactly what made it off on the device you are not holding.

**Gone:** `syncSettings` from the stored link, `syncsSettings` / `canSyncSettings` / `setSyncSettings` / `cloudHasSettings`, the row and its toggle, `WhatTravelsModal`, `ReplaceSettingsModal`, and 39 lines of CSS that only they used.

**Left:** `ConfigBinding` is built whenever the host can carry settings at all. It still starts last, after notes and attachments, for the reason already written there -- somebody who has just linked is waiting for their notes, and a plugin folder is megabytes in front of the note they opened Obsidian to read.

The vault block is now Account and Cloud vault. Neither says anything about how much of the vault travels, because all of it does.

**Dropped on purpose:** notes synced while settings stay per device. Real, rare, and the price of keeping it was that everybody else had to find a switch.

**Not migrated:** an existing `syncSettings` in a stored link is ignored, and the next save drops it. A device that had it off starts carrying settings on the next start, which is the behaviour this PR is for.

**Left open:** settings sync carries plugins. On your own devices that is the point. On a vault shared with someone else (#90) it is their plugins on your machine, and that is where the distinction belongs -- not in a switch for everybody.

Tests: 1010 passing, lint clean.

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)