### PR TITLE
ConfigBinding says settings belong to the vault, not to a device

### DIFF
--- a/src/knap/ConfigBinding.ts
+++ b/src/knap/ConfigBinding.ts
@@ -16,9 +16,12 @@
  * - **No conflict copy.** Notes and attachments keep both sides. A file called
  *   `appearance (conflict from iPhone).json` inside `.obsidian` is litter in a
  *   folder a person cannot open from Obsidian, so the newer write simply wins.
- * - **The switch.** Off by default, and off means this binding is not started
- *   at all. Turning it off later leaves both sides exactly as they are: the
- *   files stay in the cloud vault, this device stops listening.
+ * - **Nothing to turn on.** This binding starts wherever the host has a config
+ *   directory at all, so a vault is its notes and how it is set up on every
+ *   device that holds it (ADR-0096). One consequence is worth knowing before
+ *   reading the rest: the settings belong to the vault, so everybody in a
+ *   shared vault gets the same theme, hotkeys and plugins, and the carve-outs
+ *   in `configPaths.ts` are the whole of what stays personal.
  * - **`manifest.json` goes last** when a plugin folder arrives, so a folder
  *   whose `main.js` is still in flight is not a plugin that half exists.
  * - **Nothing is enabled here.** A plugin that arrives is on disk and in the
@@ -27,7 +30,8 @@
  *   plugins too, and running somebody else's code the instant it lands is a
  *   decision no sync client should make on its own.
  * - **Our own folder never travels**, in either direction, and that is in
- *   `configPaths.ts` rather than here so the server can hold the same list.
+ *   `configPaths.ts` rather than here so the server can hold the same list. It
+ *   is what keeps a second person in a vault from being signed in as the first.
  */
 
 import { generateHash } from "../hashing";


### PR DESCRIPTION
## Summary

`ConfigBinding`'s header still described the Sync settings switch that #158
removed, and it was the first thing anybody opening the file met. It now says
what holds: the binding starts wherever the host has a config directory, and
the settings belong to the vault, so everybody in a shared vault gets the same
theme, hotkeys and plugins. The carve-outs in `configPaths.ts` are the whole
of what stays personal, and our own folder is the one keeping a second person
in a vault from being signed in as the first.

Comments only. The decision is ADR-0096 in `knap-mcp-admin`
(pantalytics/knap-mcp-admin#199).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation

## Checklist

- [ ] `npm run build` succeeds
- [x] `npx tsc --noEmit` passes
- [ ] Tested in Obsidian (comment-only change, no behaviour to test)
- [x] Changes are minimal and focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Qej5HfytZUTcGcfQHK3zr

---
_Generated by [Claude Code](https://claude.ai/code/session_012Qej5HfytZUTcGcfQHK3zr)_