### PR TITLE
One server, one address

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -34,7 +34,7 @@ body:
       label: Deployment
       options:
         - Self-hosted (docker compose)
-        - Hosted (cp.knap.pantalytics.com)
+        - Hosted (app.knap.pantalytics.com)
         - Local development
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/web-publish.yml
+++ b/.github/ISSUE_TEMPLATE/web-publish.yml
@@ -19,7 +19,7 @@ body:
       label: Deployment
       options:
         - Self-hosted
-        - Hosted (cp.knap.pantalytics.com)
+        - Hosted (app.knap.pantalytics.com)
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -106,6 +106,22 @@ jobs:
             exit 1
           }
 
+      # One server, one address (ADR-0033). A second Knap host in the bundle is
+      # how the "You're offline" banner appeared over a syncing vault: the
+      # health poll kept asking cp.knap.pantalytics.com long after the server
+      # had moved. A release carrying two addresses cannot be told apart from a
+      # working one by looking at it, so it is caught here instead.
+      - name: Prove the bundle carries exactly one Knap address
+        env:
+          URL: ${{ vars.KNAP_SERVER_URL }}
+        run: |
+          hosts=$(grep -oE 'https://[a-z0-9.-]*pantalytics\.com' main.js | sort -u)
+          if [ "$hosts" != "$URL" ]; then
+            echo "::error::main.js names more than the one server. Found:"
+            echo "$hosts"
+            exit 1
+          fi
+
       # One patch above the highest version that has ever been released, so
       # BRAT sees an update whatever it last installed. Read from the releases
       # rather than from manifest.json, because the bump deliberately never

--- a/docs/catalog-submission.md
+++ b/docs/catalog-submission.md
@@ -178,7 +178,7 @@ Not blockers, but cheaper to have an answer ready than to be surprised:
   option, and an OAuth callback over `obsidian://` instead of a loopback port,
   which is what makes sign-in work on a phone and against an identity provider
   that matches redirect URIs exactly.
-- **It ships with a server configured.** `cp.knap.pantalytics.com` is a default,
+- **It ships with a server configured.** `app.knap.pantalytics.com` is a default,
   not a lock-in: the settings let you remove it and point anywhere. The README
   says so in the network section, which is where a reviewer looks.
 - **Mobile.** `isDesktopOnly: false` is a promise. The loopback HTTP server that

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -63,25 +63,27 @@ const obsidianPluginDir = process.env.OBSIDIAN_PLUGIN_DIR || "";
 const apiUrl = "";
 const authUrl = "";
 
-// The one Knap server (ADR-0033). There is no server field and no second
-// server, so the address is build configuration rather than user input, and it
-// lives here rather than in a source file that ships. Set
-// KNAP_CONTROL_PLANE_URL to build against something else, a staging control
-// plane for instance.
-const controlPlaneUrl =
-	process.env.KNAP_CONTROL_PLANE_URL || "https://cp.knap.pantalytics.com";
-console.log("control plane:", controlPlaneUrl);
-
-// Knap's own page, which the Dashboard button opens. Build configuration for
-// the same reason the control plane is: there is one of it, and a person never
-// types an address here.
+// The one Knap server (ADR-0033), and therefore one address. There is no
+// server field and no second server, so it is build configuration rather than
+// user input, and it lives here rather than in a source file that ships.
 //
-// It is app.knap.pantalytics.com, not knap.pantalytics.com. The app moved there
-// on 13 August 2026 and the bare domain is the marketing site on another box, so
-// a build carrying the old address sends the Dashboard button to a page that
-// knows nothing about anybody's vault.
-const panelUrl = process.env.KNAP_PANEL_URL || "https://app.knap.pantalytics.com/sync";
-console.log("panel:", panelUrl);
+// It was three addresses, and that is what broke. The server moved to the app
+// host on 13 August 2026, where Caddy serves exactly one name; the control
+// plane kept pointing at cp.knap.pantalytics.com, which from then on answered
+// every TLS handshake with an internal error. The health poll asked it every
+// ten seconds, failed, and put "You're offline" over a vault that was
+// syncing perfectly well. Deriving the other two from the address the client
+// actually syncs with is what stops that returning, rather than repairing it
+// once.
+//
+// KNAP_SERVER_URL doubles as the rebuild's beta switch below, so it stays
+// empty in an ordinary build. The fallback here is the address a release
+// carries. The bare domain is the marketing site on another box, so it is
+// app.knap.pantalytics.com and not knap.pantalytics.com.
+const knapUrl = process.env.KNAP_SERVER_URL || "https://app.knap.pantalytics.com";
+const controlPlaneUrl = process.env.KNAP_CONTROL_PLANE_URL || knapUrl;
+const panelUrl = process.env.KNAP_PANEL_URL || `${knapUrl}/sync`;
+console.log("knap:", knapUrl);
 console.log("git tag:", gitTag);
 
 const NotifyPlugin = {


### PR DESCRIPTION
The offline banner appeared over vaults that were syncing fine. Not a UI bug: the health poll really failed, against a host nothing else uses.

## What was wrong

The plugin carried three Knap addresses. The rebuilt client syncs with `KNAP_SERVER_URL`, the Dashboard button opens the panel, and the health poll asked the control plane at `cp.knap.pantalytics.com`. The server moved to the app host on 13 August 2026 and Caddy there serves exactly one name, so cp has since answered every TLS handshake with alert 80, internal error, no certificate offered.

`NetworkStatus` treats anything but a 200 as offline. So every device went offline ten seconds after start and put "You're offline" over a note somebody was reading, while the sync itself kept running on the app host.

## Measurement, 2026-09-07, OpenSSL 3.0.14

| host | TLS | /healthz |
|---|---|---|
| `app.knap.pantalytics.com` | TLSv1.3, valid certificate | 200 |
| `cp.knap.pantalytics.com` | alert 80, no certificate offered | unreachable |

Both names resolve to 178.105.61.116. Port 443 is open and port 80 answers 308, so the proxy is up. `knap.pantalytics.com` on the same machine serves a valid certificate, so it is the cp name and nothing wider.

## The change

One server (ADR-0033), so one address. The control plane and the panel now derive from the address the client actually syncs with. That is what stops this returning, rather than repairing it once.

Stored settings need no migration: `migrateRelayOnPremSettings` already rebuilds the server from the build-time value on every load, so an installed vault picks up the new address when it updates.

CD grows a check that the bundle names exactly one Knap host. A release carrying two addresses looks identical to a working one, which is why this went unnoticed for three weeks.

Closes pantalytics/knap-mcp-admin#202 from the plugin side. The server side is now a deletion rather than a certificate: `cp.knap.pantalytics.com` has no listener and no user, so the DNS record can go.

## Verified

- `npx tsc --noEmit`: clean
- `npx jest`: 1010 passed, 4 skipped
- `npm run lint`: 0 errors
- Built bundle names one host: `https://app.knap.pantalytics.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)