### PR TITLE
The build script survives a checkout with no .git

### DIFF
--- a/__tests__/mocks/fakeNetwork.ts
+++ b/__tests__/mocks/fakeNetwork.ts
@@ -164,7 +164,7 @@ export class FakeSocket {
 				data: bytes.buffer.slice(
 					bytes.byteOffset,
 					bytes.byteOffset + bytes.byteLength,
-				) as ArrayBuffer,
+				),
 			});
 		}, 0);
 	}

--- a/__tests__/providerChannelClaim.live.test.ts
+++ b/__tests__/providerChannelClaim.live.test.ts
@@ -106,7 +106,7 @@ live("YSweetProvider against a relay with the channel claim on", () => {
 					data: frame.buffer.slice(
 						frame.byteOffset,
 						frame.byteOffset + frame.byteLength,
-					) as ArrayBuffer,
+					),
 				}),
 			).not.toThrow();
 

--- a/docs/catalog-submission.md
+++ b/docs/catalog-submission.md
@@ -146,6 +146,52 @@ One thing this does not settle: the directory runs its own configuration, so our
 naming "Knap sync", that is the reason, and the product name is the right answer
 rather than the lint's.
 
+## The 1.13.6 scorecard, and what it took
+
+The 1.13.6 entry scored Health *Excellent* and Review *Satisfactory*, with one
+hard failure and a list of warnings. The failure was the one worth having:
+
+> Build verification failed while running the build script
+
+Two separate causes, both now fixed, and the fix is verified rather than
+assumed: a source tree with `.git` and `node_modules` removed, built with
+`npm run build` and no environment variables at all, produces a `main.js`
+byte-identical to the one attached to the 1.13.6 release.
+
+1. **`git describe` was unguarded.** `esbuild.config.mjs` opened with
+   `execSync("git describe --tags --always")`. The directory unpacks a
+   release's source and builds it with no `.git` beside it, so that call threw
+   and the build died before esbuild started. It falls back to the manifest
+   version now, which is the value it was already computing for a tagless
+   checkout. `notify-send` on a failed build is wrapped for the same reason.
+
+2. **The release could not be reproduced from its own source.** `cd.yml` builds
+   with `KNAP_SERVER_URL` set from a repository variable, and the define
+   defaulted to the empty string. `npm run build` therefore produced a plugin
+   with the whole `src/knap` path switched off, while every shipped release had
+   it on -- two different plugins from one source tree, and nothing for a
+   verifier to compare. The define now defaults to the same one server address
+   as the rest of the file (ADR-0033), which is what the repository variable
+   holds. The environment still overrides it.
+
+The warnings that were worth acting on:
+
+| Finding | What was done |
+|---|---|
+| 13 unsafe values (5 returns, 3 arguments, 3 assignments, 2 calls) | All 13 were in `src/storage/y-indexeddb.js`, from lib0's untyped `getAll`, `getLastKey`, `count` and `promise.create`, plus a `get()` whose JSDoc advertised `\| any`. Typed in place, no runtime change except one: `destroy()` dropped its close promise, so `clearData()` called `.then` on `undefined` and would have thrown. `destroy()` returns the promise again, as upstream does. The file's exemption in `eslint.config.unsafe-check.mjs` is gone with it. |
+| 2 `This assertion is unnecessary since it does not change the type` | Two `as ArrayBuffer` casts on `ArrayBuffer.prototype.slice` in the test mocks, and one `as keyof FeatureFlags` on a parameter already declared that way. Removed. |
+| 12 `This assertion is unnecessary since the receiver accepts the original type` | Not reproducible here against any configuration we can construct -- our own tsconfig, a strict one, one that includes the tests, one that includes the `.svelte` files. Tracked rather than guessed at. |
+| 2 `PluginSettingTab does not implement getSettingDefinitions()` | Left. The declarative settings API arrived in Obsidian 1.13 and is not in the `obsidian` typings this repo builds against, so the shape would be guesswork. Tracked. |
+| `super`/`Observable` deprecated, 3 | Left, for the reason recorded above: lib0's `ObservableV2` migration retypes every event on the core sync class, and this is vendored y-websocket code kept close to upstream. |
+
+Two disclosures the scorecard shows publicly and which are by design: the
+plugin encodes and decodes base64 at runtime (JWT claims, and the binary
+frames the sync protocol carries), and it reads and writes `window.localStorage`
+directly in the PocketBase auth store and its on-prem sibling. The latter is
+where a session token lives, which is browser storage on purpose: it is
+vault-local, it is not vault content, and it must not travel into the plugin
+data file that syncs.
+
 ## What is left
 
 ### 1. Click through a vault

--- a/docs/catalog-submission.md
+++ b/docs/catalog-submission.md
@@ -153,10 +153,8 @@ hard failure and a list of warnings. The failure was the one worth having:
 
 > Build verification failed while running the build script
 
-Two separate causes, both now fixed, and the fix is verified rather than
-assumed: a source tree with `.git` and `node_modules` removed, built with
-`npm run build` and no environment variables at all, produces a `main.js`
-byte-identical to the one attached to the 1.13.6 release.
+Two separate causes. The first is fixed here. The second is measured, and
+parked with the measurement, because fixing it breaks something else.
 
 1. **`git describe` was unguarded.** `esbuild.config.mjs` opened with
    `execSync("git describe --tags --always")`. The directory unpacks a
@@ -164,15 +162,25 @@ byte-identical to the one attached to the 1.13.6 release.
    and the build died before esbuild started. It falls back to the manifest
    version now, which is the value it was already computing for a tagless
    checkout. `notify-send` on a failed build is wrapped for the same reason.
+   Verified: a source tree with `.git` and `node_modules` removed builds
+   cleanly with `npm run build` and no environment variables at all.
 
-2. **The release could not be reproduced from its own source.** `cd.yml` builds
-   with `KNAP_SERVER_URL` set from a repository variable, and the define
-   defaulted to the empty string. `npm run build` therefore produced a plugin
-   with the whole `src/knap` path switched off, while every shipped release had
-   it on -- two different plugins from one source tree, and nothing for a
-   verifier to compare. The define now defaults to the same one server address
-   as the rest of the file (ADR-0033), which is what the repository variable
-   holds. The environment still overrides it.
+2. **The release still cannot be reproduced from its own source.** `cd.yml`
+   builds with `KNAP_SERVER_URL` set from a repository variable, and the define
+   defaults to the empty string, so `npm run build` produces a plugin with the
+   whole `src/knap` path switched off while every shipped release has it on.
+   Two different plugins from one source tree, and nothing for a verifier to
+   compare. Defaulting the define to the same one server address as the rest of
+   the file (ADR-0033) closes it exactly -- measured: that build is
+   byte-identical to the `main.js` attached to the 1.13.6 release -- and the
+   Obsidian wire end to end then times out driving the app, because the harness
+   has only ever exercised a build with `src/knap` off. ADR-0068 says that job
+   decides, so the default stays empty until the harness copes. Tracked in
+   [#167](https://github.com/pantalytics/knap-obsidian/issues/167).
+
+   What this means for the next scorecard: the build script now runs to
+   completion, so verification gets an artifact to compare rather than a crash.
+   It will not match until #167 lands.
 
 The warnings that were worth acting on:
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -36,15 +36,30 @@ that ships beside this one and in the repository's NOTICE.
 // "this build is not the release" meant nothing. A describe that carries no
 // tag falls back to the manifest's version, which is what the release is
 // about to be named.
-const described = execSync("git describe --tags --always", {
-	encoding: "utf8",
-}).trim();
+//
+// The directory's build verification is the second thing this has to survive.
+// It unpacks the release's source and runs `npm run build` with no `.git`
+// beside it, so an unguarded `git describe` throws EEXIT and the whole build
+// fails before esbuild starts. That is what the 1.13.6 scorecard reported as
+// "Build verification failed while running the build script". No git, no
+// describe, no problem: fall back to the manifest, which is the version the
+// release is named after anyway.
 const manifestVersion = JSON.parse(
 	fs.readFileSync("manifest.json", "utf8"),
 ).version;
-const gitTag = /^[0-9a-f]{7,40}$/.test(described)
-	? manifestVersion
-	: described;
+let described = "";
+try {
+	described = execSync("git describe --tags --always", {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "ignore"],
+	}).trim();
+} catch {
+	described = "";
+}
+const gitTag =
+	described === "" || /^[0-9a-f]{7,40}$/.test(described)
+		? manifestVersion
+		: described;
 
 const develop = process.argv[2] === "develop";
 const staging = process.argv[2] === "staging";
@@ -86,11 +101,19 @@ const panelUrl = process.env.KNAP_PANEL_URL || `${knapUrl}/sync`;
 console.log("knap:", knapUrl);
 console.log("git tag:", gitTag);
 
+// Desktop notification on a failed watch build. notify-send does not exist on
+// CI or on the directory's verifier, where a failing build would otherwise
+// fail twice and report the wrong reason, so the notification is best effort.
 const NotifyPlugin = {
 	name: "on-end",
 	setup(build) {
 		build.onEnd((result) => {
-			if (result.errors.length > 0) execSync(`notify-send "Build Failed"`);
+			if (result.errors.length === 0) return;
+			try {
+				execSync(`notify-send "Build Failed"`, { stdio: "ignore" });
+			} catch {
+				// no notification daemon here; the esbuild error is the signal
+			}
 		});
 	},
 };
@@ -150,10 +173,15 @@ const context = await esbuild.context({
 		AUTH_URL: `"${authUrl}"`,
 		CONTROL_PLANE_URL: JSON.stringify(controlPlaneUrl),
 		PANEL_URL: JSON.stringify(panelUrl),
-		// The rebuild's beta switch (src/knap/ObsidianKnap.ts): empty in every
-		// ordinary build, set via the environment to point one test build at
-		// the new server. No screen ever offers a server field (ADR-0033).
-		KNAP_SERVER_URL: JSON.stringify(process.env.KNAP_SERVER_URL || ""),
+		// The address src/knap/ObsidianKnap.ts registers against. It used to
+		// default to empty, so `npm run build` produced a plugin with the whole
+		// rebuild path switched off while the release, built with the repository
+		// variable set, shipped it on. The directory rebuilds a release from its
+		// source with no repository variables, so those two builds could never
+		// match and build verification had nothing to verify. It defaults to the
+		// same one server as everything else here (ADR-0033); the environment
+		// still overrides it to point a test build somewhere else.
+		KNAP_SERVER_URL: JSON.stringify(knapUrl),
 		REPOSITORY: `"pantalytics/knap-obsidian"`,
 	},
 	treeShaking: true,

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -173,15 +173,19 @@ const context = await esbuild.context({
 		AUTH_URL: `"${authUrl}"`,
 		CONTROL_PLANE_URL: JSON.stringify(controlPlaneUrl),
 		PANEL_URL: JSON.stringify(panelUrl),
-		// The address src/knap/ObsidianKnap.ts registers against. It used to
-		// default to empty, so `npm run build` produced a plugin with the whole
-		// rebuild path switched off while the release, built with the repository
-		// variable set, shipped it on. The directory rebuilds a release from its
-		// source with no repository variables, so those two builds could never
-		// match and build verification had nothing to verify. It defaults to the
-		// same one server as everything else here (ADR-0033); the environment
-		// still overrides it to point a test build somewhere else.
-		KNAP_SERVER_URL: JSON.stringify(knapUrl),
+		// The rebuild's beta switch (src/knap/ObsidianKnap.ts): empty in every
+		// ordinary build, set via the environment to point one test build at
+		// the new server. No screen ever offers a server field (ADR-0033).
+		//
+		// This is also why a release cannot be rebuilt from its own source:
+		// cd.yml sets this from a repository variable, so `npm run build`
+		// produces a plugin with src/knap switched off while every shipped
+		// release has it on. Defaulting it to knapUrl closes that gap and was
+		// tried here; the Obsidian wire end to end then timed out driving the
+		// app, because the harness has only ever exercised a build with
+		// src/knap off. ADR-0068 says that job decides, so the default stays
+		// empty until the harness copes. See issue #167.
+		KNAP_SERVER_URL: JSON.stringify(process.env.KNAP_SERVER_URL || ""),
 		REPOSITORY: `"pantalytics/knap-obsidian"`,
 	},
 	treeShaking: true,

--- a/eslint.config.unsafe-check.mjs
+++ b/eslint.config.unsafe-check.mjs
@@ -20,14 +20,5 @@ export default tseslint.config(
       "@typescript-eslint/no-unsafe-argument": "error",
     },
   },
-  {
-    files: ["src/storage/y-indexeddb.js"],
-    rules: {
-      "@typescript-eslint/no-unsafe-assignment": "off",
-      "@typescript-eslint/no-unsafe-argument": "off",
-      "@typescript-eslint/no-unsafe-return": "off",
-      "@typescript-eslint/no-unsafe-call": "off",
-    },
-  },
   { ignores: ["node_modules/", "main.js", "*.config.mjs"] }
 );

--- a/src/components/FeatureFlagModalContent.svelte
+++ b/src/components/FeatureFlagModalContent.svelte
@@ -12,7 +12,7 @@
 	function toggleFlag(flagName: keyof FeatureFlags) {
 		const flagValue = !settings[flagName];
 		settings[flagName] = flagValue;
-		flagManager.setFlag(flagName as keyof FeatureFlags, settings[flagName]);
+		flagManager.setFlag(flagName, settings[flagName]);
 	}
 
 	onMount(() => {

--- a/src/knap/ObsidianKnap.ts
+++ b/src/knap/ObsidianKnap.ts
@@ -1,14 +1,16 @@
 /**
  * Where the rebuilt client meets Obsidian, behind the build-time switch.
  *
- * `KNAP_SERVER_URL` is an esbuild define carrying the one server address
- * (ADR-0033), and every build now has it: the release already shipped with it
- * set, and a plain `npm run build` that left it empty produced a different
- * plugin from the one users install, which is what made the release
- * unreproducible for the directory's build verification. Empty still means
- * this whole file registers nothing, which is what a build pointed at no
- * server does; set, it adds the protocol handler and four commands. It stays
- * build-time on purpose: no screen offers a server field.
+ * `KNAP_SERVER_URL` is an esbuild define, empty in every ordinary build.
+ * Empty means this whole file registers nothing and the plugin behaves
+ * exactly as before; set, it adds the protocol handler and four commands,
+ * and one test vault can point at the new server while everything else
+ * stays where it is. That is the switch phase 2's plan asks for, and it is
+ * build-time on purpose: no screen offers a server field (ADR-0033).
+ *
+ * Every release ships with it set and no local build does, which is why the
+ * Obsidian wire end to end has never driven the plugin people install. Issue
+ * #167 carries that, and the measurement behind it.
  *
  * The screen words hold: sign in, cloud vault, link, unlink, sync. Nothing
  * here says server, relay or share to a person.

--- a/src/knap/ObsidianKnap.ts
+++ b/src/knap/ObsidianKnap.ts
@@ -1,12 +1,14 @@
 /**
  * Where the rebuilt client meets Obsidian, behind the build-time switch.
  *
- * `KNAP_SERVER_URL` is an esbuild define, empty in every ordinary build.
- * Empty means this whole file registers nothing and the plugin behaves
- * exactly as before; set, it adds the protocol handler and four commands,
- * and one test vault can point at the new server while everything else
- * stays where it is. That is the switch phase 2's plan asks for, and it is
- * build-time on purpose: no screen offers a server field (ADR-0033).
+ * `KNAP_SERVER_URL` is an esbuild define carrying the one server address
+ * (ADR-0033), and every build now has it: the release already shipped with it
+ * set, and a plain `npm run build` that left it empty produced a different
+ * plugin from the one users install, which is what made the release
+ * unreproducible for the directory's build verification. Empty still means
+ * this whole file registers nothing, which is what a build pointed at no
+ * server does; set, it adds the protocol handler and four commands. It stays
+ * build-time on purpose: no screen offers a server field.
  *
  * The screen words hold: sign in, cloud vault, link, unlink, sync. Nothing
  * here says server, relay or share to a person.

--- a/src/storage/y-indexeddb.js
+++ b/src/storage/y-indexeddb.js
@@ -18,7 +18,7 @@ export const RUNTIME_TRIM_SIZE = 50
  */
 export const fetchUpdates = (idbPersistence, beforeApplyUpdatesCallback = () => {}, afterApplyUpdatesCallback = () => {}) => {
   const [updatesStore] = idb.transact(/** @type {IDBDatabase} */ (idbPersistence.db), [updatesStoreName]) // , 'readonly')
-  return idb.getAll(updatesStore, idb.createIDBKeyRangeLowerBound(idbPersistence._dbref, false)).then(updates => {
+  return idb.getAll(updatesStore, idb.createIDBKeyRangeLowerBound(idbPersistence._dbref, false)).then(/** @param {Uint8Array[]} updates */ updates => {
     if (!idbPersistence._destroyed) {
       beforeApplyUpdatesCallback(updatesStore)
       Y.transact(idbPersistence.doc, () => {
@@ -26,8 +26,8 @@ export const fetchUpdates = (idbPersistence, beforeApplyUpdatesCallback = () => 
       }, idbPersistence, false)
     }
   })
-    .then(() => idb.getLastKey(updatesStore).then(lastKey => { idbPersistence._dbref = lastKey + 1 }))
-    .then(() => idb.count(updatesStore).then(cnt => { idbPersistence._dbsize = cnt }))
+    .then(() => idb.getLastKey(updatesStore).then(/** @param {number} lastKey */ lastKey => { idbPersistence._dbref = lastKey + 1 }))
+    .then(() => idb.count(updatesStore).then(/** @param {number} cnt */ cnt => { idbPersistence._dbsize = cnt }))
     .then(() => {
       if (!idbPersistence._destroyed) {
         afterApplyUpdatesCallback(updatesStore)
@@ -75,7 +75,13 @@ export class IndexeddbPersistence extends Observable {
      */
     this.db = null
     this.synced = false
+    /**
+     * @type {boolean|undefined}
+     */
     this._serverSynced = undefined
+    /**
+     * @type {"local" | "remote" | undefined}
+     */
     this._origin = undefined
     this._db = idb.openDB(name, db =>
       idb.createStores(db, [
@@ -86,7 +92,7 @@ export class IndexeddbPersistence extends Observable {
     /**
      * @type {Promise<IndexeddbPersistence>}
      */
-    this.whenSynced = promise.create(resolve => this.on('synced', () => resolve(this)))
+    this.whenSynced = promise.create(/** @param {(value: IndexeddbPersistence) => void} resolve */ resolve => this.on('synced', () => { resolve(this) }))
 
     void this._db.then(db => {
       this.db = db
@@ -106,7 +112,7 @@ export class IndexeddbPersistence extends Observable {
      */
     this._storeTimeout = 1000
     /**
-     * @type {any}
+     * @type {number|null}
      */
     this._storeTimeoutId = null
     /**
@@ -138,7 +144,7 @@ export class IndexeddbPersistence extends Observable {
   /**
    * Override once to handle race condition where event might have already fired
    * @param {string} name
-   * @param {function} f
+   * @param {(...args: any[]) => void} f
    */
   once (name, f) {
     if (name === 'synced' && this.synced) {
@@ -156,7 +162,7 @@ export class IndexeddbPersistence extends Observable {
     this.doc.off('update', this._storeUpdate)
     this.doc.off('destroy', this.destroy)
     this._destroyed = true
-    void this._db.then(db => {
+    return this._db.then(db => {
       db.close()
     })
   }
@@ -174,7 +180,7 @@ export class IndexeddbPersistence extends Observable {
 
   /**
    * @param {String | number | ArrayBuffer | Date} key
-   * @return {Promise<String | number | ArrayBuffer | Date | any>}
+   * @return {Promise<unknown>}
    */
   get (key) {
     return this._db.then(db => {
@@ -271,7 +277,8 @@ export class IndexeddbPersistence extends Observable {
     if (this._origin !== undefined) {
       return this._origin
     }
-    this._origin = await this.get("origin")
+    const stored = await this.get("origin")
+    this._origin = stored === "local" || stored === "remote" ? stored : undefined
     return this._origin
   }
 


### PR DESCRIPTION
## Summary

The 1.13.6 scorecard reported *Build verification failed while running the build script*. This fixes that.

`esbuild.config.mjs` opened with `execSync("git describe --tags --always")`. The directory unpacks a release's source and builds it with no `.git` beside it, so the call threw and the build died before esbuild started. It falls back to the manifest version now, which is the value it already computed for a tagless checkout. `notify-send` on a failed build is wrapped for the same reason. Verified: a source tree with `.git` and `node_modules` removed builds cleanly with `npm run build` and no environment variables at all.

**A second cause is measured but not fixed here.** `cd.yml` builds with `KNAP_SERVER_URL` set from a repository variable and the define defaults to empty, so `npm run build` produces a plugin with the whole `src/knap` path switched off while every release has it on. Defaulting the define to `knapUrl` closes it exactly, and the resulting `main.js` is byte-identical to the one attached to the 1.13.6 release. It also turns the Obsidian wire end-to-end job red: the app comes up, the plugin's fields are assigned, and the first CDP evaluation never answers within 120s. That job is green on `main`, so the flip is what did it. The harness has only ever driven the `src/knap`-off build, and the plugin does not survive being driven for real. ADR-0068 says that job decides, so the default stays empty and [#167](https://github.com/pantalytics/knap-obsidian/issues/167) carries the measurement, the failing run and the order of work.

What that means for the next scorecard: the build script runs to completion, so verification gets an artifact to compare rather than a crash. It will not match until #167 lands.

Also from the same scorecard:

- All 13 unsafe-value warnings (5 returns, 3 arguments, 3 assignments, 2 calls) were in `src/storage/y-indexeddb.js`, from lib0's untyped `getAll`, `getLastKey`, `count` and `promise.create`, plus a `get()` whose JSDoc advertised `| any`. Typed in place. The file's exemption in `eslint.config.unsafe-check.mjs` is gone with it.
- One of those was hiding a bug. `destroy()` dropped its close promise, so `clearData()` called `.then` on `undefined` and would have thrown. `destroy()` returns the promise again, as upstream y-indexeddb does. `clearData()` has no callers today.
- Three unnecessary type assertions removed: two `as ArrayBuffer` on `ArrayBuffer.prototype.slice` in test mocks, one `as keyof FeatureFlags` on a parameter already declared that way.

Left, tracked rather than guessed at: the 12 *receiver accepts the original type* assertions, which do not reproduce here against any configuration we could construct ([#166](https://github.com/pantalytics/knap-obsidian/issues/166)); and `getSettingDefinitions()` on the two settings tabs, whose API is not in the `obsidian` typings this repo builds against ([#165](https://github.com/pantalytics/knap-obsidian/issues/165)).

`docs/catalog-submission.md` records all of it, including the two disclosures the scorecard shows publicly and which are by design.

No version bump here: a new scorecard needs a release, and cutting one is a separate call.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] `npm run build` succeeds, including from a tree with no `.git`
- [x] `npm run lint` passes (0 errors, 7 warnings, all pre-existing and recorded)
- [ ] Tested in Obsidian
- [x] Changes are minimal and focused

`npx tsc --noEmit` clean. Jest: 1017 passed, 4 skipped.

Not tested in a vault. The plugin the build produces is unchanged from `main` apart from the IndexedDB storage typing, whose one behavioural change is `destroy()` returning its close promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nr2E2aTzkYasRkUQUEdVDH